### PR TITLE
Setup the ping timer after a reconnect

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -117,6 +117,7 @@ function MqttClient (streamBuilder, options) {
 
   // Setup ping timer
   this.on('connect', this._setupPingTimer);
+  this.on('reconnect', this._setupPingTimer);
 
   // Send queued packets
   this.on('connect', function () {

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -91,6 +91,20 @@ module.exports = function (server, config) {
       });
 
     });
+
+    it('should restart the ping timer if stream ends badly', function (done) {
+      var client = connect();
+
+      client.once('reconnect', function () {
+        should.exist(client.pingTimer);
+        client.end();
+        done();
+      });
+
+      client.once('connect', function () {
+        client.stream.end();
+      });
+    });
   });
 
   describe('connecting', function () {


### PR DESCRIPTION
The problem lies in the fact that the `'connect'` event is not emitted anymore at every reconnection, as it was in MQTT.js < 1.0.0. We should set up the ping timer even in the reconnect case, which is just what this PR does.

Please review, it should be straightforward anyway.
