### PR TITLE
Fixed bugs caused by parsing the protocol from the URL

### DIFF
--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -14,11 +14,13 @@ if (process.title !== 'browser') {
 }
 
 protocols.ws      = require('./ws');
+protocols.wss     = require('./ws');
 
 protocolList = [
   'mqtt',
   'mqtts',
-  'ws'
+  'ws',
+  'wss'
 ];
 
 

--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -57,6 +57,7 @@ function connect(brokerUrl, opts) {
 
   if (brokerUrl) {
     opts = xtend(url.parse(brokerUrl, true), opts);
+    opts.protocol = opts.protocol.replace(/\:$/, '')
   }
 
   // merge in the auth options if supplied

--- a/test/mqtt.js
+++ b/test/mqtt.js
@@ -95,7 +95,7 @@ describe('mqtt', function() {
     });
     
     it('should return an MqttClient when connect is called with wss:/ url', function () {
-      var c = mqtt.connect('ws://localhost', sslOpts);
+      var c = mqtt.connect('wss://localhost', sslOpts);
       
       c.options.should.have.property('protocol', 'wss')
 

--- a/test/mqtt.js
+++ b/test/mqtt.js
@@ -66,6 +66,8 @@ describe('mqtt', function() {
 
     it('should return an MqttClient when connect is called with mqtts:/ url', function () {
       var c = mqtt.connect('mqtts://localhost', sslOpts);
+      
+      c.options.should.have.property('protocol', 'mqtts')
 
       c.on('error', function() {});
 
@@ -74,6 +76,28 @@ describe('mqtt', function() {
 
     it('should return an MqttClient when connect is called with ssl:/ url', function () {
       var c = mqtt.connect('ssl://localhost', sslOpts);
+      
+      c.options.should.have.property('protocol', 'ssl')
+
+      c.on('error', function() {});
+
+      c.should.be.instanceOf(mqtt.MqttClient);
+    });
+    
+    it('should return an MqttClient when connect is called with ws:/ url', function () {
+      var c = mqtt.connect('ws://localhost', sslOpts);
+      
+      c.options.should.have.property('protocol', 'ws')
+
+      c.on('error', function() {});
+
+      c.should.be.instanceOf(mqtt.MqttClient);
+    });
+    
+    it('should return an MqttClient when connect is called with wss:/ url', function () {
+      var c = mqtt.connect('ws://localhost', sslOpts);
+      
+      c.options.should.have.property('protocol', 'wss')
 
       c.on('error', function() {});
 


### PR DESCRIPTION
- Nodes `url.parse` return `mqtts:` instead of the expected `mqtts`.
- The `wss` protocol configuration was missing.
- Added tests.