### PR TITLE
outgoingStore reading stream modified

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -219,10 +219,23 @@ MqttClient.prototype._setupStream = function () {
   // Echo connection errors
   parser.on('error', this.emit.bind(this, 'error'));
 
-  this.outgoingStore
+  var out = this.outgoingStore
     .createStream()
-    .on('data', function (packet) {
-      that._sendPacket(packet);
+    .once('readable', function() {
+      function storeDeliver() {
+        var packet = out.read(1);
+        if (!packet) {
+          return;
+        }
+        if (!that.disconnecting && !that.reconnectTimer) {
+          out.read(0);
+          that.outgoing[packet.messageId] = function() {
+            storeDeliver();
+          };
+          that._sendPacket(packet);
+        }
+      }
+      storeDeliver();
     })
     .on('error', this.emit.bind(this, 'error'));
 };


### PR DESCRIPTION
Add proper management of stored messages to support persistent Store objects (e.g. mqtt-level-store
). The stream reading mechanism was changed to avoid overhead when reading stream. A reading condition was added to avoid reading all the stream in case a reconnection is taking place but wasn't successful.
