### PR TITLE
Fixed test compatibility for node-v0.10.0.

### DIFF
--- a/test/mqtt.js
+++ b/test/mqtt.js
@@ -68,9 +68,10 @@ describe('mqtt', function() {
     });
     it('should bind stream close to connection', function(done) {
       var c = mqtt.createConnection();
-
-      c.once('close', function() { done() });
-      c.stream.end();
+      c.once('connected', function() {
+        c.once('close', function() { done() });
+        c.stream.end();
+      });
     });
     it('should bind stream error to conn', function(done) {
       var c = mqtt.createConnection();


### PR DESCRIPTION
This fix does not update MQTT to the new stream2 API, it just fixes the tests so that they run on node v0.10.
