### PR TITLE
MqttClient#end() should disable the reconnection

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -349,7 +349,7 @@ MqttClient.prototype._reconnect = function() {
 MqttClient.prototype._setupReconnect = function() {
   var that = this;
 
-  if (!that.reconnectTimer) {
+  if (!that.disconnecting && !that.reconnectTimer) {
     that.reconnectTimer = setInterval(function () {
       that._reconnect();
     }, that.options.reconnectPeriod);

--- a/test/client.js
+++ b/test/client.js
@@ -654,6 +654,15 @@ describe('MqttClient', function () {
       });
     });
 
+    it('should not reconnect if it was ended by the user', function(done) {
+      var client = createClient(port);
+
+      client.on('connect', function() {
+        client.end();
+        done(); // it will raise an exception if called two times
+      });
+    });
+
     it('should setup a reconnect timer on disconnect', function(done) {
       var client = createClient(port);
 


### PR DESCRIPTION
The last change breaks up Mosca, so this is a much needed fix.
In fact, if you programmatically close a MqttClient, that is not happening at all, as it keeps on reconnecting.

For the next time, we can push substantial new code into a new "minor" release, such as 0.3, in order to respect the semver approach.
