### PR TITLE
Change keep alive, deleted jshint errors, fixed reconnectPeriod >= connectTimeout bug

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -554,6 +554,7 @@ MqttClient.prototype._clearReconnect = function () {
  * @api private
  */
 MqttClient.prototype._cleanUp = function (forced, done) {
+
   if (done) {
     this.stream.on('close', done);
   }
@@ -570,7 +571,10 @@ MqttClient.prototype._cleanUp = function (forced, done) {
     );
   }
 
-  this._clearReconnect();
+  if (this.reconnectTimer) {
+    this._clearReconnect();
+    this._setupReconnect();
+  }
 
   if (null !== this.pingTimer) {
     this.pingTimer.clear();

--- a/lib/client.js
+++ b/lib/client.js
@@ -9,6 +9,7 @@ var events = require('events'),
   mqttPacket = require('mqtt-packet'),
   Writable = require('readable-stream').Writable,
   inherits = require('inherits'),
+  reInterval = require('reinterval'),
   setImmediate = global.setImmediate || function (callback) {
     // works in node v0.8
     process.nextTick(callback);
@@ -176,7 +177,7 @@ function MqttClient (streamBuilder, options) {
   // Clear ping timer
   this.on('close', function () {
     if (null !== that.pingTimer) {
-      clearInterval(that.pingTimer);
+      that.pingTimer.clear();
       that.pingTimer = null;
     }
   });
@@ -284,6 +285,8 @@ MqttClient.prototype._handlePacket = function (packet, done) {
       // or just log it
       break;
   }
+  // When a packet is received, reschedule the ping timer
+  this._shiftPingInterval();
 };
 
 MqttClient.prototype._checkDisconnecting = function (callback) {
@@ -570,7 +573,7 @@ MqttClient.prototype._cleanUp = function (forced, done) {
   this._clearReconnect();
 
   if (null !== this.pingTimer) {
-    clearInterval(this.pingTimer);
+    this.pingTimer.clear();
     this.pingTimer = null;
   }
 };
@@ -615,12 +618,22 @@ MqttClient.prototype._setupPingTimer = function () {
 
   if (!this.pingTimer && this.options.keepalive) {
     this.pingResp = true;
-    this.pingTimer = setInterval(function () {
+    this.pingTimer = reInterval(function () {
       that._checkPing();
     }, this.options.keepalive * 1000);
   }
 };
 
+/**
+ * _shiftPingInterval - reschedule the ping interval
+ *
+ * @api private
+ */
+MqttClient.prototype._shiftPingInterval = function () {
+  if (this.pingTimer && this.options.keepalive) {
+    this.pingTimer.reschedule(this.options.keepalive * 1000);
+  }
+};
 /**
  * _checkPing - check if a pingresp has come back, and ping the server again
  *

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mqtt",
   "description": "A library for the MQTT protocol",
-  "version": "1.5.1",
+  "version": "1.5.0",
   "contributors": [
     "Adam Rudd <adamvrr@gmail.com>",
     "Matteo Collina <matteo.collina@gmail.com> (https://github.com/mcollina)"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mqtt",
   "description": "A library for the MQTT protocol",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "contributors": [
     "Adam Rudd <adamvrr@gmail.com>",
     "Matteo Collina <matteo.collina@gmail.com> (https://github.com/mcollina)"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "browserify": "^11.0.1",
     "eslint": "^1.3.1",
     "jscs": "^2.1.1",
-    "jshint": "^2.6.2",
+    "jshint": "2.7.0",
     "mocha": "*",
     "pre-commit": "1.1.1",
     "should": "*",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "mqtt-connection": "^2.0.0",
     "mqtt-packet": "^3.2.0",
     "readable-stream": "~1.0.2",
+    "reinterval": "^1.0.1",
     "websocket-stream": "^2.0.2",
     "xtend": "^4.0.0"
   },

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -645,9 +645,9 @@ module.exports = function (server, config) {
       setTimeout(done, 1000);
     });
     it('should defer the next ping when a control packet is received', function (done) {
-      var client = connect({keepalive: 0.1});
+      var client = connect({keepalive: 0.1}),
 
-      var testPacket = {
+        testPacket = {
           topic: 'test',
           payload: 'message',
           retain: true,

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -645,6 +645,20 @@ module.exports = function (server, config) {
       });
       setTimeout(done, 1000);
     });
+    it('should defer the next ping when a control packer is received', function (done) {
+      var client = connect({keepalive: 100});
+      client.subscribe('test');
+      client._checkPing = sinon.spy();
+
+      setTimeout(function () {
+        client.publish('test');
+      }, 75);
+
+      setTimeout(function () {
+        client._checkPing.callCount.should.equal(0);
+        done();
+      }, 125);
+    });
   });
 
   describe('subscribing', function () {


### PR DESCRIPTION
## Change keepalive
Fixes #353 

Let's say that the client has a keepalive of 10 seconds,

Until now, it would send ping every 10 seconds.

Now, if it has received a control packet at 3 seconds, it'll send the next ping at 13s, so it results in a reduced data consumption.

## deleted some jshint errors for node 0.10
Fixes #354 

## reconnectPeriod >= connectTimeout supported
Fixes #346