### PR TITLE
Jon remove function constructor

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -143,8 +143,56 @@ Connection.prototype._readPayload = function() {
     var buf = this.data.slice(this.index, this.index + this.packet.length);
     var result = null;
     this.index += this.packet.length;
-    if (parse[this.packet.cmd]) {
-      result = parse[this.packet.cmd](buf, this.packet, this._packetEncoding);
+    var cmd = this.packet.cmd;
+    switch(cmd) {
+      case protocol.types[0]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
+      case protocol.types[1]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
+      case protocol.types[2]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
+      case protocol.types[3]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
+      case protocol.types[4]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
+      case protocol.types[5]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
+      case protocol.types[6]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
+      case protocol.types[7]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
+      case protocol.types[8]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
+      case protocol.types[9]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
+      case protocol.types[10]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
+      case protocol.types[11]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
+      case protocol.types[12]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
+      case protocol.types[13]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
+      case protocol.types[14]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
+      case protocol.types[15]:
+        result = parse[cmd](buf, this.packet, this._packetEncoding);
+        break;
     }
     return result;
   }


### PR DESCRIPTION
This PR removes the Function constructor so that the library can run on Tessel natively. 

We'd like to eventually support Function constructors and @tcr did some work on converting our JS to Lua parser to C so that it can be done on the device. 

There are still a few minor bugs (you can still start a server or client) but I haven't had a chance to investigate yet.
