### PR TITLE
fix bugs in example/broadcast.js

### DIFF
--- a/examples/broadcast.js
+++ b/examples/broadcast.js
@@ -1,6 +1,7 @@
 /* broadcast.js - all published messages are relayed to all connected clients */
 
-var mqtt = require('../mqtt');
+var mqtt = require('../lib/mqtt')
+        , util = require('util');
 
 mqtt.createServer(function(client) {
 	var self = this;


### PR DESCRIPTION
the lib path is wrong in require(),when you clone the repo,your can not run the example immediately.so i chnage the require('../mqtt') to require('../lib/mqtt'). And,the util lib is missing ,so i add util = require('util'); after require('../lib/mqtt') 
