### PR TITLE
Bind stream's close to MqttServiceClient's close

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -77,5 +77,6 @@ var MqttServerClient = module.exports.MqttServerClient =
 function MqttServerClient(stream, server) {
   Connection.call(this, stream, server);
   this.stream.on('error', this.emit.bind(this, 'error'));
+  this.stream.on('close', this.emit.bind(this, 'close'));
 };
 util.inherits(MqttServerClient, Connection);

--- a/test/server.js
+++ b/test/server.js
@@ -35,4 +35,16 @@ describe('MqttServer', function() {
 
     mqtt.createClient(9878);
   });
+
+  it("should bind the stream's close in the clients", function (done) {
+    var s = new server.MqttServer();
+    s.listen(9879);
+
+    s.on('client', function(client) {
+      client.on("close", function () { done(); });
+      client.stream.emit("close", new Error("bad idea!"));
+    });
+
+    mqtt.createClient(9879);
+  });
 });


### PR DESCRIPTION
Useful to have stream closed event so know when the client just disappears.
