### PR TITLE
Added small fix for reconnect code not working reliably with TLS connections see #177

### DIFF
--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -146,17 +146,29 @@ module.exports.createSecureClient = function(port, host, opts) {
         if (tls_client.authorized) {
           console.log("Connection authorized by a Certificate Authority.");
         } else {
-          console.log("Connection not authorized: " + tls_client.authorizationError)
+          console.error("Connection not authorized: " + tls_client.authorizationError)
         } 
       }
       
-    })
+    });
 
     tls_client.on('secureConnect', function() {
       if (tls_opts.rejectUnauthorized && !tls_client.authorized) {
         throw new Error('TLS not authorized');
       }
     });
+
+    tls_client.on('error', function(err) {
+      if (process.env.NODE_DEBUG) {
+        console.error("Error occurred in tls_client, ending connection:", err);
+      }
+      // close this connection to match the behaviour of net
+      // otherwise all we get is an error from the tls_client
+      // and close event doesn't fire. This is a work around
+      // to enable the reconnect code to work the same as with
+      // net.createConnection
+      this.end();
+    }.bind(tls_client));
 
     return tls_client;
   };


### PR DESCRIPTION
So based on testing @theojulienne found an issue with the reconnect code not being triggered when TLS connection failed.

The issue relates to TLS connection not triggering a `close` event on disconnect, to work around this when we detect any TLS error on the connection we end it. This ensures the standard lifecycle of the socket is respected while also triggering `close`.

Also just a couple of code tidy / corrections in the same block.

Cheers
