### PR TITLE
Use svg version of travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![mqtt.js](https://raw.githubusercontent.com/mqttjs/MQTT.js/137ee0e3940c1f01049a30248c70f24dc6e6f829/MQTT.js.png)
 =======
 
-[![Build Status](https://travis-ci.org/mqttjs/MQTT.js.png)](https://travis-ci.org/mqttjs/MQTT.js)
+[![Build Status](https://travis-ci.org/mqttjs/MQTT.js.svg)](https://travis-ci.org/mqttjs/MQTT.js)
 
 [![NPM](https://nodei.co/npm/mqtt.png)](https://nodei.co/npm/mqtt/)
 [![NPM](https://nodei.co/npm-dl/mqtt.png)](https://nodei.co/npm/mqtt/)


### PR DESCRIPTION
Hey thanks for making this available.

Just noticed you are using the png version of the build status badge, while travis actually offers a svg version. On retina-style screens this looks a lot better with svg :)

So here is a very minor PR changing the badge to the svg version. If you think it is a good idea, feel free. If not, no biggie.

Thanks again, have a nice day!