### PR TITLE
`tls.connect` first expects the host property

### DIFF
--- a/lib/connect/tls.js
+++ b/lib/connect/tls.js
@@ -3,7 +3,7 @@ var tls = require("tls")
 
 function buildBuilder(mqttClient, opts) {
   opts.port     = opts.port || 8883;
-  opts.hostname = opts.hostname || opts.host || 'localhost';
+  opts.host     = opts.hostname || opts.host || 'localhost';
 
   opts.rejectUnauthorized = !(opts.rejectUnauthorized === false);
 


### PR DESCRIPTION
@mcollina Found another one.

Maybe it would be better to have real servers to test against, kinda like an acceptance test?

I'm working on a `mqtt-server` module that builds upon the new mqtt-connection. Wanna release that one under the mqttjs organization, and use it for tests?