### PR TITLE
Added optional Proxy protocol parser

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -23,19 +23,73 @@ function Connection(stream, server) {
   this.buffer = null;
   this.packet = {};
   this.skip = false;
+  this.proxyInfo = {};
   var that = this;
 
-  // we might be using the wrapper here
-  this.stream.on('readable', function () {
-    if (!that.skip) {
-      that.parse();
-    }
-    that.skip = false;
-  });
+  if(server !== undefined && server.config.parseProxyProtocol === true){
+    this.proxyBuffer = new Buffer(108);
+    this.proxyBufferLength = 0;
+
+    this.proxyParser = function (){
+      that.parseProxyProtocol();
+    };
+
+    this.stream.on('readable', this.proxyParser);
+  } else {
+    // we might be using the wrapper here
+    this.stream.on('readable', function () {
+      if (!that.skip) {
+        that.parse();
+      }
+      that.skip = false;
+    });
+  }
 
   events.EventEmitter.call(this);
 };
 util.inherits(Connection, events.EventEmitter);
+
+Connection.prototype.__defineGetter__('remoteAddress', function() {
+  return this.proxyInfo.remoteAddress || this.stream.remoteAddress;
+});
+
+Connection.prototype.parseProxyProtocol = function() {
+    var byte, result, that = this;
+
+    do{
+      byte = this.stream.read(1);
+      if(byte === null){
+        return;
+      }
+
+      this.proxyBuffer[this.proxyBufferLength] = byte[0];
+      this.proxyBufferLength++;
+    }while(byte[0] !== 0x0a);
+
+    result = this.proxyBuffer.toString('ascii', 0, this.proxyBufferLength - 2).split(" ");
+    this.proxyInfo = {
+      family        : result[1],
+      remoteAddress : result[2],
+      proxyAddress  : result[3],
+      remotePort    : result[4],
+      proxyPort     : result[5]
+    };
+
+    this.stream.removeListener('readable', this.proxyParser);
+
+    delete this.proxyBuffer;
+    delete this.proxyBufferLength;
+    delete this.proxyParser;
+
+    this.stream.on('readable', function () {
+      if (!that.skip) {
+        that.parse();
+      }
+      that.skip = false;
+    });
+
+    this.parse();
+};
 
 Connection.prototype.parse = function() {
   var byte = null, bytes = [], result;

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,6 +8,14 @@ var fs = require('fs')
   , util = require('util')
   , Connection = require('./connection');
 
+function setConfig(config){
+  config = config || {};
+
+  this.config.parseProxyProtocol = !!config.parseProxyProtocol;
+
+  return this;
+}
+
 /**
  * MqttServer
  *
@@ -29,9 +37,13 @@ function Server(listener) {
     self.emit('client', new MqttServerClient(socket, self));
   });
 
+  this.config = {};
+
   return this;
 }
 util.inherits(MqttServer, net.Server);
+
+MqttServer.prototype.setConfig = setConfig;
 
 /**
  * MqttSecureServer
@@ -61,9 +73,13 @@ function SecureServer(keyPath, certPath, listener) {
       new MqttServerClient(clearTextStream, self));
   });
 
+  this.config = {};
+
   return this;
 }
 util.inherits(MqttSecureServer, tls.Server);
+
+MqttSecureServer.prototype.setConfig = setConfig;
 
 /**
  * MqttServerClient - wrapper around Connection

--- a/test/connection.js
+++ b/test/connection.js
@@ -37,4 +37,106 @@ describe('Connection', function() {
       });
     });
   });
+  describe('remoteAddress', function(){
+    beforeEach(function () {
+      this.stream = new Stream();
+      this.server = {
+        config : {
+          parseProxyProtocol : true
+        }
+      };
+      this.conn = new Connection(this.stream, this.server);
+    });
+    it('should return sockets forwardedFor address', function(done){
+      var that = this,
+       fixture = [
+        16, 18, // Header
+        0, 6, // Protocol id length
+        77, 81, 73, 115, 100, 112, // Protocol id
+        3, // Protocol version
+        0, // Connect flags
+        0, 30, // Keepalive
+        0, 4, //Client id length
+        116, 101, 115, 116 // Client id
+      ];
+
+      this.stream.write(new Buffer('PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\n'));
+      this.stream.write(new Buffer(fixture));
+      this.conn.on('connect', function(packet) {
+        that.conn.remoteAddress.should.equal('192.168.0.1');
+        done();
+      });
+    });
+    it('should return sockets remoteAddress if proxy was not used', function(){
+      this.stream.remoteAddress = '10.0.0.1';
+
+      this.conn.remoteAddress.should.equal('10.0.0.1');
+    });
+  });
+  describe('parsing proxy protocol', function(){
+    beforeEach(function () {
+      this.stream = new Stream();
+      this.server = {
+        config : {
+          parseProxyProtocol : true
+        }
+      };
+      this.conn = new Connection(this.stream, this.server);
+    });
+    it('should parse send-proxy packet', function(done) {
+      var that = this,
+        fixture = [
+        16, 18, // Header
+        0, 6, // Protocol id length
+        77, 81, 73, 115, 100, 112, // Protocol id
+        3, // Protocol version
+        0, // Connect flags
+        0, 30, // Keepalive
+        0, 4, //Client id length
+        116, 101, 115, 116 // Client id
+      ];
+
+      this.stream.write(new Buffer('PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\n'));
+      this.stream.write(new Buffer(fixture));
+      this.conn.on('connect', function(packet) {
+        that.conn.proxyInfo.should.eql({
+          family        : 'TCP4',
+          remoteAddress : '192.168.0.1',
+          remotePort    : '56324',
+          proxyAddress  : '192.168.0.11',
+          proxyPort     : '443'
+        });
+        done();
+      });
+    });
+    it('should parse send-proxy packet that arrives multiple packets', function(done) {
+      var that = this,
+        fixture = [
+        16, 18, // Header
+        0, 6, // Protocol id length
+        77, 81, 73, 115, 100, 112, // Protocol id
+        3, // Protocol version
+        0, // Connect flags
+        0, 30, // Keepalive
+        0, 4, //Client id length
+        116, 101, 115, 116 // Client id
+      ];
+
+      this.stream.write(new Buffer('PROXY TCP4 192.168.0.1 '));
+      setTimeout(function(){
+        that.stream.write(new Buffer('192.168.0.11 56324 443\r\n'));
+        that.stream.write(new Buffer(fixture));
+      }, 100);
+      this.conn.on('connect', function(packet) {
+        that.conn.proxyInfo.should.eql({
+          family        : 'TCP4',
+          remoteAddress : '192.168.0.1',
+          remotePort    : '56324',
+          proxyAddress  : '192.168.0.11',
+          proxyPort     : '443'
+        });
+        done();
+      });
+    });
+  });
 });

--- a/test/server.js
+++ b/test/server.js
@@ -47,4 +47,16 @@ describe('MqttServer', function() {
 
     mqtt.createClient(9879);
   });
+  describe('setConfig', function(){
+    it('should set parseProxyProtocol config data', function (){
+      var s = new server.MqttServer();
+      s.setConfig({
+        parseProxyProtocol : true
+      });
+
+      s.config.should.eql({
+        parseProxyProtocol : true
+      });
+    });
+  });
 });


### PR DESCRIPTION
Added optional Proxy protocol parser, for exposing remote client's IP if mqtt server is sitting 
behind a proxy server. This protocol is currently supported by AWS ELB and HAproxy

Protocol documentation : http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt

Sample HAproxy config :

```
global
    log 127.0.0.1 local1 info
    maxconn 4096
    user haproxy
    group haproxy
    ca-base ../ssl
    crt-base ../ssl

defaults
    log global
    option tcplog
    maxconn 4096
    timeout connect 5s
    timeout client 30s
    timeout server 30s
    timeout tunnel 1d

frontend public
    bind :8443 ssl crt eaddrinuse_me.pem
    mode tcp
    option tcplog
    log global
    default_backend mqtt

backend mqtt
    server node1 127.0.0.1:1883 send-proxy
```

Sample MQTT.js server:

``` javascript
var mqtt = require('mqtt');

mqtt.createServer(function(client) {
    var self = this;

    if (!self.clients) self.clients = {};

    client.on('connect', function(packet) {
        self.clients[packet.clientId] = client;
        client.id = packet.clientId;
        console.log('CONNECT : client id : {' + client.id + '}');
        console.log('CONNECT : client IP : {' + client.remoteAddress + '}');
        client.connack({returnCode: 0});
    });

    client.on('pingreq', function(packet) {
        console.log('PINGREQ(%s): %s', client.id, new Date());
        client.pingresp();
    });

    client.on('disconnect', function(packet) {
        console.log("DISCONNECT: client id: " + client.id);
        client.stream.end();
    });

    client.on('close', function(packet) {
        console.log("CLOSE: client id: " + client.id);
        delete self.clients[client.id];
    });

    client.on('error', function(e) {
        client.stream.end();
        console.log(e);
    });
}).setConfig({
    parseProxyProtocol : true
}).listen(1883);
```
