### PR TITLE
Export MqttClient from lib/connect/index.js to support browserization

### DIFF
--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -134,3 +134,4 @@ function connect (brokerUrl, opts) {
 
 module.exports = connect;
 module.exports.connect = connect;
+module.exports.MqttClient = MqttClient;


### PR DESCRIPTION
This change allows a browserified application to use the MqttClient exported by mqtt.js.