### PR TITLE
Fixed examples/server/orig.js

### DIFF
--- a/examples/server/orig.js
+++ b/examples/server/orig.js
@@ -7,7 +7,7 @@ mqtt.createServer(function(client) {
   if (!self.clients) self.clients = {};
 
   client.on('connect', function(packet) {
-    self.clients[packet.client] = client;
+    self.clients[packet.clientId] = client;
     client.id = packet.clientId;
     console.log("CONNECT: client id: " + client.id);
     client.subscriptions = [];


### PR DESCRIPTION
examples/server/orig.js wasn't working properly because the clients index was being incorrectly retrieved and when publishing, no clients could ever be found.
