### PR TITLE
Fix for callback as single argument to mqtt.createClient

### DIFF
--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -71,10 +71,12 @@ module.exports.createClient = function(port, host, callback) {
     , net_client, mqtt_client;
 
   if (typeof arguments[0] === 'function' && arguments.length === 1) {
+    callback = arguments[0];
     port = defaultPort;
     host = defaultHost;
-    callback = arguments[0];
   }
+  //validate this early on so we don't get hard to track errors later
+  if (typeof callback !== 'function') throw new TypeError('callback is not a function');
 
   net_client = new net.Socket();
 


### PR DESCRIPTION
The callback was overwritten with defaultPort.
Changed the order of assignments to make it work.
