### PR TITLE
Trying to fix saucelabs integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ env:
   - secure: ODwb1nuf12e0Ja/HgPwZh4aU01G8tTYZliSHI7ZWmYzGv3Yde6UnATeFG8sxGnWPRXTmaZelZfzhq7Aco1fEUnPm31af3z/iaV60iNmz6E1ifTR+oX7jxIvCDtHwBrgevrmIH8vrEUm/kQqDnFNrGG8Cc2xw/LjsNUG1wuWD+I4=
   - secure: buYrn01nPzsiduIQ5oqYTlBdDtM9WKP6gqoyq7IsutHb9sfwh9I6pUYsLibUo4Fq2um9QeXRZ4h1JLKK9xzDVSBpIGGaVzI4ClenfNt9O20IBGBnXcmEKPiRNYF4DkrqZzgx/OVWa6xzcRQI2R1ASQfoyfdpPAnqWXbfalSNkzs=
   - secure: IJRxzV03o76uiL4tCw/Zk0Es6tS/ATlQNIpQxZOyRLBoGTmZfZRKRxiESCKUASHudJgNIlw0kar2/LSJjMlYC4KnlrMJOLCYakXW+CWySe4q/f+qbrcdSK1+DZpjyr6Rmo654td/DD5KjNF3UgwBbi1GkE5fd4UL9HI5mPqDpqw=
+  - secure: gnlLiZUlj1nAes1VyJCyxGsauoEPXJIA/eDIFqTkDolU4gdaJcLvzHBa7qD+GW48OnWI5fdQTCr4ooOyKK3xoJvoLvoHGh7A/8SNcsFcs7Cf15tgJ1+tY749oumikwbfONMSfmkKoEwMj9rpYJ7rZsihbDyg1JAB18wkd2EwSOY=
 script:
-  - ci/travis-test.sh
+- ci/travis-test.sh


### PR DESCRIPTION
Following #539, the build is now broken. I've disabled the saucelabs runner in master to cut a release, but we shoud fix it.

@sublimator I've added you as a collaborator, push to this branch to run the hooks until it's green.

I'd like to have a "matrix" run, where we can run for each of the node versions, and just once for the browsers.

Ideally, we can mark that as "flaky", so that if it fails it's not a big issue.

If you need the credentials for saucelabs/ngrok, ping me via email and I'll send them to you.