### PR TITLE
Use secure protocol when requested. 

### DIFF
--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -105,8 +105,13 @@ function connect (brokerUrl, opts) {
   }
 
   if (!protocols[opts.protocol]) {
-    opts.protocol = protocolList.filter(function (key) {
-      return typeof protocols[key] === 'function'
+    const isSecure = (['mqtts', 'wss'].indexOf(opts.protocol) !== -1)
+    opts.protocol = protocolList.filter(function (key, index) {
+      if (isSecure && index % 2 === 0) {
+        // Skip insecure protocols when requesting a secure one.
+        return false
+      }
+      return (typeof protocols[key] === 'function')
     })[0]
   }
 

--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -105,7 +105,7 @@ function connect (brokerUrl, opts) {
   }
 
   if (!protocols[opts.protocol]) {
-    const isSecure = (['mqtts', 'wss'].indexOf(opts.protocol) !== -1)
+    const isSecure = ['mqtts', 'wss'].indexOf(opts.protocol) !== -1
     opts.protocol = protocolList.filter(function (key, index) {
       if (isSecure && index % 2 === 0) {
         // Skip insecure protocols when requesting a secure one.

--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -4,7 +4,6 @@ var MqttClient = require('../client')
 var url = require('url')
 var xtend = require('xtend')
 var protocols = {}
-var protocolList = []
 
 if (process.title !== 'browser') {
   protocols.mqtt = require('./tcp')
@@ -16,13 +15,6 @@ if (process.title !== 'browser') {
 
 protocols.ws = require('./ws')
 protocols.wss = require('./ws')
-
-protocolList = [
-  'mqtt',
-  'mqtts',
-  'ws',
-  'wss'
-]
 
 /**
  * Parse the auth attribute and merge username and password in the options object.
@@ -106,7 +98,12 @@ function connect (brokerUrl, opts) {
 
   if (!protocols[opts.protocol]) {
     const isSecure = ['mqtts', 'wss'].indexOf(opts.protocol) !== -1
-    opts.protocol = protocolList.filter(function (key, index) {
+    opts.protocol = [
+      'mqtt',
+      'mqtts',
+      'ws',
+      'wss'
+    ].filter(function (key, index) {
       if (isSecure && index % 2 === 0) {
         // Skip insecure protocols when requesting a secure one.
         return false


### PR DESCRIPTION
Current issue: #392 

When requesting the `mqtts` protocol in the browser `ws` is used instead of `wss`. I attempted to solve the issue with desired feedback in issue #392. 

Solution: Check if requesting a secure protocol then skip any insecure protocols in the filter. I chose this because it still relied on the filter. The `isSecure` constant is very clear. The only thing funny is the mod I used to determine if the key was secure. I'm open to suggestions but this passes all the tests and works with my code. I took a look at creating a test case, but I don't think I'm familiar enough with your setup to do that.

Alternative solutions:
- reversing protocolList
- if statement like proposed in issue