### PR TITLE
Fixed the ping rescheduling

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -285,8 +285,6 @@ MqttClient.prototype._handlePacket = function (packet, done) {
       // or just log it
       break;
   }
-  // When a packet is received, reschedule the ping timer
-  this._shiftPingInterval();
 };
 
 MqttClient.prototype._checkDisconnecting = function (callback) {
@@ -593,6 +591,9 @@ MqttClient.prototype._sendPacket = function (packet, cb) {
   if (!this.connected) {
     return this.queue.push({ packet: packet, cb: cb });
   }
+
+  // When sending a packet, reschedule the ping timer
+  this._shiftPingInterval();
 
   switch (packet.qos) {
     case 2:


### PR DESCRIPTION
Fixes #357
Fixes #359 

As said in the documentation, the ping should be rescheduled when sending packets, not on packet receive.

> It is the responsibility of the Client to ensure that the interval between Control Packets being sent does not exceed the Keep Alive value. In the absence of sending any other Control Packets, the Client MUST send a PINGREQ Packet [MQTT-3.1.2-23]

## How to reproduce the error fixed by this PR

Here is an emitter client. It sends packet every seconds. There wasn't any problem with this one.
```js
var mqtt    = require('./');
var client  = mqtt.connect('mqtt://test.mosquitto.org', {keepalive: 1});

client.on('message', function (topic, message) {
    console.log(message.toString());
});

client.on('disconnect', function () {
    console.log('DISCONNECTION');
});

var i = 0;
setInterval(function () {
    client.publish('test4mqttjs', 'Hello mqtt' + i);
    console.log(i++ % 2 ? 'tac' : 'tic');
}, 1000);
```

Here is the listener. Here was the problem.

```js
var mqtt    = require('./');
var client  = mqtt.connect('mqtt://test.mosquitto.org', {keepalive: 3});

client.subscribe('test4mqttjs');

client.on('message', function (topic, message) {
    console.log(message.toString());
});

client.on('offline', function () {
    console.log('DISCONNECTION');
});
```

It should not disconnect, but with MQTT.js v1.6.0, it did when the emitter was up because of the ping rescheduler. See more infos in the associated issue.