### PR TITLE
Fix to support TLS server and client auth for wss://

### DIFF
--- a/lib/connect/ws.js
+++ b/lib/connect/ws.js
@@ -16,6 +16,21 @@ function buildBuilder (client, opts) {
     if (opts.hasOwnProperty('rejectUnauthorized')) {
       wsOpt.rejectUnauthorized = opts.rejectUnauthorized;
     }
+    if (opts.hasOwnProperty('ca')) {
+      wsOpt.ca = opts.ca;
+    }
+    if (opts.hasOwnProperty('cert')) {
+      wsOpt.cert = opts.cert;
+    }
+    if (opts.hasOwnProperty('key')) {
+      wsOpt.key = opts.key;
+    }
+    if (opts.hasOwnProperty('pfx')) {
+      wsOpt.pfx = opts.pfx;
+    }
+    if (opts.hasOwnProperty('passphrase')) {
+      wsOpt.passphrase = opts.passphrase;
+    }
   }
 
   return websocket(url, wsOpt);

--- a/lib/connect/ws.js
+++ b/lib/connect/ws.js
@@ -3,6 +3,15 @@
 var websocket = require('websocket-stream'),
   _URL = require('url');
 
+var wssProperties = [
+  'rejectUnauthorized',
+  'ca',
+  'cert',
+  'key',
+  'pfx',
+  'passphrase'
+];
+
 function buildBuilder (client, opts) {
   var wsOpt = {
       protocol: 'mqttv3.1'
@@ -13,24 +22,12 @@ function buildBuilder (client, opts) {
     url = opts.protocol + '://' + host + ':' + port + path;
 
   if ('wss' === opts.protocol) {
-    if (opts.hasOwnProperty('rejectUnauthorized')) {
-      wsOpt.rejectUnauthorized = opts.rejectUnauthorized;
-    }
-    if (opts.hasOwnProperty('ca')) {
-      wsOpt.ca = opts.ca;
-    }
-    if (opts.hasOwnProperty('cert')) {
-      wsOpt.cert = opts.cert;
-    }
-    if (opts.hasOwnProperty('key')) {
-      wsOpt.key = opts.key;
-    }
-    if (opts.hasOwnProperty('pfx')) {
-      wsOpt.pfx = opts.pfx;
-    }
-    if (opts.hasOwnProperty('passphrase')) {
-      wsOpt.passphrase = opts.passphrase;
-    }
+    //Copy pertinent TLS properties
+    wssProperties.forEach(function(prop) {
+      if(opts.hasOwnProperty(prop)) {
+        wsOpts[prop] = opts[prop];
+      }
+    });
   }
 
   return websocket(url, wsOpt);

--- a/lib/connect/ws.js
+++ b/lib/connect/ws.js
@@ -1,16 +1,15 @@
 'use strict';
 
 var websocket = require('websocket-stream'),
-  _URL = require('url');
-
-var wssProperties = [
-  'rejectUnauthorized',
-  'ca',
-  'cert',
-  'key',
-  'pfx',
-  'passphrase'
-];
+  _URL = require('url'),
+  wssProperties = [
+    'rejectUnauthorized',
+    'ca',
+    'cert',
+    'key',
+    'pfx',
+    'passphrase'
+  ];
 
 function buildBuilder (client, opts) {
   var wsOpt = {
@@ -22,10 +21,9 @@ function buildBuilder (client, opts) {
     url = opts.protocol + '://' + host + ':' + port + path;
 
   if ('wss' === opts.protocol) {
-    //Copy pertinent TLS properties
-    wssProperties.forEach(function(prop) {
-      if(opts.hasOwnProperty(prop)) {
-        wsOpts[prop] = opts[prop];
+    wssProperties.forEach(function (prop) {
+      if (opts.hasOwnProperty(prop)) {
+        wsOpt[prop] = opts[prop];
       }
     });
   }


### PR DESCRIPTION
Added options to pass ca, cert, and key options to the underlying websocket-stream instance. This allows use with self-signed CAs and certificate based client authentication.

Tested against a mosquitto install, but not sure how to test as part of this project as the server does not appear to (currently) support wss.