### PR TITLE
Session Present flag is needed while handling connect event

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,9 @@ version 1.3 and 1.4 works fine without those.
 `function(connack) {}`
 
 Emitted on successful (re)connection (i.e. connack rc=0). 
-* `connack` received connack packet 
+* `connack` received connack packet. When `clean` connection option is `false` and server has a previous session 
+for `clientId` connection option, then `connack.sessionPresent` flag is `true`. When that is the case, 
+you may rely on stored session and prefer not to send subscribe commands for the client.
 
 #### Event `'reconnect'`
 

--- a/README.md
+++ b/README.md
@@ -212,9 +212,10 @@ version 1.3 and 1.4 works fine without those.
 
 #### Event `'connect'`
 
-`function() {}`
+`function(connack) {}`
 
-Emitted on successful (re)connection (i.e. connack rc=0).
+Emitted on successful (re)connection (i.e. connack rc=0). 
+* `connack` received connack packet 
 
 #### Event `'reconnect'`
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -667,7 +667,7 @@ MqttClient.prototype._handleConnack = function (packet) {
   clearTimeout(this.connackTimer);
 
   if (0 === rc) {
-    this.emit('connect', null, {sessionPresent: packet.sessionPresent});
+    this.emit('connect', packet);
   } else if (0 < rc) {
     this.emit('error',
         new Error('Connection refused: ' + errors[rc]));

--- a/lib/client.js
+++ b/lib/client.js
@@ -667,7 +667,7 @@ MqttClient.prototype._handleConnack = function (packet) {
   clearTimeout(this.connackTimer);
 
   if (0 === rc) {
-    this.emit('connect');
+    this.emit('connect', null, {sessionPresent: packet.sessionPresent});
   } else if (0 < rc) {
     this.emit('error',
         new Error('Connection refused: ' + errors[rc]));

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -199,6 +199,26 @@ module.exports = function (server, config) {
       client.once('error', done);
     });
 
+    it('should provide connack packet with connect event', function (done) {
+      server.once('client', function (serverClient) {
+        serverClient.connack({returnCode: 0, sessionPresent: true});
+
+        server.once('client', function (serverClient) {
+          serverClient.connack({returnCode: 0, sessionPresent: false});
+        });
+      });
+
+      var client = connect();
+      client.once('connect', function (packet) {
+        should(packet.sessionPresent).be.equal(true);
+        client.once('connect', function (packet) {
+          should(packet.sessionPresent).be.equal(false);
+          client.end();
+          done();
+        });
+      });
+    });
+
     it('should mark the client as connected', function (done) {
       var client = connect();
       client.once('connect', function () {


### PR DESCRIPTION
After making connection client needs to know if there exists its stored session in server side. Flag is avaliable in packet, however it should be passed to event as argument. For future needs argument type is object.