### PR TITLE
Update documentation for subscribe function

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Subscribe to a topic or topics
 * `topic` is a `String` topic to subscribe to or an `Array` of
   topics to subscribe to. It can also be an object, it has as object
   keys the topic name and as value the QoS, like `{'test1': 0, 'test2': 1}`. 
-  Mqtt `topic` wildcard characters are supported (`+` - for single level and `#` - for multi level)
+  MQTT `topic` wildcard characters are supported (`+` - for single level and `#` - for multi level)
 * `options` is the options to subscribe with, including:
   * `qos` qos subscription level, default 0
 * `callback` - `function (err, granted)`

--- a/README.md
+++ b/README.md
@@ -315,7 +315,8 @@ Subscribe to a topic or topics
 
 * `topic` is a `String` topic to subscribe to or an `Array` of
   topics to subscribe to. It can also be an object, it has as object
-  keys the topic name and as value the QoS, like `{'test1': 0, 'test2': 1}`.
+  keys the topic name and as value the QoS, like `{'test1': 0, 'test2': 1}`. 
+  Mqtt `topic` wildcard characters are supported (`+` - for single level and `#` - for multi level)
 * `options` is the options to subscribe with, including:
   * `qos` qos subscription level, default 0
 * `callback` - `function (err, granted)`


### PR DESCRIPTION
I wanted quickly check in documentation if this library support wildcard characters in subscribe function, unfortunately, I found this information in one of the issues (#432). 

This PR only clarify that library has support for MQTT wildcards.