### PR TITLE
Simplify rejectUnauthorized defaulting by using `!== false`

### DIFF
--- a/lib/connect/tls.js
+++ b/lib/connect/tls.js
@@ -6,14 +6,7 @@ function buildBuilder (mqttClient, opts) {
   opts.port = opts.port || 8883;
   opts.host = opts.hostname || opts.host || 'localhost';
 
-  /**
-   * this should be further investigated
-   * the result is opts.rejectUnauthorized = opts.rejectUnauthorized
-   * do you want to check for undefined and set it to false default ?
-   */
-  /*jshint ignore:start */
-  opts.rejectUnauthorized = !(false === opts.rejectUnauthorized);
-  /*jshint ignore:end */
+  opts.rejectUnauthorized = false !== opts.rejectUnauthorized;
 
   connection = tls.connect(opts);
   /*eslint no-use-before-define: [2, "nofunc"]*/


### PR DESCRIPTION
I believe this is much easier to read and it complies with the check-style rules. It's important that a reader can understand this line and that the default setting is true.