### PR TITLE
Don't load "crypto" just for "randomBytes"

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2,7 +2,6 @@
  * Module dependencies
  */
 var events        = require('events')
-  , crypto        = require('crypto')
   , Store         = require('./store')
   , eos           = require('end-of-stream')
   , mqttPacket    = require('mqtt-packet')
@@ -26,7 +25,7 @@ var defaultConnectOptions = {
 };
 
 var defaultId = function() {
-  return 'mqttjs_' + crypto.randomBytes(8).toString('hex');
+  return 'mqttjs_' + Math.random().toString(16).substr(2, 8);
 };
 
 function nop() {}


### PR DESCRIPTION
This is fine in node, but in the browser it loads the enormous crypto dependency when all that is needed is a random ID.  The `crypto.randomBytes` function is also not supported on older browsers, so it would seem more sensible to use the simpler `Math.random()` unless true cryptographic security is required for this ID.