### PR TITLE
add clientId and aliases as 'string' types

### DIFF
--- a/bin/pub.js
+++ b/bin/pub.js
@@ -51,7 +51,7 @@ function multisend (args) {
 
 function start (args) {
   args = minimist(args, {
-    string: ['hostname', 'username', 'password', 'key', 'cert', 'ca', 'message'],
+    string: ['hostname', 'username', 'password', 'key', 'cert', 'ca', 'message', 'clientId', 'i', 'id'],
     integer: ['port', 'qos'],
     boolean: ['stdin', 'retain', 'help', 'insecure', 'multiline'],
     alias: {

--- a/bin/sub.js
+++ b/bin/sub.js
@@ -10,7 +10,7 @@ var minimist = require('minimist')
 
 function start (args) {
   args = minimist(args, {
-    string: ['hostname', 'username', 'password', 'key', 'cert', 'ca'],
+    string: ['hostname', 'username', 'password', 'key', 'cert', 'ca', 'clientId', 'i', 'id'],
     integer: ['port', 'qos', 'keepAlive'],
     boolean: ['stdin', 'help', 'clean', 'insecure'],
     alias: {


### PR DESCRIPTION
If the clientId is a number (OpenSensors.io does this), the minimist library will interpret it as a number, causing an error when the code goes to use it.

I've added clientId and its aliases to the 'string' types so things will continue to work.

Note that minimist explicitly requires you to spell out all the strings, it won't figure it out from the alias this. I've contact them but it appears the project maybe orphaned or at least not on the front burner. 

Also not that minimist doesn't take an 'integer' parameter so that could possible be removed from the dictionary passed to minimist. However, I did not make this change and its presence is harmless.