### PR TITLE
Add .qosZeroNotQueued option to MqttClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ the `connect` event. Typically a `net.Socket`.
   * `password`: the password required by your broker, if any
   * `incomingStore`: a [Store](#store) for the incoming packets
   * `outgoingStore`: a [Store](#store) for the outgoing packets
+  * `qosZeroNotQueued`: if connection is broken, do not queue outgoing QoS zero messages (default `false`)
   * `will`: a message that will sent by the broker automatically when
      the client disconnect badly. The format is:
     * `topic`: the topic to publish

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ the `connect` event. Typically a `net.Socket`.
   * `password`: the password required by your broker, if any
   * `incomingStore`: a [Store](#store) for the incoming packets
   * `outgoingStore`: a [Store](#store) for the outgoing packets
-  * `qosZeroNotQueued`: if connection is broken, do not queue outgoing QoS zero messages (default `false`)
+  * `queueQoSZero`: if connection is broken, queue outgoing QoS zero messages (default `true`)
   * `will`: a message that will sent by the broker automatically when
      the client disconnect badly. The format is:
     * `topic`: the topic to publish

--- a/lib/client.js
+++ b/lib/client.js
@@ -91,7 +91,7 @@ function MqttClient (streamBuilder, options) {
   this.incomingStore = this.options.incomingStore || new Store();
 
   // Should QoS zero messages be queued when the connection is broken?
-  this.qosZeroNotQueued = this.options.qosZeroNotQueued || false;
+  this.queueQoSZero = null == this.options.queueQoSZero ? true : this.options.queueQoSZero;
 
   // Ping timer, setup in _setupPingTimer
   this.pingTimer = null;
@@ -600,14 +600,10 @@ MqttClient.prototype._cleanUp = function (forced, done) {
  */
 MqttClient.prototype._sendPacket = function (packet, cb) {
   if (!this.connected) {
-    if (0 === packet.qos && this.qosZeroNotQueued) {
-      if (cb) {
-        cb(new Error('No connection to broker'));
-      } else {
-        this.emit('error', new Error('No connection to broker'));
-      }
-    } else {
+    if (0 < packet.qos || 'publish' !== packet.cmd || this.queueQoSZero) {
       this.queue.push({ packet: packet, cb: cb });
+    } else if (cb) {
+      cb(new Error('No connection to broker'));
     }
 
     return;

--- a/lib/client.js
+++ b/lib/client.js
@@ -90,6 +90,9 @@ function MqttClient (streamBuilder, options) {
   this.outgoingStore = this.options.outgoingStore || new Store();
   this.incomingStore = this.options.incomingStore || new Store();
 
+  // Should QoS zero messages be queued when the connection is broken?
+  this.qosZeroNotQueued = this.options.qosZeroNotQueued || false;
+
   // Ping timer, setup in _setupPingTimer
   this.pingTimer = null;
   // Is the client connected?
@@ -597,7 +600,17 @@ MqttClient.prototype._cleanUp = function (forced, done) {
  */
 MqttClient.prototype._sendPacket = function (packet, cb) {
   if (!this.connected) {
-    return this.queue.push({ packet: packet, cb: cb });
+    if (0 === packet.qos && this.qosZeroNotQueued) {
+      if (cb) {
+        cb(new Error('No connection to broker'));
+      } else {
+        this.emit('error', new Error('No connection to broker'));
+      }
+    } else {
+      this.queue.push({ packet: packet, cb: cb });
+    }
+
+    return;
   }
 
   // When sending a packet, reschedule the ping timer

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -271,6 +271,23 @@ module.exports = function (server, config) {
       });
     });
 
+    it('should not queue qos 0 messages if qosZeroNotQueued is true', function () {
+      var client = connect({qosZeroNotQueued: true});
+
+      client.publish('test', 'test', {qos: 0}, function () {/* Silence 'no connection' error */});
+      client.queue.length.should.equal(0);
+    });
+
+    it('should still queue qos != 0 messages if qosZeroNotQueued is true', function () {
+      var client = connect({qosZeroNotQueued: true});
+
+      client.publish('test', 'test', {qos: 1});
+      client.publish('test', 'test', {qos: 2});
+      client.subscribe('test');
+      client.unsubscribe('test');
+      client.queue.length.should.equal(4);
+    });
+
     if (!process.env.TRAVIS) {
       it('should queue message until connected', function (done) {
         var client = connect();

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -271,21 +271,29 @@ module.exports = function (server, config) {
       });
     });
 
-    it('should not queue qos 0 messages if qosZeroNotQueued is true', function () {
-      var client = connect({qosZeroNotQueued: true});
+    it('should not queue qos 0 messages if queueQoSZero is false', function () {
+      var client = connect({queueQoSZero: false});
 
-      client.publish('test', 'test', {qos: 0}, function () {/* Silence 'no connection' error */});
+      client.publish('test', 'test', {qos: 0});
       client.queue.length.should.equal(0);
     });
 
-    it('should still queue qos != 0 messages if qosZeroNotQueued is true', function () {
-      var client = connect({qosZeroNotQueued: true});
+    it('should still queue qos != 0 messages if queueQoSZero is false', function () {
+      var client = connect({queueQoSZero: false});
 
       client.publish('test', 'test', {qos: 1});
       client.publish('test', 'test', {qos: 2});
       client.subscribe('test');
       client.unsubscribe('test');
       client.queue.length.should.equal(4);
+    });
+
+    it('should call cb if an outgoing QoS 0 message is not sent', function (done) {
+      var client = connect({queueQoSZero: false});
+
+      client.publish('test', 'test', {qos: 0}, function () {
+        done();
+      });
     });
 
     if (!process.env.TRAVIS) {


### PR DESCRIPTION
My proposal for #397

The default behavior remains identical to existing behavior. If a client's .qosZeroNotQueued option is set to true, then it will stop queuing QoS zero messages, but will still queue QoS 1 and 2 messages if disconnected.

I wasn't sure what branch to put this in, and it isn't a breaking change, so I put it in master. Let me know if it should go somewhere else.