### PR TITLE
Default to using port 443 for wss connections. Fixes #477

### DIFF
--- a/lib/connect/ws.js
+++ b/lib/connect/ws.js
@@ -16,9 +16,17 @@ function buildBuilder (client, opts) {
     protocol: 'mqtt'
   }
   var host = opts.hostname || 'localhost'
-  var port = String(opts.port || 80)
   var path = opts.path || '/'
-  var url = opts.protocol + '://' + host + ':' + port + path
+
+  if (!opts.port) {
+    if (opts.protocol === 'wss') {
+      opts.port = 443
+    } else {
+      opts.port = 80
+    }
+  }
+
+  var url = opts.protocol + '://' + host + ':' + opts.port + path
 
   if ((opts.protocolId === 'MQIsdp') && (opts.protocolVersion === 3)) {
     wsOpt.protocol = 'mqttv3.1'


### PR DESCRIPTION
As discussed.

Note: The test framework isn't set up to test this, e.g. by mocking websocket-stream, so I've omitted tests for this minor fix, as extending the test framework is a bit out of scope.
