### PR TITLE
Fix crash on ack callback not exist

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -372,7 +372,10 @@ MqttClient.prototype._handleAck = function(packet) {
     , cb = this.inflight[type][mid];
 
   // Check if callback exists
-  if(!cb) this.emit('error', new Error('Unknown message id'));
+  if(!cb) {
+    this.emit('error', new Error('Unknown message id'));
+    return;
+  }
 
   // Process
   switch (type) {


### PR DESCRIPTION
Client(as publisher) got duplicate 'pubrec' if broker is busy (test by Mosquitto, QoS=2),
and crash on undefined callback.
