### PR TITLE
Handling wrong authentication.

### DIFF
--- a/bin/pub.js
+++ b/bin/pub.js
@@ -12,7 +12,7 @@ var mqtt      = require('../')
 function send(args) {
   var client = mqtt.connect(args);
   client.on('connect', function() {
-    client.publish(args.topic, args.message, args);
+    client.publish(args.topic, args.message, args, function(err){ if(err) console.log(err); });
     client.end();
   });
   client.on('error', function(err){

--- a/bin/pub.js
+++ b/bin/pub.js
@@ -15,6 +15,13 @@ function send(args) {
     client.publish(args.topic, args.message, args);
     client.end();
   });
+  client.on('error', function(err){
+    // Handle 'Wrong credentials' case
+    console.warn(err);
+    client.end();
+  });
+  // TODO: Handle 'No Authorization'
+  
 }
 
 function start(args) {

--- a/bin/sub.js
+++ b/bin/sub.js
@@ -89,8 +89,16 @@ function start(args) {
   var client = mqtt.connect(args);
 
   client.on('connect', function() {
-    client.subscribe(args.topic, { qos: args.qos });
-  });
+    client.subscribe(args.topic, { qos: args.qos }, function(err, granted){
+      // Handle 'No authorization'
+      if (err){
+        console.warn('Error: ', err);
+        client.end();
+      }else if (granted.length && granted[0].hasOwnProperty('qos') && granted[0].qos > 2) {
+        console.warn('Error: client not authorized to subscribe to %s', granted[0].topic);
+        client.end();
+      }
+    });
 
   client.on('message', function(topic, payload) {
     if (args.verbose) {
@@ -105,7 +113,6 @@ function start(args) {
     console.warn(err);
     client.end();
   });
-  // TODO: alert impossibility to subscribe to a topic, 'No authorization'.
   
 }
 

--- a/bin/sub.js
+++ b/bin/sub.js
@@ -99,6 +99,14 @@ function start(args) {
       console.log(payload.toString())
     }
   });
+  
+  client.on('error', function(err){
+    // Handle 'No Authentication'
+    console.warn(err);
+    client.end();
+  });
+  // TODO: alert impossibility to subscribe to a topic, 'No authorization'.
+  
 }
 
 module.exports = start;


### PR DESCRIPTION
Done: emit an error on console if credentials are wrong, (both for pub and sub).

Todo: gotta be handled the 'No Authorizations' case.
I did some attempts on sub.js, editing the client.on('connect') callback this way:

      client.on('connect', function() {
        client.subscribe(args.topic, { qos: args.qos }, function(err, granted){
          if (err){
            console.warn('Error: ', err);
            client.end();
          }else console.log('Granted: ', granted);
        });

and this is my output on a topic that i'm not authorized to subscribe to:

    Granted: [ { topic: 'priv8', qos: 128 } ]

Weird, isn't it? The broker i'm using is Mosca. I'm implementing on Mosca the following functions: authenticate, authorizePublish, authorizeSubscribe.
