### PR TITLE
payload in 'publish' appended as Buffer instead of string

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -108,7 +108,12 @@ module.exports.publish = function(opts) {
 
   /* Check required fields */
   if (typeof topic !== 'string' || topic.length <= 0) return null;
-  if (typeof payload !== 'string') return null;
+  /* if payload is a string, we'll convert it into a buffer */
+  if(typeof payload == 'string') {
+	  payload = new Buffer(payload);
+  }
+  /* accepting only a buffer for payload */
+  if (!Buffer.isBuffer(payload)) return null;
   if (typeof qos !== 'number' || qos < 0 || qos > 2) return null;
   if (typeof id !== 'number' || id < 0 || id > 0xFFFF) return null;
 
@@ -123,12 +128,11 @@ module.exports.publish = function(opts) {
   if (qos > 0) packet.payload = packet.payload.concat(gen_number(id));
 
 
-  /* Payload */
-  packet.payload = packet.payload.concat(gen_string(payload, true));
+  buf = new Buffer([packet.header]
+		  .concat(gen_length(packet.payload.length + payload.length))
+		  .concat(packet.payload));
 
-  return new Buffer([packet.header]
-            .concat(gen_length(packet.payload.length))
-            .concat(packet.payload));
+  return Buffer.concat([buf, payload]);
 };
 
 /* Puback, pubrec, pubrel and pubcomp */


### PR DESCRIPTION
Hi Adamvr,

I've encountered problem using your mqtt.js as a server. After tracing around the code I found some disagreement with the MQTT spec. Regarding the spec, payload should be a raw buffer instead of a utf-8 string. i had to alter the code so my java mqtt client works as expected. hopefully this can be pulled upstream but of course you can keep your original design and maybe branch out for people to test this code.

Cheers,  
Freehaha
