### PR TITLE
Fixed stream2 implementation.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -21,11 +21,15 @@ function Connection(stream, server) {
 
   this.buffer = null;
   this.packet = {};
+  this.skip = false;
   var that = this;
 
   // we might be using the wrapper here
   this.stream.on('readable', function () {
-    that.parse();
+    if (!that.skip) {
+      that.parse();
+    }
+    that.skip = false;
   });
 
   events.EventEmitter.call(this);
@@ -33,7 +37,7 @@ function Connection(stream, server) {
 util.inherits(Connection, events.EventEmitter);
 
 Connection.prototype.parse = function() {
-  var byte = null;
+  var byte = null, bytes = [];
   
   // Fresh packet - parse the header
   if (!this.packet.cmd) {
@@ -44,11 +48,15 @@ Connection.prototype.parse = function() {
     parse.header(byte, this.packet);
   }
 
-  // FIXME we are assuming we can read the full
-  // length header in one shot
   if (!this.packet.length) {
     var tmp = {mul: 1, length: 0};
     byte = this.stream.read(1);
+
+    if (byte === null) {
+      return;
+    }
+
+    bytes.push(byte);
     var pos = 1;
 
     while (pos++ < 4) {
@@ -57,14 +65,17 @@ Connection.prototype.parse = function() {
         tmp.mul * (byte[0] & protocol.LENGTH_MASK);
       tmp.mul *= 0x80;
 
+      if ((byte[0] & protocol.LENGTH_FIN_MASK) === 0) {
+        break;
+      }
+
       byte = this.stream.read(1);
       if(byte === null) {
-        break;
+        this.skip = true;
+        this.stream.unshift(Buffer.concat(bytes));
+        return;
       }
-      if ((byte[0] & protocol.LENGTH_FIN_MASK) === 0) {
-        this.stream.unshift(byte);
-        break;
-      }
+      bytes.push(byte);
     }
 
     this.packet.length = tmp.length;

--- a/lib/server.js
+++ b/lib/server.js
@@ -76,5 +76,6 @@ util.inherits(MqttSecureServer, tls.Server);
 var MqttServerClient = module.exports.MqttServerClient =
 function MqttServerClient(stream, server) {
   Connection.call(this, stream, server);
+  this.stream.on('error', this.emit.bind(this, 'error'));
 };
 util.inherits(MqttServerClient, Connection);

--- a/test/server.js
+++ b/test/server.js
@@ -23,4 +23,16 @@ describe('MqttServer', function() {
 
     mqtt.createClient(9877);
   });
+
+  it("should bind the stream's error in the clients", function (done) {
+    var s = new server.MqttServer();
+    s.listen(9878);
+
+    s.on('client', function(client) {
+      client.on("error", function () { done(); });
+      client.stream.emit("error", new Error("bad idea!"));
+    });
+
+    mqtt.createClient(9878);
+  });
 });


### PR DESCRIPTION
The fix for the stream2 implementation I provided. I am sorry I did test the previous implementation on Mosca, I could have catch the problem earlier.

That implementation was clearly broken, it could not parse the messages with length longer than 1 byte. Now it works correctly.
You should merge it and publish an updated package, and possibly yank 0.2.5.
I'm so sorry :sob:.

I also fixed a bug in the server implementation.
