### PR TITLE
Increase max listeners on stream to 1000

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -245,6 +245,9 @@ MqttClient.prototype._setupStream = function () {
   // Echo connection errors
   parser.on('error', this.emit.bind(this, 'error'));
 
+  // many drain listeners are needed for qos 1 callbacks if the connection is intermittent
+  this.stream.setMaxListeners(1000);
+
   clearTimeout(this.connackTimer);
   this.connackTimer = setTimeout(function () {
     that._cleanUp(true);


### PR DESCRIPTION
10 listeners is quite easily not enough on an intermittent connection when each publish callback requires a drain listener.