### PR TITLE
Fixed borked example in Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ mqtt.createServer(function(client) {
       granted.push(packet.subscriptions[i].qos);
     }
 
-    client.suback({granted: granted});
+    client.suback({granted: granted, messageId: packet.messageId});
   });
 
   client.on('pingreq', function(packet) {


### PR DESCRIPTION
Using the example verbatim throws "Error: Invalid message id" in the suback. Please sanity check.
