### PR TITLE
Increase default keepalive value.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -10,7 +10,7 @@ var Connection = require('./connection')
  * Default options
  */
 var defaultConnectOptions = {
-  keepalive: 10,
+  keepalive: 60,
   protocolId: 'MQIsdp',
   protocolVersion: 3,
   reconnectPeriod: 1000


### PR DESCRIPTION
Low keepalive values may be important in some applications, but this is something that should be decided after some thought. A minute keepalive should be acceptable in most cases, so is more appropriate as a default than a low value.
