### PR TITLE
Added test for the suback response return code 0x80 rejected.

### DIFF
--- a/test/connection.parse.js
+++ b/test/connection.parse.js
@@ -505,15 +505,15 @@ module.exports = function() {
         retain: false,
         qos: 0,
         dup: false,
-        length: 5,
-        granted: [0, 1, 2],
+        length: 6,
+        granted: [0, 1, 2, 128],
         messageId: 6
       };
 
       var fixture = [
-        144, 5, // Header
+        144, 6, // Header
         0, 6, // Message id
-        0, 1, 2 // Granted qos (0, 1, 2)
+        0, 1, 2, 128 // Granted qos (0, 1, 2) and a rejected being 0x80
       ];
 
       this.stream.write(new Buffer(fixture));


### PR DESCRIPTION
As per the recent release of the mqtt-v3.1.1 spec.

Probably good to have it in there even though it didn't require any changes, please correct me if I have missed something.

At the moment there is no checks to ensure they are in the list of permitted values being.

> SUBACK return codes other than 0x00, 0x01, 0x02 and 0x80 are reserved and MUST NOT be used.

Cheers
