### PR TITLE
Bumped dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
     "help-me": "^0.1.0",
     "inherits": "^2.0.1",
     "minimist": "^1.1.0",
-    "mqtt-connection": "^2.0.0",
-    "mqtt-packet": "^3.2.0",
+    "mqtt-connection": "^2.1.1",
+    "mqtt-packet": "^4.0.5",
     "readable-stream": "~1.0.2",
     "reinterval": "^1.0.1",
-    "websocket-stream": "^2.0.2",
+    "websocket-stream": "^3.0.1",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
@@ -66,7 +66,7 @@
     "mocha": "*",
     "pre-commit": "1.1.1",
     "should": "*",
-    "sinon": "~1.10.0",
+    "sinon": "~1.17.2",
     "through2": "^0.6.3",
     "uglify": "^0.1.1",
     "ws": "^0.8.0",

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -645,7 +645,7 @@ module.exports = function (server, config) {
       setTimeout(done, 1000);
     });
     it('should defer the next ping when sending a control packet', function (done) {
-      var client = connect({keepalive: 0.1});
+      var client = connect({keepalive: 1});
 
       client.once('connect', function () {
         client._checkPing = sinon.spy();
@@ -662,9 +662,9 @@ module.exports = function (server, config) {
             setTimeout(function () {
               client._checkPing.callCount.should.equal(0);
               done();
-            }, 75);
-          }, 75);
-        }, 75);
+            }, 750);
+          }, 750);
+        }, 750);
       });
     });
   });


### PR DESCRIPTION
- mqtt-connection
- mqtt-packet
- websocket-stream

I had to increase the timeouts for the ping deferal test in order to get the tests to run.. We should discuss on what's going on there. Functionality seems to be fine and keepalive < 1sec doesn't seem to be a realistic requirement. 

btw the test with 0.1s doesn't run on v1.6.3 at my machine either - but obviously they passed on your side.. 