### PR TITLE
Client id set correctly for CONNECT messages in the example server

### DIFF
--- a/examples/server/broadcast.js
+++ b/examples/server/broadcast.js
@@ -10,7 +10,8 @@ mqtt.createServer(function(client) {
 
   client.on('connect', function(packet) {
     client.connack({returnCode: 0});
-    client.id = packet.client;
+    client.id = packet.clientId;
+    console.log("CONNECT: client id: " + client.id);
     self.clients[client.id] = client;
   });
 

--- a/examples/server/orig.js
+++ b/examples/server/orig.js
@@ -8,7 +8,8 @@ mqtt.createServer(function(client) {
 
   client.on('connect', function(packet) {
     self.clients[packet.client] = client;
-    client.id = packet.client;
+    client.id = packet.clientId;
+    console.log("CONNECT: client id: " + client.id);
     client.subscriptions = [];
     client.connack({returnCode: 0});
   });

--- a/examples/server/tls.js
+++ b/examples/server/tls.js
@@ -9,7 +9,8 @@ mqtt.createSecureServer("private-key.pem", "public-cert.pem", function(client) {
 
   client.on('connect', function(packet) {
     client.connack({returnCode: 0});
-    client.id = packet.client;
+    client.id = packet.clientId;
+    console.log("CONNECT: client id: " + client.id);
     self.clients[client.id] = client;
   });
 


### PR DESCRIPTION
For the CONNECT message, the client id is retrieved from the packet itself. In the implementation of the examples servers, this was not the case, so I corrected that. I've also taken the liberty of adding a console.log to show that the clientid is set correctly (previsously it was 'undefined'). If possible, can we keep the console log, it's probably easier for beginning MQTT'ers like myself.
Note: The incoming messages publish were coming from a bridged mosquitto broker.
