### PR TITLE
Race condition between clearReconnect and setupStream in MQTTClient.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -125,11 +125,6 @@ function MqttClient(streamBuilder, options) {
     that._setupReconnect();
   });
 
-  // Clear reconnect timer on connect
-  this.on('connect', function() {
-    that._clearReconnect();
-  });
-
   events.EventEmitter.call(this);
 };
 util.inherits(MqttClient, events.EventEmitter);
@@ -141,6 +136,8 @@ util.inherits(MqttClient, events.EventEmitter);
  */
 MqttClient.prototype._setupStream = function() {
   var that = this;
+
+  this._clearReconnect();
 
   this.stream = this.streamBuilder();
 


### PR DESCRIPTION
A very strange race condition between `_clearReconnect` and `_setupStream` has been highlighted by @ldstein in https://github.com/mcollina/mosca/issues/68#issuecomment-29064007, regarding MQTT over Websocket support.

From that post:

> Ok, after I restart Mosca, I see multiple 'streamConnected' and no 'clientConnected' messages appearing in Chrome's console. One of the surplus connections is then 'closed', resulting in _setupStream being run again, resulting in an infinite loop.

It seems that the `'close'` event sometimes is not fired. Instead, we can move the `_clearReconnect` behavior directly inside `_setupStream`.
