### PR TITLE
Adding this.options.queue as an option

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -95,7 +95,7 @@ function MqttClient (streamBuilder, options) {
   // Are we disconnecting?
   this.disconnecting = false;
   // Packet queue
-  this.queue = [];
+  this.queue = this.options.queue || [];
   // Are we intentionally disconnecting?
   this.disconnecting = false;
   // connack timer

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -374,6 +374,36 @@ module.exports = function (server, config) {
       });
     });
 
+    it('should publish a message (offline) from queue', function (done) {
+      var nop,
+        topic = 'test',
+        payload = 'test',
+        queuePacket = {cmd: 'publish',
+            topic: topic,
+            payload: payload,
+            qos: 0,
+            retain: false,
+            messageId: 1
+          },
+        queue,
+        client;
+
+      nop = function () {};
+      queue = [{ packet: queuePacket, cb: nop }];
+
+      client = connect({queue: queue});
+
+      server.once('client', function (serverClient) {
+        serverClient.once('publish', function (packet) {
+          packet.topic.should.equal(topic);
+          packet.payload.toString().should.equal(payload);
+          packet.qos.should.equal(0);
+          packet.retain.should.equal(false);
+          done();
+        });
+      });
+    });
+
     it('should publish a message (online)', function (done) {
       var client = connect(),
         payload = 'test',


### PR DESCRIPTION
I have added the ability to supply the `queue` of packages that is used while the client is offline to the constructor options. The test shows how one could use this to create a stream of messages that will be published right after the connection is made. I am aware that I could use

```
mqtt.connect();
mqtt.publish();
```
to publish even if the connection is not established, but this way I can queue messages without having access to a `MqttClient` instance. 

This functionality is needed to store packages published by the `<mqtt-publish>` before the `<mqtt-connection>` element can know If it might get the `MqttClient` injected or create it itself. 