### PR TITLE
Clear ping timer and delay puback/pubcomp

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -428,7 +428,7 @@ MqttClient.prototype._handlePubrel = function(packet) {
     , pub = this.incoming.pubrel[mid]
     , pubcomp_called = false
     , pubcomp = (function () {
-        pubcomp_called || that.conn.pubcomp({messageID: mid});
+        pubcomp_called || this.conn.pubcomp({messageID: mid});
         pubcomp_called = true; 
     }).bind(this);
 


### PR DESCRIPTION
Couple of things here:
1. Clear the ping timer on close (sometimes you can get a close without an error, e.g. if the server is restarted). I don't think this should be controversial.
2. When emitting 'message', pass a callback function which the event handler should call when it's done (the callback then does puback/pubcomp). This gives it the opportunity to do some asynchronous work before puback/pubcomp is done. For instance, I'm relaying messages to another message queue system and only want puback/pubcomp to be sent once that system has acked the message. I realise this changes the API; I wonder if there's a way to do this and keep compatibility with existing code?
