### PR TITLE
Accept an options object in `mqtt.createSecureServer`

### DIFF
--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -8,8 +8,8 @@ var net = require('net')
   , MqttSecureServer = require('./server').MqttSecureServer
   , MqttClient = require('./client')
   , MqttConnection = require('./connection')
-  , tls = require("tls")
-  , fs = require("fs");
+  , tls = require('tls')
+  , fs = require('fs');
 
 var defaultPort = 1883
   , defaultHost = 'localhost';
@@ -134,14 +134,26 @@ module.exports.createServer = function(listener) {
 /**
  * createSecureServer - create a tls secured MQTT server
  *
+ * @param {Object} opts - server options
+ * - OR
  * @param {String} keyPath - path to private key
  * @param {String} certPath - path to public cert
- * @param {Function} listener - called on new client conns
+ * @param {Function} [listener] - called on new client conns
  */
-
 module.exports.createSecureServer =
-function(keyPath, certPath, listener) {
-  return new MqttSecureServer(keyPath, certPath, listener);
+function (keyPath, certPath, listener) {
+  var opts = {};
+
+  // Deprecated style
+  if ('string' === typeof keyPath && 'string' === typeof certPath) {
+    // TODO: deprecation warning?
+    opts.key = fs.readFileSync(keyPath);
+    opts.cert = fs.readFileSync(certPath);
+  } else if ('object' === typeof keyPath) {
+    opts = keyPath;
+  }
+
+  return new MqttSecureServer(opts, listener);
 };
 
 /**

--- a/lib/server.js
+++ b/lib/server.js
@@ -36,21 +36,25 @@ util.inherits(MqttServer, net.Server);
 /**
  * MqttSecureServer
  *
- * @param {String} privateKeyPath
- * @param {String} publicCertPath
+ * @param {Object} opts - server options
  * @param {Function} listener
  */
 var MqttSecureServer = module.exports.MqttSecureServer = 
-function SecureServer(keyPath, certPath, listener) {
+function SecureServer (opts, listener) {
   if (!(this instanceof SecureServer)) {
-    return new SecureServer(listener);
+    return new SecureServer(listener, opts);
   }
+
+  // new MqttSecureServer(function(){})
+  if ('function' === typeof opts) {
+    listener = opts;
+    opts = {};
+  }
+
   var self = this;
 
-  tls.Server.call(self, {
-    key: fs.readFileSync(keyPath),
-    cert: fs.readFileSync(certPath)
-  });
+  tls.Server.call(self, opts);
+
   if (listener) {
     self.on('client', listener);
   }

--- a/test/mqtt.js
+++ b/test/mqtt.js
@@ -3,6 +3,7 @@
  */
 
 var should = require('should')
+  , fs = require('fs')
   , net = require('net');
 
 /**
@@ -73,6 +74,15 @@ describe('mqtt', function() {
         __dirname + '/helpers/private-key.pem', 
         __dirname + '/helpers/public-cert.pem'
       );
+      s.should.be.instanceOf(mqtt.MqttSecureServer);
+    });
+
+    it('should accept options object', function() {
+      var s = mqtt.createSecureServer({
+        key: fs.readFileSync(__dirname + '/helpers/private-key.pem'),
+        cert: fs.readFileSync(__dirname + '/helpers/public-cert.pem')
+      });
+
       s.should.be.instanceOf(mqtt.MqttSecureServer);
     });
   });


### PR DESCRIPTION
Solution to #137

* Remove support for `MqttSecureServer(path, path, callback)`, requires an options object
* Backwards compatibility added at the `mqtt.createSecureServer` level.
* Options object accepts the same keys as those passed into `tls.Server`, therefore the `fs.readFileSync`s to fetch the keys and certs are now pushed out to the user level

Stuff not done:

* Deprecation warning (if necessary?)
* Update docs