### PR TITLE
Ignore Vi/Vim temporary files from git/npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 node_modules
 certs/*
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~


### PR DESCRIPTION
`npm install mqtt` contains several artefacts, notably a set of Vi undo files (e.g `.package.json.un~`).

I've added a list of common vim files to be excluded from git (and therefore npm) so that future published versions exclude these files.

The main way I found this out is that [node-webkit](https://github.com/rogerwang/node-webkit) craps out on these files and cannot run with them in the file-tree.
