### PR TITLE
Ensure subscribe callback is set before checkDisconnect

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -97,8 +97,6 @@ function MqttClient (streamBuilder, options) {
   this.disconnecting = false;
   // Packet queue
   this.queue = [];
-  // Are we intentionally disconnecting?
-  this.disconnecting = false;
   // connack timer
   this.connackTimer = null;
   // Reconnect timer
@@ -403,7 +401,7 @@ MqttClient.prototype.subscribe = function () {
   if (this._checkDisconnecting(callback)) {
     return this;
   }
-  
+
   if (!opts) {
     opts = { qos: 0 };
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -395,15 +395,15 @@ MqttClient.prototype.subscribe = function () {
     obj = [obj];
   }
 
-  if (this._checkDisconnecting(callback)) {
-    return this;
-  }
-
   if ('function' !== typeof callback) {
     opts = callback;
     callback = nop;
   }
 
+  if (this._checkDisconnecting(callback)) {
+    return this;
+  }
+  
   if (!opts) {
     opts = { qos: 0 };
   }

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -786,6 +786,32 @@ module.exports = function (server, config) {
       });
     });
 
+    it('should fire a callback with error if disconnected (options provided)', function (done) {
+      var client = connect(),
+        topic = 'test';
+      client.once('connect', function () {
+        client.end(true, function () {
+          client.subscribe(topic, {qos: 2}, function (err, granted) {
+            should.not.exist(granted, 'granted given');
+            should.exist(err, 'no error given');
+            done();
+          });
+        });
+      });
+    });
+    it('should fire a callback with error if disconnected (options not provided)', function (done) {
+      var client = connect(),
+        topic = 'test';
+      client.once('connect', function () {
+        client.end(true, function () {
+          client.subscribe(topic, function (err, granted) {
+            should.not.exist(granted, 'granted given');
+            should.exist(err, 'no error given');
+            done();
+          });
+        });
+      });
+    });
     it('should subscribe with a chinese topic', function (done) {
       var client = connect(),
         topic = '中国';


### PR DESCRIPTION
If `MqttClient.subscribe` is called with a topic and options object, but no callback function, then the options object is being passed to `_checkDisconnect` as the callback. If the client is currently disconnecting then this results in `TypeError: object is not a function` as it tries to invoke the callback which is actually the options object.

The `subscribe` function already does the necessary work to properly set `opts` and `callback` depending on what was passed into the function, but the call to `_checkDisconnect` happens before that is done.

This fix moves the call to `_checkDisconnect` to below the point where callback will be guaranteed to be a function. 