### PR TITLE
Prevent unecessary 'drain' listeners on the write stream when buffering publishes in qos 0 with no callback

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -330,8 +330,6 @@ MqttClient.prototype.publish = function (topic, message, opts, callback) {
     return this;
   }
 
-  callback = callback || nop;
-
   packet = {
     cmd: 'publish',
     topic: topic,
@@ -344,8 +342,9 @@ MqttClient.prototype.publish = function (topic, message, opts, callback) {
   switch (opts.qos) {
     case 1:
     case 2:
+
       // Add to callbacks
-      this.outgoing[packet.messageId] = callback;
+      this.outgoing[packet.messageId] = callback || nop;
       this._sendPacket(packet);
       break;
     default:


### PR DESCRIPTION
Moving the default of the publish callback to nop. The defaulting is still done for the qos 1/2 callbacks, but under qos 0, the callback is left undefined so as to not add nop event handlers to the 'drain' event on the stream when the stream is buffering.

I don't believe this effects any situation except for when:
- publishing with no callback in qos 0
- when the stream is not ready to write to
in this situation it doesn't add a 'drain' listener to the write stream