### PR TITLE
Gracefully handle unknown message id's in handlePubrel

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -866,15 +866,10 @@ MqttClient.prototype._handlePubrel = function (packet, callback) {
     that = this;
 
   that.incomingStore.get(packet, function (err, pub) {
-    if (err) {
-      return that.emit('error', err);
-    }
-
-    if ('pubrel' !== pub.cmd) {
+    if (!err && 'pubrel' !== pub.cmd) {
       that.emit('message', pub.topic, pub.payload, pub);
-      that.incomingStore.put(packet);
     }
-
+    that.incomingStore.put(packet);
     that._sendPacket({cmd: 'pubcomp', messageId: mid}, callback);
   });
 };


### PR DESCRIPTION
This should handle PUBREL messages without throwing an exception for unknown message id's. 
See #415 for more details. 