### PR TITLE
Remove a .only on a test.

### DIFF
--- a/test/client.js
+++ b/test/client.js
@@ -253,7 +253,7 @@ describe('MqttClient', function () {
       }, 2000)
     })
 
-    it.only('should not send the same packet multiple times on a flaky connection', function (done) {
+    it('should not send the same packet multiple times on a flaky connection', function (done) {
       this.timeout(3500)
 
       var KILL_COUNT = 4


### PR DESCRIPTION
A test was singled out when developing a previous commit. Restore the unit tests to normal operation.