### PR TITLE
Introduce 'fastClientDisconnectDetect' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The arguments are:
 the `connect` event. Typically a `net.Socket`.
 * `options` is the client connection options (see: the [connect packet](https://github.com/mcollina/mqtt-packet#connect)). Defaults:
   * `keepalive`: `10` seconds, set to `0` to disable
+  * `reschedulePings`: reschedule ping messages after sending packets (default `true`)
   * `clientId`: `'mqttjs_' + Math.random().toString(16).substr(2, 8)`
   * `protocolId`: `'MQTT'`
   * `protocolVersion`: `4`

--- a/lib/client.js
+++ b/lib/client.js
@@ -16,6 +16,7 @@ var events = require('events'),
   },
   defaultConnectOptions = {
     keepalive: 10,
+    reschedulePings: true,
     protocolId: 'MQTT',
     protocolVersion: 4,
     reconnectPeriod: 1000,
@@ -642,7 +643,7 @@ MqttClient.prototype._setupPingTimer = function () {
  * @api private
  */
 MqttClient.prototype._shiftPingInterval = function () {
-  if (this.pingTimer && this.options.keepalive && !this.options.fastClientDisconnectDetect) { 
+  if (this.pingTimer && this.options.keepalive && this.options.reschedulePings) {
     this.pingTimer.reschedule(this.options.keepalive * 1000);
   }
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -642,7 +642,7 @@ MqttClient.prototype._setupPingTimer = function () {
  * @api private
  */
 MqttClient.prototype._shiftPingInterval = function () {
-  if (this.pingTimer && this.options.keepalive) {
+  if (this.pingTimer && this.options.keepalive && !this.options.fastClientDisconnectDetect) { 
     this.pingTimer.reschedule(this.options.keepalive * 1000);
   }
 };

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -605,6 +605,114 @@ module.exports = function (server, config) {
         done();
       });
     });
+    it('should not checkPing if publishing at a higher rate than keepalive', function (done) {
+      var interval = 3,
+        client = connect({keepalive: interval});
+
+      client._checkPing = sinon.spy();
+
+      client.once('connect', function () {
+
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client._checkPing.callCount.should.equal(0);
+
+        client.end();
+        done();
+      });
+    });
+    it('should checkPing if publishing at a higher rate than keepalive and reschedulePings===false', function (done) {
+      var interval = 3,
+        client = connect({keepalive: interval,reschedulePings:false});
+
+      client._checkPing = sinon.spy();
+
+      client.once('connect', function () {
+
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client.publish('foo', 'bar');
+        clock.tick(interval * 500);
+        client._checkPing.callCount.should.equal(7);
+
+        client.end();
+        done();
+      });
+    });
   });
 
   describe('pinging', function () {

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -606,109 +606,33 @@ module.exports = function (server, config) {
       });
     });
     it('should not checkPing if publishing at a higher rate than keepalive', function (done) {
-      var interval = 3,
-        client = connect({keepalive: interval});
+      var intervalMs = 3000,
+        client = connect({keepalive: intervalMs / 1000});
 
       client._checkPing = sinon.spy();
 
       client.once('connect', function () {
-
         client.publish('foo', 'bar');
-        clock.tick(interval * 500);
+        clock.tick(intervalMs - 1);
         client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
+        clock.tick(2);
         client._checkPing.callCount.should.equal(0);
-
         client.end();
         done();
       });
     });
     it('should checkPing if publishing at a higher rate than keepalive and reschedulePings===false', function (done) {
-      var interval = 3,
-        client = connect({keepalive: interval,reschedulePings:false});
+      var intervalMs = 3000,
+        client = connect({keepalive: intervalMs / 1000,reschedulePings:false});
 
       client._checkPing = sinon.spy();
 
       client.once('connect', function () {
-
         client.publish('foo', 'bar');
-        clock.tick(interval * 500);
+        clock.tick(intervalMs - 1);
         client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client.publish('foo', 'bar');
-        clock.tick(interval * 500);
-        client._checkPing.callCount.should.equal(7);
-
+        clock.tick(2);
+        client._checkPing.callCount.should.equal(1);
         client.end();
         done();
       });


### PR DESCRIPTION
If the client publishes faster than the keepalive interval, PINGREQ messages keep getting rescheduled and will not be sent.  If connectivity is lost between the client and the broker during such a period, the client may not be able to detect that its published messages aren't reaching the broker.  This change introduces a new option ('fastClientDisconnectDetect') to **not** reschedule PINGREQ messages when sending packets.

This is in accordance with the MQTT spec v3.1.1, paragraph 3.1.2.10 (Keep Alive), which states that clients may send PINGREQ at any time:
```
The Client can send PINGREQ at any time, irrespective of the Keep Alive value, and use the PINGRESP to determine that the network and the Server are working.
```