### PR TITLE
Connection as a Writable stream

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -55,9 +55,6 @@ function MqttClient(streamBuilder, options) {
 
   this._setupStream();
 
-  // MqttConnection
-  this.conn = new Connection(this.stream);
-
   // Ping timer, setup in _setupPingTimer
   this.pingTimer = null;
   // Is the client connected?
@@ -83,9 +80,6 @@ function MqttClient(streamBuilder, options) {
     pubrel: {}
   };
 
-  // Echo connection errors
-  this.conn.on('error', this.emit.bind(this, 'error'));
-
   // Mark connected on connect
   this.on('connect', function() {
     this.connected = true;
@@ -94,11 +88,6 @@ function MqttClient(streamBuilder, options) {
   // Mark disconnected on stream close
   this.on('close', function() {
     this.connected = false;
-  });
-
-  // Handle connack
-  this.conn.on('connack', function (packet) {
-    that._handleConnack(packet);
   });
 
   // Setup ping timer
@@ -119,27 +108,6 @@ function MqttClient(streamBuilder, options) {
     that.queue = [];
   });
 
-  // Handle incoming publish
-  this.conn.on('publish', function (packet) {
-    that._handlePublish(packet);
-  });
-
-  // one single handleAck function
-  var handleAck = function (packet) {
-    that._handleAck(packet);
-  };
-
-  // Handle incoming acks
-  var acks = ['puback', 'pubrec', 'pubcomp', 'suback', 'unsuback'];
-  
-  acks.forEach(function (event) {
-    that.conn.on(event, handleAck);
-  });
-
-  // Handle outgoing acks
-  this.conn.on('pubrel', function (packet) {
-    that._handlePubrel(packet);
-  });
 
   // Clear ping timer
   this.on('close', function () {
@@ -173,6 +141,9 @@ MqttClient.prototype._setupStream = function() {
 
   this.stream = this.streamBuilder();
 
+  // MqttConnection
+  this.conn = this.stream.pipe(new Connection());
+
   // Suppress connection errors
   this.stream.on('error', nop);
 
@@ -187,6 +158,36 @@ MqttClient.prototype._setupStream = function() {
   this.stream.on('secureConnect', function () {
     that.conn.connect(that.options);
   });
+
+  // Handle incoming publish
+  this.conn.on('publish', function (packet) {
+    that._handlePublish(packet);
+  });
+
+  // one single handleAck function
+  var handleAck = function (packet) {
+    that._handleAck(packet);
+  };
+
+  // Handle incoming acks
+  var acks = ['puback', 'pubrec', 'pubcomp', 'suback', 'unsuback'];
+  
+  acks.forEach(function (event) {
+    that.conn.on(event, handleAck);
+  });
+
+  // Handle outgoing acks
+  this.conn.on('pubrel', function (packet) {
+    that._handlePubrel(packet);
+  });
+
+  // Handle connack
+  this.conn.on('connack', function (packet) {
+    that._handleConnack(packet);
+  });
+
+  // Echo connection errors
+  this.conn.on('error', this.emit.bind(this, 'error'));
 };
 
 /**
@@ -361,9 +362,12 @@ MqttClient.prototype.end = function() {
  */
 MqttClient.prototype._reconnect = function() {
 
-  this._setupStream();
+  if (this.conn) {
+    this.conn.removeAllListeners();
+    delete this.conn;
+  }
 
-  this.conn.reconnect(this.stream);
+  this._setupStream();
 };
 
 /**

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -3,10 +3,10 @@ var events = require('events')
   , protocol = require('./protocol')
   , generate = require('./generate')
   , parse = require('./parse')
+  , Stream = require("stream").Stream
   , Writable = require("stream").Writable
   , delay = global.setImmediate;
 
-var Writable = require("stream").Writable
 
 if (!Writable) {
   Writable = require("readable-stream").Writable;
@@ -19,30 +19,24 @@ if(!delay) {
 }
 
 var Connection = module.exports = 
-function Connection(stream, server) {
-  this.server = server;
+function Connection() {
+  if (!(this instanceof Connection)) {
+    return new Connection();
+  }
 
   this.generate = generate;
+
+  Writable.call(this);
+
+  this._newPacket();
+
   var that = this;
+  this.on("pipe", function(source) {
 
-  events.EventEmitter.call(this);
-
-  this.reconnect(stream);
+    that.stream = source;
+  });
 };
-util.inherits(Connection, events.EventEmitter);
-
-Connection.prototype._setupParser = function() {
-  this.parser = this.stream.pipe(new PacketParser({
-    connection: this
-  }));
-};
-
-Connection.prototype.reconnect = function(stream) {
-  var that = this;
-
-  this.stream = stream;
-  this._setupParser();
-};
+util.inherits(Connection, Writable);
 
 for (var k in protocol.types) {
   var v = protocol.types[k];
@@ -59,30 +53,13 @@ for (var k in protocol.types) {
   Connection.prototype[v] = new Function("opts", fun);
 }
 
-function PacketParser(options) {
-
-  if (!(this instanceof PacketParser)) {
-    return new PacketParser(options);
-  }
-
-  Writable.call(this, options);
-
-  this.conn = options.connection;
-  this.newPacket();
-}
-
-PacketParser.prototype = Object.create(
-  Writable.prototype,
-  { constructor: { value: PacketParser } }
-);
-
-PacketParser.prototype.newPacket = function() {
+Connection.prototype._newPacket = function() {
   this.packet = {};
   this.tmp = { pos: 1, mul: 1, length: 0};
   this.partialPayload = null;
 }
 
-PacketParser.prototype._parseHeader = function() {
+Connection.prototype._parseHeader = function() {
   // Fresh packet - parse the header
   if (!this.packet.cmd) {
     // there is at least one byte in the buffer
@@ -93,7 +70,7 @@ PacketParser.prototype._parseHeader = function() {
   return true;
 };
 
-PacketParser.prototype._parseLength = function() {
+Connection.prototype._parseLength = function() {
   var result = true, data = this.data;
 
   if (this.packet.length === undefined) {
@@ -130,7 +107,7 @@ PacketParser.prototype._parseLength = function() {
   return result;
 };
 
-PacketParser.prototype._readPayload = function() {
+Connection.prototype._readPayload = function() {
   var result = true;
 
   // Do we have a payload?
@@ -170,17 +147,17 @@ PacketParser.prototype._readPayload = function() {
   Object.keys(parse).forEach(function(key) {
     fun = fun +
     "   case '" + key + "': \n" +
-    "     result = parse." + key + "(buf, this.packet, this.conn.encoding); \n" +
+    "     result = parse." + key + "(buf, this.packet, this.encoding); \n" +
     "     break; \n ";
   });
 
   fun += "} \n";
   fun += "return result; \n";
 
-  PacketParser.prototype._parsePayload = new Function("parse", fun);
+  Connection.prototype._parsePayload = new Function("parse", fun);
 })();
 
-PacketParser.prototype._write = function(data, encoding, done) {
+Connection.prototype._write = function(data, encoding, done) {
 
   var byte = null, result;
 
@@ -197,13 +174,13 @@ PacketParser.prototype._write = function(data, encoding, done) {
     result = this._parsePayload(parse);
 
     // Clear packet state
-    this.newPacket();
+    this._newPacket();
 
     // Emit packet or error
     if (result instanceof Error) {
-      this.conn.emit("error", result);
+      this.emit("error", result);
     } else {
-      this.conn.emit(result.cmd, result);
+      this.emit(result.cmd, result);
     }
 
     var that = this;

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -165,11 +165,12 @@ module.exports.createConnection = function(port, host, callback) {
   }
 
   net_client = net.createConnection(port, host);
-  mqtt_conn = new MqttConnection(net_client);
+  mqtt_conn = net_client.pipe(new MqttConnection());
 
   // Echo net errors
-  mqtt_conn.stream.on('error', mqtt_conn.emit.bind(mqtt_conn, 'error'));
-  mqtt_conn.stream.on('close', mqtt_conn.emit.bind(mqtt_conn, 'close'));
+  net_client.on('error', mqtt_conn.emit.bind(mqtt_conn, 'error'));
+
+  net_client.on('close', mqtt_conn.emit.bind(mqtt_conn, 'close'));
 
   net_client.on('connect', function() {
     mqtt_conn.emit('connected');

--- a/lib/server.js
+++ b/lib/server.js
@@ -74,8 +74,10 @@ util.inherits(MqttSecureServer, tls.Server);
 
 var MqttServerClient = module.exports.MqttServerClient =
 function MqttServerClient(stream, server) {
-  Connection.call(this, stream, server);
-  this.stream.on('error', this.emit.bind(this, 'error'));
-  this.stream.on('close', this.emit.bind(this, 'close'));
+  Connection.call(this);
+  stream.on('error', this.emit.bind(this, 'error'));
+  stream.on('close', this.emit.bind(this, 'close'));
+  stream.pipe(this);
+  this.server = server;
 };
 util.inherits(MqttServerClient, Connection);

--- a/test/connection.js
+++ b/test/connection.js
@@ -14,7 +14,7 @@ describe('Connection', function() {
   beforeEach(function () {
     var that = this;
     this.stream = new Stream();
-    this.conn = new Connection(this.stream);
+    this.conn = this.stream.pipe(new Connection());
   });
 
   describe('parsing', require('./connection.parse.js'));
@@ -34,7 +34,7 @@ describe('Connection', function() {
 
       this.stream.write(new Buffer(fixture));
       this.conn.on('connect', function(packet) {
-        this.parser.packet.should.eql({});
+        this.packet.should.eql({});
         done();
       });
     });


### PR DESCRIPTION
I moved the parsing logic directly inside the Connection object, which became a Writable.
It is not needed to be a Duplex, as it will do nothing in writing. 

The interface remains the same, but it allows cool stuff like:

```
// stream is from somewhere, it might be a named pipe, a websocket, or whatever other transport

var mqtt = require("mqtt");
var conn = stream.pipe(new mqtt.Connection());

conn.publish("hello", "world");
```

Fixes #121 

@adamvr and @timoxley please provide feedbacks :).

I'd like this to go into #118, as it simplifies the reconnecting logic.

I'd like to also expose this through the "main" `mqtt` object, so we can do "crazy" ideas like MQTT over Websocket (and any other kind of Stream).
