### PR TITLE
Use cross platform alternatives for browser-build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "mocha --bail",
     "pretest": "standard",
     "prepublish": "npm run browser-build",
-    "browser-build": "rm -rf dist/; mkdir dist/; browserify mqtt.js -s mqtt > dist/mqtt.js; uglifyjs --screw-ie8 < dist/mqtt.js > dist/mqtt.min.js",
+    "browser-build": "rimraf dist/ && mkdirp dist/ && browserify mqtt.js -s mqtt > dist/mqtt.js && uglifyjs --screw-ie8 < dist/mqtt.js > dist/mqtt.min.js",
     "browser-test": "zuul --server test/browser/server.js --local --open test/browser/test.js",
     "sauce-test": "zuul --server test/browser/server.js --tunnel ngrok -- test/browser/test.js"
   },
@@ -71,8 +71,10 @@
   "devDependencies": {
     "browserify": "^13.1.1",
     "mocha": "*",
+    "mkdirp": "^0.5.1",
     "mqtt-connection": "^3.0.0",
     "pre-commit": "^1.1.3",
+    "rimraf": "^2.5.4",
     "should": "*",
     "sinon": "~1.17.0",
     "standard": "^8.0.0",


### PR DESCRIPTION
Makes the `browser-build` NPM script ditch any platform-specific code by using cross-platform Node-based utilities.

Fixes #499