### PR TITLE
Fixed message id generation according to spec

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -66,6 +66,8 @@ function MqttClient(streamBuilder, options) {
   this.disconnecting = false;
   // Reconnect timer
   this.reconnectTimer = null;
+  // MessageIDs starting with 1
+  this.nextId = 1;
 
   // Inflight messages
   this.inflight = {
@@ -578,5 +580,10 @@ MqttClient.prototype._handlePubrel = function(packet) {
  * _nextId
  */
 MqttClient.prototype._nextId = function() {
-  return Math.floor(Math.random() * 65535);
+  var id = this.nextId++;
+  // Ensure 16 bit unsigned int:
+  if (id === 65535) {
+    this.nextId = 1;
+  }
+  return id;
 };

--- a/test/client.js
+++ b/test/client.js
@@ -74,4 +74,28 @@ var server = mqtt.createServer(function (client) {
 
 describe('MqttClient', function() {
   abstractClientTests(server, createClient, port);
+
+  describe('_nextId', function() {
+
+    it('should return 1 on first call', function() {
+      var client = createClient();
+
+      client._nextId().should.equal(1);
+    }),
+
+    it('should return 2 on second call', function() {
+      var client = createClient();
+      client._nextId();
+
+      client._nextId().should.equal(2);
+    }),
+
+    it('should return 1 once the interal counter reached limit', function() {
+      var client = createClient();
+      client.nextId = 65535;
+
+      client._nextId().should.equal(65535);
+      client._nextId().should.equal(1);
+    })
+  })
 });


### PR DESCRIPTION
Changed id generation from random to increasing by one - as suggested by
the specification. Using random numbers does not guarantee that the same
id isn't used twice. Also made sure that 0 is never used since it's an
invalid message id.

For details see section 2.4 of the spec:
http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#msg-id
