### PR TITLE
Fixed an error in handling outgoingStore.del

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -824,14 +824,14 @@ MqttClient.prototype._handleAck = function (packet) {
     case 'suback':
       delete this.outgoing[mid];
       this.outgoingStore.del(packet, function (err, original) {
-        var i,
-          origSubs = original.subscriptions,
-          granted = packet.granted;
-
         if (err) {
           // missing packet, what should we do?
           return that.emit('error', err);
         }
+
+        var i,
+          origSubs = original.subscriptions,
+          granted = packet.granted;
 
         for (i = 0; i < granted.length; i += 1) {
           origSubs[i].qos = granted[i];


### PR DESCRIPTION
This PR addresses the following error:

```text
project/node_modules/mqtt/lib/client.js:828
          origSubs = original.subscriptions,
                             ^

TypeError: Cannot read property 'subscriptions' of undefined
    at project/node_modules/mqtt/lib/client.js:828:30
    at Store.del (project/node_modules/mqtt/lib/store.js:78:5)
    at MqttClient._handleAck (project/node_modules/mqtt/lib/client.js:826:26)
    at MqttClient._handlePacket (project/node_modules/mqtt/lib/client.js:279:12)
    at process (project/node_modules/mqtt/lib/client.js:230:12)
    at Writable.writable._write (project/node_modules/mqtt/lib/client.js:240:5)
    at doWrite (project/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (project/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at Writable.write (project/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at Socket.ondata (_stream_readable.js:528:20)
```

The error is identified at:

```js
    // client.js, line 827
    case 'suback':
      delete this.outgoing[mid];
      this.outgoingStore.del(packet, function (err, original) {
        var i,
          origSubs = original.subscriptions, // ERROR: we must check for error first
          granted = packet.granted;

        if (err) {
          // missing packet, what should we do?
          return that.emit('error', err);
        }

        for (i = 0; i < granted.length; i += 1) {
          origSubs[i].qos = granted[i];
        }

        cb(null, origSubs);
      });
      break;
```