### PR TITLE
Adding bower.json file to add to bower registry

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "mqtt",
+  "description": "A library for the MQTT protocol",
+  "main": "mqtt.js",
+  "authors": [
+    "Adam Rudd <adamvrr@gmail.com>",
+    "Matteo Collina <matteo.collina@gmail.com> (https://github.com/mcollina)"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "mqtt",
+    "publish/subscribe",
+    "publish",
+    "subscribe"
+  ],
+  "homepage": "https://github.com/ccravens/MQTT.js",
+  "moduleType": [],
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
It would be great for this package to be available via bower. This addition provides the required bower.json file, and the project can be registered on bower via "bower register mqtt https://github.com/mqttjs/MQTT.js"