### PR TITLE
Clear the connack timeout on close event

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -146,6 +146,7 @@ function MqttClient (streamBuilder, options) {
   // Mark disconnected on stream close
   this.on('close', function () {
     this.connected = false;
+    clearTimeout(this.connackTimer);
   });
 
   // Setup ping timer


### PR DESCRIPTION
Shouldn't the connack timeout be cleared if a close event is received?  If it isn't cleared, it can interrupt a reconnect attempt in progress.