### PR TITLE
Handle paths properly

### DIFF
--- a/lib/connect/ws.js
+++ b/lib/connect/ws.js
@@ -4,8 +4,9 @@ var URL = require('url');
 
 function buildBuilder(client, opts) {
   var host = opts.hostname || 'localhost'
-    , port = opts.port || 80
-    , url = opts.protocol + '://' + host + ':' + port
+    , port = String(opts.port || 80)
+    , path = opts.path || '/'
+    , url = opts.protocol + '://' + host + ':' + port + path
     , ws =  websocket(url, {
         protocol: 'mqttv3.1'
       });
@@ -39,9 +40,16 @@ function buildBuilderBrowser(mqttClient, opts) {
     }
   }
 
+  if (!opts.path) {
+    opts.path = parsed.pathname;
+    if (!opts.path) {
+      opts.path = '/';
+    }
+  }
+
   var host = opts.hostname || opts.host
-    , port = opts.port
-    , url = opts.protocol + '://' + host + ':' + opts.port
+    , port = String(opts.port)
+    , url = opts.protocol + '://' + host + ':' + port + opts.path;
 
   return websocket(url, 'mqttv3.1');
 }


### PR DESCRIPTION
This became an issue with for example `fubar` which does not allow WebSocket connections on any path but `/mqtt`. :stuck_out_tongue_winking_eye: