### PR TITLE
Added DefinitelyTyped badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 [![Build Status](https://travis-ci.org/mqttjs/MQTT.js.svg)](https://travis-ci.org/mqttjs/MQTT.js)
 
+[![DefinitelyTyped](http://img.shields.io/badge/Definitely-Typed-blue.svg)](https://github.com/borisyankov/DefinitelyTyped/tree/master/mqtt)
+
 [![NPM](https://nodei.co/npm/mqtt.png)](https://nodei.co/npm/mqtt/)
 [![NPM](https://nodei.co/npm-dl/mqtt.png)](https://nodei.co/npm/mqtt/)
 


### PR DESCRIPTION
I created a TypeScript type definition of the MQTT.js a while ago. It can be found in [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) repository. This instance provides a badge for a project, which has a type definition.

Instead of the experimental badge, one could just mention about the type definitions somewhere in the text or just leave the README as it is.