### PR TITLE
Added connection.destroy() on incoming connections

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -56,10 +56,10 @@ Connection.prototype.setPacketEncoding = function (encoding) {
 
 Connection.prototype.destroy = function(){
   var stream = this.stream;
-  if (stream.socket) {
-    stream.socket.close();
-  } else if(stream.destroy){
+   if (stream.destroy) {
     stream.destroy();
+  } else if(stream.socket){
+    stream.socket.close();
   } else {
     stream.end();
   }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -54,6 +54,17 @@ Connection.prototype.setPacketEncoding = function (encoding) {
   return this;
 };
 
+Connection.prototype.destroy = function(){
+  var stream = this.stream;
+  if (stream.socket) {
+    stream.socket.close();
+  } else if(stream.destroy){
+    stream.destroy();
+  } else {
+    stream.end();
+  }
+}
+
 Connection.prototype._newPacket = function() {
   this.packet = {};
   this.tmp = { pos: 1, mul: 1, length: 0};

--- a/lib/server.js
+++ b/lib/server.js
@@ -25,7 +25,7 @@ function Server(listener) {
     self.on('client', listener);
   }
 
-  self.on('connection', function(socket) {
+  self.on('connection', function(socket) 
     var client = new MqttServerClient(socket, self);
     
     client.destroy = socket.destroy.bind(socket);

--- a/lib/server.js
+++ b/lib/server.js
@@ -25,8 +25,14 @@ function Server(listener) {
     self.on('client', listener);
   }
 
-  self.on('connection', function(socket) {
-    self.emit('client', new MqttServerClient(socket, self));
+  self.on('connection', function(socket) 
+    var client = new MqttServerClient(socket, self);
+    
+    client.destroy = function(){
+      this.stream.destroy();
+    }
+    
+    self.emit('client', client);
   });
 
   return this;

--- a/lib/server.js
+++ b/lib/server.js
@@ -25,7 +25,7 @@ function Server(listener) {
     self.on('client', listener);
   }
 
-  self.on('connection', function(socket) 
+  self.on('connection', function(socket) {
     var client = new MqttServerClient(socket, self);
     
     client.destroy = socket.destroy.bind(socket);

--- a/lib/server.js
+++ b/lib/server.js
@@ -28,9 +28,7 @@ function Server(listener) {
   self.on('connection', function(socket) 
     var client = new MqttServerClient(socket, self);
     
-    client.destroy = function(){
-      this.stream.destroy();
-    }
+    client.destroy = socket.destroy.bind(socket);
     
     self.emit('client', client);
   });

--- a/lib/server.js
+++ b/lib/server.js
@@ -28,7 +28,9 @@ function Server(listener) {
   self.on('connection', function(socket) 
     var client = new MqttServerClient(socket, self);
     
-    client.destroy = socket.destroy.bind(socket);
+    client.destroy = function(){
+      this.stream.destroy();
+    }
     
     self.emit('client', client);
   });

--- a/lib/server.js
+++ b/lib/server.js
@@ -25,14 +25,8 @@ function Server(listener) {
     self.on('client', listener);
   }
 
-  self.on('connection', function(socket) 
-    var client = new MqttServerClient(socket, self);
-    
-    client.destroy = function(){
-      this.stream.destroy();
-    }
-    
-    self.emit('client', client);
+  self.on('connection', function(socket) {
+    self.emit('client', new MqttServerClient(socket, self));
   });
 
   return this;

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -77,6 +77,20 @@ module.exports = function(server, createClient, port) {
     });
   });
 
+  describe("destroying", function() {
+    it('should close the connection',function(done){
+      var client = createClient(port);
+
+      client.once('close',function() {
+        done();
+      });
+
+      client.once('connect',function() {
+        client.conn.destroy();
+      });
+    })
+  });
+
   describe('connecting', function() {
 
     it('should connect to the broker', function (done) {
@@ -540,17 +554,17 @@ module.exports = function(server, createClient, port) {
 
     it('should accept an hash of subscriptions', function(done) {
       var client = createClient(port);
-      
+
       var topics = {'test1': 0, 'test2': 1}
-      
+
       client.once('connect', function() {
         client.subscribe(topics);
       });
-      
+
       server.once('client', function(client) {
 	client.once('subscribe', function(packet) {
 	  var expected = [];
-      
+
 	  for (var k in topics) {
 	    if (topics.hasOwnProperty(k)) {
 	      expected.push({
@@ -559,13 +573,13 @@ module.exports = function(server, createClient, port) {
 	      });
 	    }
 	  }
-	  
+
 	  packet.subscriptions.should.eql(expected);
 	  done();
 	});
       });
     });
-      
+
     it('should accept an options parameter', function(done) {
       var client = createClient(port);
 


### PR DESCRIPTION
Calling connection.end() does not close the underlying socket instance as seen [here](https://github.com/mcollina/mows/issues/16), this makes it possible to destroy incoming connections by the server.

The reason for defining this within the server rather than the client, is that the client might receive different types of sockets and only the server-specific implementation would know how to close it.