### PR TITLE
Fixes issue #50

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -327,15 +327,16 @@ MqttClient.prototype._handlePublish = function(packet) {
   var topic = packet.topic
     , message = packet.payload
     , qos = packet.qos
-    , mid = packet.messageId;
+    , mid = packet.messageId
+    , retain = packet.retain;
 
   switch (qos) {
     case 0:
-      this.emit('message', topic, message);
+      this.emit('message', topic, message, qos, mid, retain);
       break;
     case 1:
       this.conn.puback({messageId: mid});
-      this.emit('message', topic, message);
+      this.emit('message', topic, message, qos, mid, retain);
       break;
     case 2:
       this.conn.pubrec({messageId: mid});


### PR DESCRIPTION
This adds the qos, messageId and retain flag of a received packet to the parameters of the emitted 'message' event. 

Users interested in such information of a received packet can just change their existing on.`('message', function(topic, message) {...});` to `on.('message', function(topic, message, qos, mid, retain) {...});`
