### PR TITLE
Ensure client attempts a reconnect on no PINGRESP

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -31,11 +31,11 @@ var nop = function(){};
  * @param {Object} [options] - connection options
  * (see Connection#connect)
  */
-var MqttClient = module.exports = 
+var MqttClient = module.exports =
 function MqttClient(streamBuilder, options) {
   var that = this;
 
-  if (!this instanceof MqttClient) { 
+  if (!this instanceof MqttClient) {
     return new MqttClient(stream, options);
   }
 
@@ -179,7 +179,7 @@ MqttClient.prototype._setupStream = function() {
 
   // Handle incoming acks
   var acks = ['puback', 'pubrec', 'pubcomp', 'suback', 'unsuback'];
-  
+
   acks.forEach(function (event) {
     that.conn.on(event, handleAck);
   });
@@ -192,6 +192,11 @@ MqttClient.prototype._setupStream = function() {
   // Handle connack
   this.conn.on('connack', function (packet) {
     that._handleConnack(packet);
+  });
+
+  // Handle pingresp
+  this.conn.on('pingresp', function (packet) {
+    that._handlePingresp(packet);
   });
 
   // Echo connection errors
@@ -216,15 +221,15 @@ MqttClient.prototype._setupStream = function() {
  *     client.publish('topic', 'message', {qos: 1, retain: true});
  * @example client.publish('topic', 'message', console.log);
  */
-MqttClient.prototype.publish = 
+MqttClient.prototype.publish =
 function(topic, message, opts, callback) {
   var packet;
 
   // .publish(topic, payload, cb);
   if ('function' === typeof opts) {
-    callback = opts;  
+    callback = opts;
     opts = null;
-  } 
+  }
 
   // Default opts
   if(!opts) opts = {qos: 0, retain: false};
@@ -276,7 +281,7 @@ function(topic, message, opts, callback) {
  * @example client.subscribe('topic', {qos: 1});
  * @example client.subscribe('topic', console.log);
  */
-MqttClient.prototype.subscribe = 
+MqttClient.prototype.subscribe =
 function(topic, opts, callback) {
   var subs = [];
 
@@ -434,21 +439,46 @@ MqttClient.prototype._sendPacket = function(type, packet, cb) {
 
 /**
  * _setupPingTimer - setup the ping timer
- * 
+ *
  * @api private
  */
 MqttClient.prototype._setupPingTimer = function() {
   var that = this;
 
   if (!this.pingTimer && this.options.keepalive) {
-    this.pingTimer = setInterval((function () {
-      that.conn.pingreq();
-    }), this.options.keepalive * 600);
+    this.pingResp = true;
+    this.pingTimer = setInterval(function () {
+        that._checkPing();
+    }, this.options.keepalive * 600);
   }
 };
 
 /**
- * _handleConnack 
+ * _checkPing - check if a pingresp has come back, and ping the server again
+ *
+ * @api private
+ */
+MqttClient.prototype._checkPing = function () {
+  if (this.pingResp) {
+    this.pingResp = false;
+    this.conn.pingreq();
+  } else {
+    this._cleanUp();
+    this._reconnect();
+  }
+};
+
+/**
+ * _handlePingresp - handle a pingresp
+ *
+ * @api private
+ */
+MqttClient.prototype._handlePingresp = function () {
+  this.pingResp = true;
+};
+
+/**
+ * _handleConnack
  *
  * @param {Object} packet
  * @api private
@@ -470,7 +500,7 @@ MqttClient.prototype._handleConnack = function(packet) {
   if (rc === 0) {
     this.emit('connect');
   } else if (rc > 0) {
-    this.emit('error', 
+    this.emit('error',
         new Error('Connection refused: ' + errors[rc]));
   }
 };

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -32,7 +32,7 @@ module.exports = function(server, createClient, port) {
 
     it('should stop ping timer if stream closes', function(done) {
       var client = createClient(port);
-      
+
       client.once('close', function() {
         should.not.exist(client.pingTimer);
         done();
@@ -59,7 +59,7 @@ module.exports = function(server, createClient, port) {
 
     it('should stop ping timer after end called', function(done) {
       var client = createClient(port);
-      
+
       client.once('connect', function() {
         should.exist(client.pingTimer);
         client.end();
@@ -78,7 +78,7 @@ module.exports = function(server, createClient, port) {
       server.once('client', function(client) {
         done();
       });
-    }); 
+    });
 
     it('should send a default client id', function (done) {
       var client = createClient(port);
@@ -243,7 +243,7 @@ module.exports = function(server, createClient, port) {
       var client = createClient(port)
         , payload = 'test'
         , topic = 'test';
-      
+
       var opts = {
         retain: true,
         qos: 1
@@ -266,7 +266,7 @@ module.exports = function(server, createClient, port) {
 
     it('should fire a callback (qos 0)', function (done) {
       var client = createClient(port);
-      
+
       client.once('connect', function() {
         client.publish('a', 'b', done);
       });
@@ -360,7 +360,7 @@ module.exports = function(server, createClient, port) {
   describe('pinging', function () {
     it('should set a ping timer', function (done) {
       var client = createClient(port, {keepalive: 3});
-      client.on('connect', function() {
+      client.once('connect', function() {
         should.exist(client.pingTimer);
         done();
       });
@@ -371,6 +371,24 @@ module.exports = function(server, createClient, port) {
         should.not.exist(client.pingTimer);
         done();
       });
+    });
+    it('should reconnect if pingresp is not sent', function(done) {
+      var client = createClient(port, {keepalive:1});
+      // Fake no pingresp being send by stubbing the _handlePingresp function
+      client._handlePingresp = function () {};
+      client.once('close', function() {
+        client.once('connect', function() {
+            true.should.equal(true);
+            done();
+        });
+      });
+    });
+    it('should not reconnect if pingresp is successful', function(done) {
+      var client = createClient(port, {keepalive:1});
+      client.once('close', function() {
+        done(new Error('Client closed connection'));
+      });
+      setTimeout(done, 1000);
     });
   });
 
@@ -479,7 +497,7 @@ module.exports = function(server, createClient, port) {
         };
 
       client.subscribe(testPacket.topic);
-      client.once('message', 
+      client.once('message',
           function(topic, message, packet) {
         topic.should.equal(testPacket.topic);
         message.should.equal(testPacket.payload);
@@ -505,7 +523,7 @@ module.exports = function(server, createClient, port) {
           };
 
       client.subscribe(testPacket.topic);
-      client.once('message', 
+      client.once('message',
           function(topic, message, packet) {
         topic.should.equal(testPacket.topic);
         message.should.be.an.instanceOf(Buffer);
@@ -534,7 +552,7 @@ module.exports = function(server, createClient, port) {
       server.testPublish = testPacket;
 
       client.subscribe(testPacket.topic);
-      client.once('message', 
+      client.once('message',
           function(topic, message, packet) {
         topic.should.equal(testPacket.topic);
         message.should.equal(testPacket.payload);


### PR DESCRIPTION
Fixes #144

On every PINGREQ it sets `this.pingResp` to `false`, then if `this.pingResp` is still false by the next pingreq interval, it resets the connection. `this.pingResp` is set to true for the first ping.

Then, there is a handler on PINGRESPs which simply sets `this.pingResp` to true, so that a successful pingresp can be noted.

I'm not 100% happy with the tests - while they do test the functionality they're very "side-effecty".
