### PR TITLE
Avoid storing subscribes in the outgoingStore

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -118,7 +118,6 @@ function MqttClient (streamBuilder, options) {
 
     this.connected = true
     var outStore = null
-    var sessionAlive = true
     outStore = this.outgoingStore.createStream()
 
     // Control of stored messages
@@ -140,11 +139,8 @@ function MqttClient (streamBuilder, options) {
             if (cb) {
               cb(err, status)
             }
-            // Ensure that the next message will only be read after callback is issued
-            // and only if the current connection is still active
-            if (sessionAlive) {
-              storeDeliver()
-            }
+
+            storeDeliver()
           }
           that._sendPacket(packet)
         } else if (outStore.destroy) {
@@ -154,10 +150,6 @@ function MqttClient (streamBuilder, options) {
       storeDeliver()
     })
     .on('error', this.emit.bind(this, 'error'))
-
-    this.once('close', function () {
-      sessionAlive = false
-    })
   })
 
   // Mark disconnected on stream close
@@ -468,11 +460,16 @@ MqttClient.prototype.subscribe = function () {
     messageId: this._nextId()
   }
 
-  this.outgoing[packet.messageId] = function (err, subs) {
+  this.outgoing[packet.messageId] = function (err, packet) {
     if (!err) {
       subs.forEach(function (sub) {
         that._subscribedTopics[sub.topic] = sub.qos
       })
+
+      var granted = packet.granted
+      for (var i = 0; i < granted.length; i += 1) {
+        subs[i].qos = granted[i]
+      }
     }
 
     callback(err, subs)
@@ -661,6 +658,11 @@ MqttClient.prototype._sendPacket = function (packet, cb) {
 
   // When sending a packet, reschedule the ping timer
   this._shiftPingInterval()
+
+  if (packet.cmd !== 'publish') {
+    sendPacket(this, packet, cb)
+    return
+  }
 
   switch (packet.qos) {
     case 2:
@@ -873,25 +875,11 @@ MqttClient.prototype._handleAck = function (packet) {
       break
     case 'suback':
       delete this.outgoing[mid]
-      this.outgoingStore.del(packet, function (err, original) {
-        if (err) {
-          // missing packet, what should we do?
-          return that.emit('error', err)
-        }
-
-        var origSubs = original.subscriptions
-        var granted = packet.granted
-
-        for (var i = 0; i < granted.length; i += 1) {
-          origSubs[i].qos = granted[i]
-        }
-
-        cb(null, origSubs)
-      })
+      cb(null, packet)
       break
     case 'unsuback':
       delete this.outgoing[mid]
-      this.outgoingStore.del(packet, cb)
+      cb(null)
       break
     default:
       that.emit('error', new Error('unrecognized packet type'))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mqtt",
   "description": "A library for the MQTT protocol",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "contributors": [
     "Adam Rudd <adamvrr@gmail.com>",
     "Matteo Collina <matteo.collina@gmail.com> (https://github.com/mcollina)"
@@ -57,18 +57,18 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "browserify": "^11.0.1",
+    "browserify": "^13.0.0",
     "mocha": "*",
-    "mqtt-connection": "^2.0.0",
-    "pre-commit": "1.1.1",
+    "mqtt-connection": "^3.0.0",
+    "pre-commit": "^1.1.3",
     "should": "*",
-    "sinon": "~1.10.0",
+    "sinon": "~1.17.0",
     "standard": "^8.0.0",
     "through2": "^2.0.0",
     "uglify": "^0.1.1",
-    "ws": "^0.8.0",
+    "ws": "^1.0.0",
     "zuul": "^3.4.0",
-    "zuul-ngrok": "gnandretta/zuul-ngrok#upgrade-ngrok"
+    "zuul-ngrok": "^4.0.0"
   },
   "standard": {
     "globals": [

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -1375,6 +1375,7 @@ module.exports = function (server, config) {
           tryReconnect = false
         } else {
           offlineEvent.should.equal(true)
+          client.end()
           done()
         }
       })
@@ -1399,6 +1400,7 @@ module.exports = function (server, config) {
 
       client.once('close', function () {
         should.exist(client.reconnectTimer)
+        client.end()
         done()
       })
     })
@@ -1454,6 +1456,7 @@ module.exports = function (server, config) {
 
       function check () {
         if (serverPublished && clientCalledBack) {
+          client.end()
           done()
         }
       }
@@ -1465,6 +1468,8 @@ module.exports = function (server, config) {
       var clientCalledBack = false
 
       server.once('client', function (serverClient) {
+        // ignore errors
+        serverClient.on('error', function () {})
         serverClient.on('publish', function () {
           setImmediate(function () {
             serverClient.stream.destroy()
@@ -1486,6 +1491,7 @@ module.exports = function (server, config) {
 
       function check () {
         if (serverPublished && clientCalledBack) {
+          client.end()
           done()
         }
       }

--- a/test/client.js
+++ b/test/client.js
@@ -268,6 +268,7 @@ describe('MqttClient', function () {
       })
 
       var server2 = new Server(function (client) {
+        client.on('error', function () {})
         client.on('connect', function (packet) {
           if (packet.clientId === 'invalid') {
             client.connack({returnCode: 2})

--- a/test/client.js
+++ b/test/client.js
@@ -253,12 +253,11 @@ describe('MqttClient', function () {
       }, 2000)
     })
 
-    it.only('should not send the same packet multiple times on a flaky connection', function (done) {
+    it('should not send the same packet multiple times on a flaky connection', function (done) {
       this.timeout(3500)
 
       var KILL_COUNT = 4
       var killedConnections = 0
-      var subCallbackCount = 0
       var subIds = {}
       var client = mqtt.connect({
         port: port + 46,
@@ -280,13 +279,10 @@ describe('MqttClient', function () {
 
       server2.on('client', function (c) {
         client.subscribe('topic', function () {
-          subCallbackCount++
-          if (subCallbackCount === KILL_COUNT) {
-            done()
-            client.end(true)
-            c.destroy()
-            server2.destroy()
-          }
+          done()
+          client.end(true)
+          c.destroy()
+          server2.destroy()
         })
 
         c.on('subscribe', function (packet) {

--- a/test/websocket_client.js
+++ b/test/websocket_client.js
@@ -18,6 +18,8 @@ function attachWebsocketServer (wsServer) {
     var connection = new Connection(stream)
 
     wsServer.emit('client', connection)
+    stream.on('error', function () {})
+    connection.on('error', function () {})
   })
 
   return wsServer


### PR DESCRIPTION
#460 #468 #469 #450 are about a subscribe that goes multiple times to AWS IoT.

I reverted your fixes @miotabbott because they were not working on my machine, and multiple duplicated subscribes where happening. I changed the queue logic, so only  PUBLISH packets are stored in the `outgoingStore`.

@miotabbott can you please review this? Also everybody else :).
