### PR TITLE
Removed [options] param from mqtt.Client#unsubscribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Subscribe to a topic or topics
 
 -------------------------------------------------------
 <a name="unsubscribe"></a>
-### mqtt.Client#unsubscribe(topic/topic array, [options], [callback])
+### mqtt.Client#unsubscribe(topic/topic array, [callback])
 
 Unsubscribe from a topic or topics
 


### PR DESCRIPTION
The number of parameters for mqtt.Client#unsubscribe was wrong in the documentation. Unsubscribe method doesn't accept an options parameter.