### PR TITLE
Clean up the connection buffer if there is no data in it.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -9,8 +9,7 @@ var Connection = module.exports =
 function Connection(stream, server) {
   this.server = server;
   this.stream = stream;
-  this.buffer = new Buffer(bufferSize);
-  this.buffer.written = this.buffer.read = 0;
+  this.buffer = null;
   this.packet = {};
   var that = this;
   this.stream.on('data', function (buf) {
@@ -23,32 +22,39 @@ util.inherits(Connection, events.EventEmitter);
 
 Connection.prototype.parse = function(buf) {
 
-  // Do we have enough space for the incoming data?
-  if (this.buffer.written + buf.length > this.buffer.length) {
-    // Then buf does not fit in the free space left
+  if (this.buffer !== null) {
 
-    var previousPacketPart = this.buffer.written - this.buffer.read;
-    var totalReceivedSize = previousPacketPart + buf.length;
+    // Do we have enough space for the incoming data?
+    if (this.buffer.written + buf.length > this.buffer.length) {
+      // Then buf does not fit in the free space left
 
-    // Is this.buffer big enough for the incoming data
-    var newBuffer = null;
-    if (totalReceivedSize > this.buffer.length) {
-      // allocate a bigger buffer, with some free space
-      newBuffer = new Buffer(totalReceivedSize * 2);
-    } else {
-      // rotate the buffer, so there is free space at the end
-      newBuffer = this.buffer;
+      var previousPacketPart = this.buffer.written - this.buffer.read;
+      var totalReceivedSize = previousPacketPart + buf.length;
+
+      // Is this.buffer big enough for the incoming data
+      var newBuffer = null;
+      if (totalReceivedSize > this.buffer.length) {
+        // allocate a bigger buffer, with some free space
+        newBuffer = new Buffer(totalReceivedSize * 2);
+      } else {
+        // rotate the buffer, so there is free space at the end
+        newBuffer = this.buffer;
+      }
+
+      this.buffer.copy(newBuffer, 0, this.buffer.read, this.buffer.written);
+      newBuffer.written = previousPacketPart;
+      newBuffer.read = 0;
+      this.buffer = newBuffer;
     }
-
-    this.buffer.copy(newBuffer, 0, this.buffer.read, this.buffer.written);
-    newBuffer.written = previousPacketPart;
-    newBuffer.read = 0;
-    this.buffer = newBuffer;
+    
+    // Copy incoming data into the internal buffer
+    buf.copy(this.buffer, this.buffer.written);
+    this.buffer.written += buf.length;
+  } else {
+    this.buffer = buf;
+    this.buffer.read = 0;
+    this.buffer.written = this.buffer.length;
   }
-  
-  // Copy incoming data into the internal buffer
-  buf.copy(this.buffer, this.buffer.written);
-  this.buffer.written += buf.length;
   
   var pos = this.buffer.read, len = this.buffer.written;
   while (pos < len) {
@@ -107,11 +113,9 @@ Connection.prototype.parse = function(buf) {
   this.buffer.written = len;
   
   // Processed all the data in the buffer and read length
-  // (this is needed since as assume length always starts
-  // at the buf[1], reset pointers
-  if (this.buffer.written === this.buffer.read && 
-      this.packet.length) {
-    this.buffer.written = this.buffer.read = 0;
+  // then we can clean up the buffer
+  if (this.buffer.written === this.buffer.read) {
+    this.buffer = null;
   }
 };
 


### PR DESCRIPTION
This patch automatically reduces the memory footprint of a long-running connection, while still allowing high-throughput clients and servers to fill the underlining socket.

There is still some space for further optimizations: I believe it is possible to remove the 'cache buffer' totally.
