### PR TITLE
[WIP] Add TypeScript 2.1 typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ npm-debug.log
 dist/
 yarn.lock
 coverage
+.idea/

--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -60,16 +60,47 @@ function parseBrokerUrl (brokerUrl) {
       // protocol
       // clientId
     {
-      // hostname: parsed.hostname,
       // NOTE: we use JUST the host, not parsed.host which includes the port
       host: parsed.hostname,
-      path: parsed.path || '/'
+      path: parsed.path || '/',
+      // TODO: remove
+      hostname: parsed.hostname
     })
 }
 
 function warnHostNameDeprecation () {
+  // The test uses hostname twice, once in `connect` when checking passed in
+  // opts and once in the acutall test to check the value is correct.
   console.warn('Use of mqtt.Client ' +
-    '`opts.hostname` is deprecated. Use `opts.host`')
+    '`opts.hostname` is deprecated. Use `opts.host`.\n' +
+    // Note we clone options in connect/ssl and delete 'hostname'
+    // so hostname isn't used.
+    patchHostName.usages +
+    ' usages detected.')
+}
+
+patchHostName.usages = 0
+function patchHostName (opts) {
+  if (!patchHostName.setHandler) {
+    process.once('exit', warnHostNameDeprecation)
+    patchHostName.setHandler = true
+  }
+
+  if (opts.hostname) {
+    var _hostname = opts.hostname
+    delete opts['hostname']
+    Object.defineProperty(opts, 'hostname', {
+      get: function () {
+        patchHostName.usages++
+        return _hostname
+      },
+      set: function (value) {
+        _hostname = value
+      },
+      configurable: true,
+      enumerable: true
+    })
+  }
 }
 
 /**
@@ -88,10 +119,9 @@ function connect (brokerUrl, opts) {
 
   if (opts.hostname) {
     opts.host = opts.hostname
-    delete opts['hostname']
+    patchHostName.usages++
+    // For testing
     warnHostNameDeprecation()
-    // So we can see it amongst jibberish
-    process.once('exit', warnHostNameDeprecation)
   }
 
   if (brokerUrl) {
@@ -101,6 +131,8 @@ function connect (brokerUrl, opts) {
       throw new Error('Missing protocol')
     }
   }
+
+  patchHostName(opts)
 
   // Someone out in the wild might be using {auth: 'user:pass'} out in the wild
   // Keep old behaviour? Tests actually pass without this.

--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -21,17 +21,49 @@ protocols.wss = require('./ws')
  *
  * @param {Object} [opts] option object
  */
-function parseAuthOptions (opts) {
+function parseAuthOptions (auth, opts) {
   var matches
-  if (opts.auth) {
-    matches = opts.auth.match(/^(.+):(.+)$/)
+  if (auth) {
+    matches = auth.match(/^(.+):(.+)$/)
     if (matches) {
       opts.username = matches[1]
       opts.password = matches[2]
     } else {
-      opts.username = opts.auth
+      opts.username = auth
     }
   }
+}
+
+function parseBrokerUrl (brokerUrl) {
+  var opts = {}
+  var parsed = url.parse(brokerUrl, true)
+  if (parsed.port != null) {
+    opts.port = Number(parsed.port)
+  }
+  if (parsed.protocol) {
+    opts.protocol = parsed.protocol.replace(/:$/, '')
+  }
+
+  // Parse username/password
+  parseAuthOptions(parsed.auth, opts)
+
+  // Support clientId passed in the query string of the url
+  if (parsed.query && typeof parsed.query.clientId === 'string') {
+    opts.clientId = parsed.query.clientId
+  }
+
+  return xtend(
+    opts,
+      // username
+      // password
+      // port
+      // protocol
+      // clientId
+    {
+      hostname: parsed.hostname,
+      host: parsed.host,
+      path: parsed.path || '/'
+    })
 }
 
 /**
@@ -49,26 +81,16 @@ function connect (brokerUrl, opts) {
   opts = opts || {}
 
   if (brokerUrl) {
-    var parsed = url.parse(brokerUrl, true)
-    if (parsed.port != null) {
-      parsed.port = Number(parsed.port)
-    }
-
-    opts = xtend(parsed, opts)
-
-    if (opts.protocol === null) {
+    // Options object always override brokerUrl specified options
+    opts = xtend(parseBrokerUrl(brokerUrl), opts)
+    if (!opts.protocol) {
       throw new Error('Missing protocol')
     }
-    opts.protocol = opts.protocol.replace(/:$/, '')
   }
 
-  // merge in the auth options if supplied
-  parseAuthOptions(opts)
-
-  // support clientId passed in the query string of the url
-  if (opts.query && typeof opts.query.clientId === 'string') {
-    opts.clientId = opts.query.clientId
-  }
+  // Someone out in the wild might be using {auth: 'user:pass'} out in the wild
+  // Keep old behaviour? Tests actually pass without this.
+  parseAuthOptions(opts.auth, opts)
 
   if (opts.cert && opts.key) {
     if (opts.protocol) {

--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -36,7 +36,7 @@ function parseAuthOptions (auth, opts) {
 
 function parseBrokerUrl (brokerUrl) {
   var opts = {}
-  var parsed = url.parse(brokerUrl, true)
+  var parsed = url.parse(brokerUrl, /* parseQueryString = */ true)
   if (parsed.port != null) {
     opts.port = Number(parsed.port)
   }
@@ -60,10 +60,16 @@ function parseBrokerUrl (brokerUrl) {
       // protocol
       // clientId
     {
-      hostname: parsed.hostname,
-      host: parsed.host,
+      // hostname: parsed.hostname,
+      // NOTE: we use JUST the host, not parsed.host which includes the port
+      host: parsed.hostname,
       path: parsed.path || '/'
     })
+}
+
+function warnHostNameDeprecation () {
+  console.warn('Use of mqtt.Client ' +
+    '`opts.hostname` is deprecated. Use `opts.host`')
 }
 
 /**
@@ -79,6 +85,14 @@ function connect (brokerUrl, opts) {
   }
 
   opts = opts || {}
+
+  if (opts.hostname) {
+    opts.host = opts.hostname
+    delete opts['hostname']
+    warnHostNameDeprecation()
+    // So we can see it amongst jibberish
+    process.once('exit', warnHostNameDeprecation)
+  }
 
   if (brokerUrl) {
     // Options object always override brokerUrl specified options
@@ -152,7 +166,6 @@ function connect (brokerUrl, opts) {
 
       opts.host = opts.servers[client._reconnectCount].host
       opts.port = opts.servers[client._reconnectCount].port
-      opts.hostname = opts.host
 
       client._reconnectCount++
     }

--- a/lib/connect/tcp.js
+++ b/lib/connect/tcp.js
@@ -8,10 +8,10 @@ var net = require('net')
 function buildBuilder (client, opts) {
   var port, host
   opts.port = opts.port || 1883
-  opts.hostname = opts.hostname || opts.host || 'localhost'
+  opts.host = opts.host || 'localhost'
 
   port = opts.port
-  host = opts.hostname
+  host = opts.host
 
   return net.createConnection(port, host)
 }

--- a/lib/connect/tls.js
+++ b/lib/connect/tls.js
@@ -4,7 +4,7 @@ var tls = require('tls')
 function buildBuilder (mqttClient, opts) {
   var connection
   opts.port = opts.port || 8883
-  opts.host = opts.hostname || opts.host || 'localhost'
+  opts.host = opts.host || 'localhost'
 
   opts.rejectUnauthorized = opts.rejectUnauthorized !== false
 

--- a/lib/connect/tls.js
+++ b/lib/connect/tls.js
@@ -1,7 +1,14 @@
 'use strict'
 var tls = require('tls')
 
-function buildBuilder (mqttClient, opts) {
+function buildBuilder (mqttClient, opts_) {
+  var opts = Object.keys(opts_).reduce(function (acc, k) {
+    if (k !== 'hostname') {
+      acc[k] = opts_[k]
+    }
+    return acc
+  }, {})
+
   var connection
   opts.port = opts.port || 8883
   opts.host = opts.host || 'localhost'

--- a/lib/connect/ws.js
+++ b/lib/connect/ws.js
@@ -13,7 +13,7 @@ var WSS_OPTIONS = [
 var IS_BROWSER = process.title === 'browser'
 
 function buildUrl (opts, client) {
-  var url = opts.protocol + '://' + opts.hostname + ':' + opts.port + opts.path
+  var url = opts.protocol + '://' + opts.host + ':' + opts.port + opts.path
   if (typeof (opts.transformWsUrl) === 'function') {
     url = opts.transformWsUrl(url, opts, client)
   }
@@ -21,8 +21,8 @@ function buildUrl (opts, client) {
 }
 
 function setDefaultOpts (opts) {
-  if (!opts.hostname) {
-    opts.hostname = 'localhost'
+  if (!opts.host) {
+    opts.host = 'localhost'
   }
   if (!opts.port) {
     if (opts.protocol === 'wss') {
@@ -64,22 +64,19 @@ function buildBuilder (client, opts) {
 }
 
 function buildBuilderBrowser (client, opts) {
-  if (!opts.hostname) {
-    opts.hostname = opts.host
-  }
-
-  if (!opts.hostname) {
-    // Throwing an error in a Web Worker if no `hostname` is given, because we
-    // can not determine the `hostname` automatically.  If connecting to
-    // localhost, please supply the `hostname` as an argument.
+  if (!opts.host) {
+    // Throwing an error in a Web Worker if no `host` is given, because we
+    // can not determine the `host` automatically.  If connecting to
+    // localhost, please supply the `host` as an argument.
     if (typeof (document) === 'undefined') {
-      throw new Error('Could not determine host. Specify host manually.')
+      throw new Error('Could not determine host. Specify `host` manually.')
     }
-    var parsed = urlModule.parse(document.URL)
-    opts.hostname = parsed.hostname
+    var parsed = urlModule.parse(document.URL, true)
+
+    opts.host = parsed.hostname
 
     if (!opts.port) {
-      opts.port = parsed.port
+      opts.port = Number(parsed.port)
     }
   }
   return createWebSocket(client, opts)

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
   "scripts": {
     "test": "node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --bail",
     "pretest": "standard | snazzy",
+    "tslint": "tslint types/**/*.d.ts",
     "prepublish": "nsp check && npm run browser-build",
     "browser-build": "rimraf dist/ && mkdirp dist/ && browserify mqtt.js -s mqtt > dist/mqtt.js && uglifyjs --screw-ie8 < dist/mqtt.js > dist/mqtt.min.js",
     "browser-test": "zuul --server test/browser/server.js --local --open test/browser/test.js",
     "sauce-test": "zuul --server test/browser/server.js --tunnel ngrok -- test/browser/test.js",
-    "ci": "npm run test && codecov"
+    "ci": "npm run tslint && npm run test && codecov"
   },
   "pre-commit": [
     "test"
@@ -85,6 +86,8 @@
     "snazzy": "^6.0.0",
     "standard": "^8.6.0",
     "through2": "^2.0.3",
+    "tslint": "^4.5.1",
+    "tslint-config-standard": "^4.0.0",
     "typescript": "^2.2.1",
     "uglify": "^0.1.5",
     "uglify-js": "^2.7.5",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "url": "git://github.com/mqttjs/MQTT.js.git"
   },
   "main": "mqtt.js",
+  "types" : "types/index.d.ts",
   "scripts": {
     "test": "node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --bail",
     "pretest": "standard | snazzy",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git://github.com/mqttjs/MQTT.js.git"
   },
   "main": "mqtt.js",
-  "types" : "types/index.d.ts",
+  "types": "types/index.d.ts",
   "scripts": {
     "test": "node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --bail",
     "pretest": "standard | snazzy",
@@ -85,6 +85,7 @@
     "snazzy": "^6.0.0",
     "standard": "^8.6.0",
     "through2": "^2.0.3",
+    "typescript": "^2.2.1",
     "uglify": "^0.1.5",
     "uglify-js": "^2.7.5",
     "ws": "^1.0.0",

--- a/test/mqtt.js
+++ b/test/mqtt.js
@@ -13,6 +13,25 @@ describe('mqtt', function () {
       c.should.be.instanceOf(mqtt.MqttClient)
     })
 
+    it('should warn that `hostname` is deprecated, while still honouring it', function () {
+      var oldWarn = console.warn
+      try {
+        var asserted = false
+        console.warn = function (s) {
+          asserted = true
+          s.split('\n')[0].should.be.equal(
+            'Use of mqtt.Client `opts.hostname` is deprecated. Use `opts.host`.')
+        }
+        var c = mqtt.connect('mqtt://localhost:1883', {hostname: 'test'})
+        asserted.should.be.equal(true)
+        c.should.be.instanceOf(mqtt.MqttClient)
+        c.options.hostname.should.be.equal('test')
+        c.options.host.should.be.equal('test')
+      } finally {
+        console.warn = oldWarn
+      }
+    })
+
     it('should throw an error when called with no protocol specified', function () {
       (function () {
         mqtt.connect('foo.bar.com')

--- a/test/mqtt.js
+++ b/test/mqtt.js
@@ -56,7 +56,7 @@ describe('mqtt', function () {
     it('should return an MqttClient with correct host when called with a host and port', function () {
       var c = mqtt.connect('tcp://user:pass@localhost:1883')
 
-      c.options.should.have.property('hostname', 'localhost')
+      c.options.should.have.property('host', 'localhost')
       c.options.should.have.property('port', 1883)
     })
 

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "tslint-config-standard"
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,7 @@
+export * from './lib/client';
+export * from './lib/connect';
+export * from './lib/store';
+export * from './lib/types'
+export * from './lib/client-options'
+import { MqttClient } from './lib/client'
+export { MqttClient as Client };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
-export * from './lib/client';
-export * from './lib/connect';
-export * from './lib/store';
+export * from './lib/client'
+export * from './lib/connect'
+export * from './lib/store'
 export * from './lib/types'
 export * from './lib/client-options'
 import { MqttClient } from './lib/client'
-export { MqttClient as Client };
+export { MqttClient as Client }

--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -1,119 +1,124 @@
-import { Store } from './store';
-import { QoS } from './types';
-export interface ClientOptions extends SecureClientOptions {
-    href?: string;
-    auth?: string;
-    hostname?: string;
-    port?: number;
-    host?: string;
-    pathname?: string;
-    search?: string;
-    query?: string | any;
-    slashes?: boolean;
-    hash?: string;
-    path?: string;
-    protocol?: 'wss' | 'ws' | 'mqtt' | 'mqtts' | 'tcp' | 'ssl';
-    wsOptions?: {
-        [x: string]: any;
-    };
+import { MqttClient } from './client'
+import { Store } from './store'
+import { QoS } from './types'
+
+export interface IClientOptions extends ISecureClientOptions {
+  // The options are extended by url.parse() fields in connect() function
+  href?: string
+  auth?: string
+  hostname?: string
+  port?: number // port is made into a number subsequently
+  host?: string
+  search?: string
+  query?: string | any
+  slashes?: boolean
+  hash?: string
+  path?: string
+  pathname?: string
+
+  protocol?: 'wss' | 'ws' | 'mqtt' | 'mqtts' | 'tcp' | 'ssl'
+
+  wsOptions?: {
+    [x: string]: any;
+  }
+  /**
+   *  10 seconds, set to 0 to disable
+   */
+  keepalive?: number
+  /**
+   * 'mqttjs_' + Math.random().toString(16).substr(2, 8)
+   */
+  clientId?: string
+  /**
+   * 'MQTT'
+   */
+  protocolId?: string
+  /**
+   * 4
+   */
+  protocolVersion?: number
+  /**
+   * true, set to false to receive QoS 1 and 2 messages while offline
+   */
+  clean?: boolean
+  /**
+   * 1000 milliseconds, interval between two reconnections
+   */
+  reconnectPeriod?: number
+  /**
+   * 30 * 1000 milliseconds, time to wait before a CONNACK is received
+   */
+  connectTimeout?: number
+  /**
+   * the username required by your broker, if any
+   */
+  username?: string
+  /**
+   * the password required by your broker, if any
+   */
+  password?: string
+  /**
+   * a Store for the incoming packets
+   */
+  incomingStore?: Store
+  /**
+   * a Store for the outgoing packets
+   */
+  outgoingStore?: Store
+  queueQoSZero?: boolean
+  reschedulePings?: boolean
+  servers?: Array<{
+    host: string;
+    port: number;
+  }>
+  /**
+   * a message that will sent by the broker automatically when the client disconnect badly.
+   */
+  will?: {
     /**
-     *  10 seconds, set to 0 to disable
+     * the topic to publish
      */
-    keepalive?: number;
+    topic: string;
     /**
-     * 'mqttjs_' + Math.random().toString(16).substr(2, 8)
+     * the message to publish
      */
-    clientId?: string;
-    /**
-     * 'MQTT'
-     */
-    protocolId?: string;
-    /**
-     * 4
-     */
-    protocolVersion?: number;
-    /**
-     * true, set to false to receive QoS 1 and 2 messages while offline
-     */
-    clean?: boolean;
-    /**
-     * 1000 milliseconds, interval between two reconnections
-     */
-    reconnectPeriod?: number;
-    /**
-     * 30 * 1000 milliseconds, time to wait before a CONNACK is received
-     */
-    connectTimeout?: number;
-    /**
-     * the username required by your broker, if any
-     */
-    username?: string;
-    /**
-     * the password required by your broker, if any
-     */
-    password?: string;
-    /**
-     * a Store for the incoming packets
-     */
-    incomingStore?: Store;
-    /**
-     * a Store for the outgoing packets
-     */
-    outgoingStore?: Store;
-    queueQoSZero?: boolean;
-    reschedulePings?: boolean;
-    servers?: Array<{
-        host: string;
-        port: number;
-    }>;
-    /**
-     * a message that will sent by the broker automatically when the client disconnect badly.
-     */
-    will?: {
-        /**
-         * the topic to publish
-         */
-        topic: string;
-        /**
-         * the message to publish
-         */
-        payload: string;
-        /**
-         * the QoS
-         */
-        qos: QoS;
-        /**
-         * the retain flag
-         */
-        retain: boolean;
-    };
-    transformWsUrl?: (url: string, options: ClientOptions, client: any) => string;
-}
-export interface SecureClientOptions {
-    /**
-     * path to private key
-     */
-    key?: string;
-    /**
-     * path to corresponding public cert
-     */
-    cert?: string;
-    ca?: string;
-    rejectUnauthorized?: boolean;
-}
-export interface ClientPublishOptions {
+    payload: string;
     /**
      * the QoS
      */
-    qos?: QoS;
+    qos: QoS;
     /**
      * the retain flag
      */
-    retain?: boolean;
+    retain: boolean;
+  }
+  transformWsUrl?: (url: string, options: IClientOptions, client: MqttClient) => string
 }
-export interface ClientSubscribeOptions {
-    /**
-     * the QoS
-     */
-    qos?: QoS;
+export interface ISecureClientOptions {
+  /**
+   * path to private key
+   */
+  key?: string
+  /**
+   * path to corresponding public cert
+   */
+  cert?: string
+  ca?: string
+  rejectUnauthorized?: boolean
+}
+export interface IClientPublishOptions {
+  /**
+   * the QoS
+   */
+  qos?: QoS
+  /**
+   * the retain flag
+   */
+  retain?: boolean
+}
+export interface IClientSubscribeOptions {
+  /**
+   * the QoS
+   */
+  qos?: QoS
 }

--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -4,18 +4,10 @@ import { QoS } from './types'
 
 export interface IClientOptions extends ISecureClientOptions {
   // The options are extended by url.parse() fields in connect() function
-  href?: string
-  auth?: string
   hostname?: string
   port?: number // port is made into a number subsequently
   host?: string
-  search?: string
-  query?: string | any
-  slashes?: boolean
-  hash?: string
   path?: string
-  pathname?: string
-
   protocol?: 'wss' | 'ws' | 'mqtt' | 'mqtts' | 'tcp' | 'ssl'
 
   wsOptions?: {

--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -1,0 +1,119 @@
+import { Store } from './store';
+import { QoS } from './types';
+export interface ClientOptions extends SecureClientOptions {
+    href?: string;
+    auth?: string;
+    hostname?: string;
+    port?: number;
+    host?: string;
+    pathname?: string;
+    search?: string;
+    query?: string | any;
+    slashes?: boolean;
+    hash?: string;
+    path?: string;
+    protocol?: 'wss' | 'ws' | 'mqtt' | 'mqtts' | 'tcp' | 'ssl';
+    wsOptions?: {
+        [x: string]: any;
+    };
+    /**
+     *  10 seconds, set to 0 to disable
+     */
+    keepalive?: number;
+    /**
+     * 'mqttjs_' + Math.random().toString(16).substr(2, 8)
+     */
+    clientId?: string;
+    /**
+     * 'MQTT'
+     */
+    protocolId?: string;
+    /**
+     * 4
+     */
+    protocolVersion?: number;
+    /**
+     * true, set to false to receive QoS 1 and 2 messages while offline
+     */
+    clean?: boolean;
+    /**
+     * 1000 milliseconds, interval between two reconnections
+     */
+    reconnectPeriod?: number;
+    /**
+     * 30 * 1000 milliseconds, time to wait before a CONNACK is received
+     */
+    connectTimeout?: number;
+    /**
+     * the username required by your broker, if any
+     */
+    username?: string;
+    /**
+     * the password required by your broker, if any
+     */
+    password?: string;
+    /**
+     * a Store for the incoming packets
+     */
+    incomingStore?: Store;
+    /**
+     * a Store for the outgoing packets
+     */
+    outgoingStore?: Store;
+    queueQoSZero?: boolean;
+    reschedulePings?: boolean;
+    servers?: Array<{
+        host: string;
+        port: number;
+    }>;
+    /**
+     * a message that will sent by the broker automatically when the client disconnect badly.
+     */
+    will?: {
+        /**
+         * the topic to publish
+         */
+        topic: string;
+        /**
+         * the message to publish
+         */
+        payload: string;
+        /**
+         * the QoS
+         */
+        qos: QoS;
+        /**
+         * the retain flag
+         */
+        retain: boolean;
+    };
+    transformWsUrl?: (url: string, options: ClientOptions, client: any) => string;
+}
+export interface SecureClientOptions {
+    /**
+     * path to private key
+     */
+    key?: string;
+    /**
+     * path to corresponding public cert
+     */
+    cert?: string;
+    ca?: string;
+    rejectUnauthorized?: boolean;
+}
+export interface ClientPublishOptions {
+    /**
+     * the QoS
+     */
+    qos?: QoS;
+    /**
+     * the retain flag
+     */
+    retain?: boolean;
+}
+export interface ClientSubscribeOptions {
+    /**
+     * the QoS
+     */
+    qos?: QoS;
+}

--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -4,9 +4,8 @@ import { QoS } from './types'
 
 export interface IClientOptions extends ISecureClientOptions {
   // The options are extended by url.parse() fields in connect() function
-  hostname?: string
   port?: number // port is made into a number subsequently
-  host?: string
+  host?: string // host does NOT include port
   path?: string
   protocol?: 'wss' | 'ws' | 'mqtt' | 'mqtts' | 'tcp' | 'ssl'
 

--- a/types/lib/client.d.ts
+++ b/types/lib/client.d.ts
@@ -1,0 +1,254 @@
+/// <reference types="node" />
+/**
+ * Module dependencies
+ */
+import * as events from 'events';
+import { Store } from './store';
+import { Packet, QoS } from './types';
+import { ClientOptions, ClientPublishOptions, ClientSubscribeOptions } from './client-options';
+export interface SubscriptionGrant {
+    /**
+     *  is a subscribed to topic
+     */
+    topic: string;
+    /**
+     *  is the granted qos level on it
+     */
+    qos: QoS | number;
+}
+export interface SubscriptionRequest {
+    /**
+     *  is a subscribed to topic
+     */
+    topic: string;
+    /**
+     *  is the granted qos level on it
+     */
+    qos: QoS;
+}
+export interface SubscriptionMap {
+    /**
+     * object which has topic names as object keys and as value the QoS, like {'test1': 0, 'test2': 1}.
+     */
+    [topic: string]: QoS;
+}
+export declare type ClientSubscribeCallback = (err: Error, granted: SubscriptionGrant[]) => void;
+export declare type OnMessageCallback = (topic: string, payload: Buffer, packet: Packet) => void;
+export declare type OnPacketCallback = (packet: Packet) => void;
+export declare type OnErrorCallback = (error: Error) => void;
+export declare type PacketCallback = (error?: Error, packet?: Packet) => any;
+export interface IReinterval {
+    clear: () => void;
+    reschedule(ms: number): any;
+}
+export interface IStream extends events.EventEmitter {
+    pipe(to: any): any;
+    destroy(): any;
+    end(): any;
+}
+/**
+ * MqttClient constructor
+ *
+ * @param {Stream} stream - stream
+ * @param {Object} [options] - connection options
+ * (see Connection#connect)
+ */
+export declare class MqttClient extends events.EventEmitter {
+    connackTimer: NodeJS.Timer;
+    reconnectTimer: NodeJS.Timer;
+    pingTimer: IReinterval;
+    connected: boolean;
+    disconnecting: boolean;
+    disconnected: boolean;
+    reconnecting: boolean;
+    pingResp: boolean;
+    nextId: number;
+    queue: Array<{
+        packet: Packet;
+        cb: PacketCallback;
+    }>;
+    _subscribedTopics: any;
+    outgoing: {
+        [x: number]: PacketCallback;
+    };
+    incomingStore: Store;
+    outgoingStore: Store;
+    stream: IStream;
+    streamBuilder: (MqttClient) => IStream;
+    options: ClientOptions;
+    queueQoSZero: boolean;
+    on(event: 'message', cb: OnMessageCallback): this;
+    on(event: 'packetsend' | 'packetreceive', cb: OnPacketCallback): this;
+    on(event: 'error', cb: OnErrorCallback): this;
+    on(event: string, cb: Function): this;
+    once(event: 'message', cb: OnMessageCallback): this;
+    once(event: 'packetsend' | 'packetreceive', cb: OnPacketCallback): this;
+    once(event: 'error', cb: OnErrorCallback): this;
+    once(event: string, cb: Function): this;
+    constructor(streamBuilder: any, options: any);
+    /**
+     * setup the event handlers in the inner stream.
+     *
+     * @api private
+     */
+    _setupStream(): void;
+    _handlePacket(packet: Packet, done: PacketCallback): void;
+    _checkDisconnecting(callback: PacketCallback): boolean;
+    /**
+     * publish - publish <message> to <topic>
+     *
+     * @param {String} topic - topic to publish to
+     * @param {(String|Buffer)} message - message to publish
+     *
+     * @param {Object}    [opts] - publish options, includes:
+     *   @param {Number}  [opts.qos] - qos level to publish on
+     *   @param {Boolean} [opts.retain] - whether or not to retain the message
+     *
+     * @param {Function} [callback] - function(err){}
+     *    called when publish succeeds or fails
+     * @returns {Client} this - for chaining
+     * @api public
+     *
+     * @example client.publish('topic', 'message');
+     * @example
+     *     client.publish('topic', 'message', {qos: 1, retain: true});
+     * @example client.publish('topic', 'message', console.log);
+     */
+    publish(topic: string, message: string | Buffer, opts: ClientPublishOptions, callback?: PacketCallback): this;
+    publish(topic: string, message: string | Buffer, callback?: PacketCallback): this;
+    /**
+     * subscribe - subscribe to <topic>
+     *
+     * @param {String, Array, Object} topic - topic(s) to subscribe to, supports objects in the form {'topic': qos}
+     * @param {Object} [opts] - optional subscription options, includes:
+     * @param  {Number} [opts.qos] - subscribe qos level
+     * @param {Function} [callback] - function(err, granted){} where:
+     *    {Error} err - subscription error (none at the moment!)
+     *    {Array} granted - array of {topic: 't', qos: 0}
+     * @returns {MqttClient} this - for chaining
+     * @api public
+     * @example client.subscribe('topic');
+     * @example client.subscribe('topic', {qos: 1});
+     * @example client.subscribe({'topic': 0, 'topic2': 1}, console.log);
+     * @example client.subscribe('topic', console.log);
+     */
+    subscribe(topic: string | string[], opts: ClientSubscribeOptions, callback?: ClientSubscribeCallback): this;
+    subscribe(topic: string | string[] | SubscriptionMap, callback?: ClientSubscribeCallback): this;
+    /**
+     * unsubscribe - unsubscribe from topic(s)
+     *
+     * @param {String, Array} topic - topics to unsubscribe from
+     * @param {Function} [callback] - callback fired on unsuback
+     * @returns {MqttClient} this - for chaining
+     * @api public
+     * @example client.unsubscribe('topic');
+     * @example client.unsubscribe('topic', console.log);
+     */
+    unsubscribe(topic: string | string[], callback: PacketCallback): this;
+    /**
+     * end - close connection
+     *
+     * @returns {MqttClient} this - for chaining
+     * @param {Boolean} force - do not wait for all in-flight messages to be acked
+     * @param {Function} cb - called when the client has been closed
+     *
+     * @api public
+     */
+    end(force?: boolean, cb?: boolean): this;
+    /**
+     * _reconnect - implement reconnection
+     * @api privateish
+     */
+    private _reconnect();
+    /**
+     * _setupReconnect - setup reconnect timer
+     */
+    private _setupReconnect();
+    /**
+     * _clearReconnect - clear the reconnect timer
+     */
+    private _clearReconnect();
+    /**
+     * _cleanUp - clean up on connection end
+     * @api private
+     */
+    private _cleanUp(forced, done?);
+    /**
+     * _sendPacket - send or queue a packet
+     * @param {Object} packet - packet options
+     * @param {Function} cb - callback when the packet is sent
+     * @api private
+     */
+    private _sendPacket(packet, cb?);
+    /**
+     * _setupPingTimer - setup the ping timer
+     *
+     * @api private
+     */
+    private _setupPingTimer();
+    /**
+     * _shiftPingInterval - reschedule the ping interval
+     *
+     * @api private
+     */
+    private _shiftPingInterval();
+    /**
+     * _checkPing - check if a pingresp has come back, and ping the server again
+     *
+     * @api private
+     */
+    private _checkPing();
+    /**
+     * _handlePingresp - handle a pingresp
+     *
+     * @api private
+     */
+    private _handlePingresp(packet);
+    /**
+     * _handleConnack
+     *
+     * @param {Object} packet
+     * @api private
+     */
+    private _handleConnack(packet);
+    /**
+     * _handlePublish
+     *
+     * @param {Object} packet
+     * @api private
+     */
+    private _handlePublish(packet, done);
+    /**
+     * Handle messages with backpressure support, one at a time.
+     * Override at will.
+     *
+     * @param packet packet the packet
+     * @param callback callback call when finished
+     * @api public
+     */
+    handleMessage(packet: Packet, callback: PacketCallback): void;
+    /**
+     * _handleAck
+     *
+     * @param {Object} packet
+     * @api private
+     */
+    private _handleAck(packet);
+    /**
+     * _handlePubrel
+     *
+     * @param {Object} packet
+     * @param callback
+     * @api private
+     */
+    private _handlePubrel(packet, callback);
+    /**
+     * _nextId
+     */
+    private _nextId();
+    /**
+     * getLastMessageId
+     */
+    getLastMessageId(): number;
+}
+export { ClientOptions };

--- a/types/lib/client.d.ts
+++ b/types/lib/client.d.ts
@@ -2,49 +2,55 @@
 /**
  * Module dependencies
  */
-import * as events from 'events';
-import { Store } from './store';
-import { Packet, QoS } from './types';
-import { ClientOptions, ClientPublishOptions, ClientSubscribeOptions } from './client-options';
-export interface SubscriptionGrant {
-    /**
-     *  is a subscribed to topic
-     */
-    topic: string;
-    /**
-     *  is the granted qos level on it
-     */
-    qos: QoS | number;
+import * as events from 'events'
+import {
+  IClientOptions,
+  IClientPublishOptions,
+  IClientSubscribeOptions
+} from './client-options'
+import { Store } from './store'
+import { Packet, QoS } from './types'
+export interface ISubscriptionGrant {
+  /**
+   *  is a subscribed to topic
+   */
+  topic: string
+  /**
+   *  is the granted qos level on it, may return 128 on error
+   */
+  qos: QoS | number
 }
-export interface SubscriptionRequest {
-    /**
-     *  is a subscribed to topic
-     */
-    topic: string;
-    /**
-     *  is the granted qos level on it
-     */
-    qos: QoS;
+export interface ISubscriptionRequest {
+  /**
+   *  is a subscribed to topic
+   */
+  topic: string
+  /**
+   *  is the granted qos level on it
+   */
+  qos: QoS
 }
-export interface SubscriptionMap {
-    /**
-     * object which has topic names as object keys and as value the QoS, like {'test1': 0, 'test2': 1}.
-     */
-    [topic: string]: QoS;
+export interface ISubscriptionMap {
+  /**
+   * object which has topic names as object keys and as value the QoS, like {'test1': 0, 'test2': 1}.
+   */
+  [topic: string]: QoS
 }
-export declare type ClientSubscribeCallback = (err: Error, granted: SubscriptionGrant[]) => void;
-export declare type OnMessageCallback = (topic: string, payload: Buffer, packet: Packet) => void;
-export declare type OnPacketCallback = (packet: Packet) => void;
-export declare type OnErrorCallback = (error: Error) => void;
-export declare type PacketCallback = (error?: Error, packet?: Packet) => any;
-export interface IReinterval {
-    clear: () => void;
-    reschedule(ms: number): any;
-}
+
+export declare type ClientSubscribeCallback = (err: Error, granted: ISubscriptionGrant[]) => void
+export declare type OnMessageCallback = (topic: string, payload: Buffer, packet: Packet) => void
+export declare type OnPacketCallback = (packet: Packet) => void
+export declare type OnErrorCallback = (error: Error) => void
+export declare type PacketCallback = (error?: Error, packet?: Packet) => any
+
+// export interface IReinterval {
+//   clear: () => void
+//   reschedule (ms: number): any
+// }
 export interface IStream extends events.EventEmitter {
-    pipe(to: any): any;
-    destroy(): any;
-    end(): any;
+  pipe (to: any): any
+  destroy (): any
+  end (): any
 }
 /**
  * MqttClient constructor
@@ -54,201 +60,131 @@ export interface IStream extends events.EventEmitter {
  * (see Connection#connect)
  */
 export declare class MqttClient extends events.EventEmitter {
-    connackTimer: NodeJS.Timer;
-    reconnectTimer: NodeJS.Timer;
-    pingTimer: IReinterval;
-    connected: boolean;
-    disconnecting: boolean;
-    disconnected: boolean;
-    reconnecting: boolean;
-    pingResp: boolean;
-    nextId: number;
-    queue: Array<{
-        packet: Packet;
-        cb: PacketCallback;
-    }>;
-    _subscribedTopics: any;
-    outgoing: {
-        [x: number]: PacketCallback;
-    };
-    incomingStore: Store;
-    outgoingStore: Store;
-    stream: IStream;
-    streamBuilder: (MqttClient) => IStream;
-    options: ClientOptions;
-    queueQoSZero: boolean;
-    on(event: 'message', cb: OnMessageCallback): this;
-    on(event: 'packetsend' | 'packetreceive', cb: OnPacketCallback): this;
-    on(event: 'error', cb: OnErrorCallback): this;
-    on(event: string, cb: Function): this;
-    once(event: 'message', cb: OnMessageCallback): this;
-    once(event: 'packetsend' | 'packetreceive', cb: OnPacketCallback): this;
-    once(event: 'error', cb: OnErrorCallback): this;
-    once(event: string, cb: Function): this;
-    constructor(streamBuilder: any, options: any);
-    /**
-     * setup the event handlers in the inner stream.
-     *
-     * @api private
-     */
-    _setupStream(): void;
-    _handlePacket(packet: Packet, done: PacketCallback): void;
-    _checkDisconnecting(callback: PacketCallback): boolean;
-    /**
-     * publish - publish <message> to <topic>
-     *
-     * @param {String} topic - topic to publish to
-     * @param {(String|Buffer)} message - message to publish
-     *
-     * @param {Object}    [opts] - publish options, includes:
-     *   @param {Number}  [opts.qos] - qos level to publish on
-     *   @param {Boolean} [opts.retain] - whether or not to retain the message
-     *
-     * @param {Function} [callback] - function(err){}
-     *    called when publish succeeds or fails
-     * @returns {Client} this - for chaining
-     * @api public
-     *
-     * @example client.publish('topic', 'message');
-     * @example
-     *     client.publish('topic', 'message', {qos: 1, retain: true});
-     * @example client.publish('topic', 'message', console.log);
-     */
-    publish(topic: string, message: string | Buffer, opts: ClientPublishOptions, callback?: PacketCallback): this;
-    publish(topic: string, message: string | Buffer, callback?: PacketCallback): this;
-    /**
-     * subscribe - subscribe to <topic>
-     *
-     * @param {String, Array, Object} topic - topic(s) to subscribe to, supports objects in the form {'topic': qos}
-     * @param {Object} [opts] - optional subscription options, includes:
-     * @param  {Number} [opts.qos] - subscribe qos level
-     * @param {Function} [callback] - function(err, granted){} where:
-     *    {Error} err - subscription error (none at the moment!)
-     *    {Array} granted - array of {topic: 't', qos: 0}
-     * @returns {MqttClient} this - for chaining
-     * @api public
-     * @example client.subscribe('topic');
-     * @example client.subscribe('topic', {qos: 1});
-     * @example client.subscribe({'topic': 0, 'topic2': 1}, console.log);
-     * @example client.subscribe('topic', console.log);
-     */
-    subscribe(topic: string | string[], opts: ClientSubscribeOptions, callback?: ClientSubscribeCallback): this;
-    subscribe(topic: string | string[] | SubscriptionMap, callback?: ClientSubscribeCallback): this;
-    /**
-     * unsubscribe - unsubscribe from topic(s)
-     *
-     * @param {String, Array} topic - topics to unsubscribe from
-     * @param {Function} [callback] - callback fired on unsuback
-     * @returns {MqttClient} this - for chaining
-     * @api public
-     * @example client.unsubscribe('topic');
-     * @example client.unsubscribe('topic', console.log);
-     */
-    unsubscribe(topic: string | string[], callback: PacketCallback): this;
-    /**
-     * end - close connection
-     *
-     * @returns {MqttClient} this - for chaining
-     * @param {Boolean} force - do not wait for all in-flight messages to be acked
-     * @param {Function} cb - called when the client has been closed
-     *
-     * @api public
-     */
-    end(force?: boolean, cb?: boolean): this;
-    /**
-     * _reconnect - implement reconnection
-     * @api privateish
-     */
-    private _reconnect();
-    /**
-     * _setupReconnect - setup reconnect timer
-     */
-    private _setupReconnect();
-    /**
-     * _clearReconnect - clear the reconnect timer
-     */
-    private _clearReconnect();
-    /**
-     * _cleanUp - clean up on connection end
-     * @api private
-     */
-    private _cleanUp(forced, done?);
-    /**
-     * _sendPacket - send or queue a packet
-     * @param {Object} packet - packet options
-     * @param {Function} cb - callback when the packet is sent
-     * @api private
-     */
-    private _sendPacket(packet, cb?);
-    /**
-     * _setupPingTimer - setup the ping timer
-     *
-     * @api private
-     */
-    private _setupPingTimer();
-    /**
-     * _shiftPingInterval - reschedule the ping interval
-     *
-     * @api private
-     */
-    private _shiftPingInterval();
-    /**
-     * _checkPing - check if a pingresp has come back, and ping the server again
-     *
-     * @api private
-     */
-    private _checkPing();
-    /**
-     * _handlePingresp - handle a pingresp
-     *
-     * @api private
-     */
-    private _handlePingresp(packet);
-    /**
-     * _handleConnack
-     *
-     * @param {Object} packet
-     * @api private
-     */
-    private _handleConnack(packet);
-    /**
-     * _handlePublish
-     *
-     * @param {Object} packet
-     * @api private
-     */
-    private _handlePublish(packet, done);
-    /**
-     * Handle messages with backpressure support, one at a time.
-     * Override at will.
-     *
-     * @param packet packet the packet
-     * @param callback callback call when finished
-     * @api public
-     */
-    handleMessage(packet: Packet, callback: PacketCallback): void;
-    /**
-     * _handleAck
-     *
-     * @param {Object} packet
-     * @api private
-     */
-    private _handleAck(packet);
-    /**
-     * _handlePubrel
-     *
-     * @param {Object} packet
-     * @param callback
-     * @api private
-     */
-    private _handlePubrel(packet, callback);
-    /**
-     * _nextId
-     */
-    private _nextId();
-    /**
-     * getLastMessageId
-     */
-    getLastMessageId(): number;
+  // public connackTimer: NodeJS.Timer
+  // public reconnectTimer: NodeJS.Timer
+  // public pingTimer: IReinterval
+
+  public connected: boolean
+  public disconnecting: boolean
+  public disconnected: boolean
+  public reconnecting: boolean
+
+  // public pingResp: boolean
+  // public nextId: number
+  // public queue: Array<{
+  //     packet: Packet
+  //     cb: PacketCallback
+  // }>
+  // public outgoing: {
+  //     [x: number]: PacketCallback
+  // }
+
+  public incomingStore: Store
+  public outgoingStore: Store
+  // public stream: IStream
+  // public streamBuilder: (MqttClient) => IStream
+  public options: IClientOptions
+  public queueQoSZero: boolean
+
+  constructor (streamBuilder: (MqttClient) => IStream, options: IClientOptions)
+
+  public on (event: 'message', cb: OnMessageCallback): this
+  public on (event: 'packetsend' | 'packetreceive', cb: OnPacketCallback): this
+  public on (event: 'error', cb: OnErrorCallback): this
+  public on (event: string, cb: Function): this
+
+  public once (event: 'message', cb: OnMessageCallback): this
+  public once (event:
+                'packetsend'
+                | 'packetreceive', cb: OnPacketCallback): this
+  public once (event: 'error', cb: OnErrorCallback): this
+  public once (event: string, cb: Function): this
+
+  /**
+   * publish - publish <message> to <topic>
+   *
+   * @param {String} topic - topic to publish to
+   * @param {(String|Buffer)} message - message to publish
+   *
+   * @param {Object}    [opts] - publish options, includes:
+   *   @param {Number}  [opts.qos] - qos level to publish on
+   *   @param {Boolean} [opts.retain] - whether or not to retain the message
+   *
+   * @param {Function} [callback] - function(err){}
+   *    called when publish succeeds or fails
+   * @returns {Client} this - for chaining
+   * @api public
+   *
+   * @example client.publish('topic', 'message')
+   * @example
+   *     client.publish('topic', 'message', {qos: 1, retain: true})
+   * @example client.publish('topic', 'message', console.log)
+   */
+  public publish (topic: string, message: string | Buffer,
+                 opts: IClientPublishOptions, callback?: PacketCallback): this
+  public publish (topic: string, message: string | Buffer,
+                 callback?: PacketCallback): this
+
+  /**
+   * subscribe - subscribe to <topic>
+   *
+   * @param {String, Array, Object} topic - topic(s) to subscribe to, supports objects in the form {'topic': qos}
+   * @param {Object} [opts] - optional subscription options, includes:
+   * @param  {Number} [opts.qos] - subscribe qos level
+   * @param {Function} [callback] - function(err, granted){} where:
+   *    {Error} err - subscription error (none at the moment!)
+   *    {Array} granted - array of {topic: 't', qos: 0}
+   * @returns {MqttClient} this - for chaining
+   * @api public
+   * @example client.subscribe('topic')
+   * @example client.subscribe('topic', {qos: 1})
+   * @example client.subscribe({'topic': 0, 'topic2': 1}, console.log)
+   * @example client.subscribe('topic', console.log)
+   */
+  public subscribe (topic:
+                     string
+                     | string[], opts: IClientSubscribeOptions, callback?: ClientSubscribeCallback): this
+  public subscribe (topic:
+                     string
+                     | string[]
+                     | ISubscriptionMap, callback?: ClientSubscribeCallback): this
+
+  /**
+   * unsubscribe - unsubscribe from topic(s)
+   *
+   * @param {String, Array} topic - topics to unsubscribe from
+   * @param {Function} [callback] - callback fired on unsuback
+   * @returns {MqttClient} this - for chaining
+   * @api public
+   * @example client.unsubscribe('topic')
+   * @example client.unsubscribe('topic', console.log)
+   */
+  public unsubscribe (topic: string | string[], callback: PacketCallback): this
+
+  /**
+   * end - close connection
+   *
+   * @returns {MqttClient} this - for chaining
+   * @param {Boolean} force - do not wait for all in-flight messages to be acked
+   * @param {Function} cb - called when the client has been closed
+   *
+   * @api public
+   */
+  public end (force?: boolean, cb?: boolean): this
+
+  /**
+   * Handle messages with backpressure support, one at a time.
+   * Override at will.
+   *
+   * @param packet packet the packet
+   * @param callback callback call when finished
+   * @api public
+   */
+  public handleMessage (packet: Packet, callback: PacketCallback): void
+
+  /**
+   * getLastMessageId
+   */
+  public getLastMessageId (): number
 }
-export { ClientOptions };
+export { IClientOptions }

--- a/types/lib/connect/index.d.ts
+++ b/types/lib/connect/index.d.ts
@@ -1,0 +1,12 @@
+import { MqttClient, ClientOptions } from '../client';
+declare const protocols: any;
+/**
+ * connect - connect to an MQTT broker.
+ *
+ * @param {String} [brokerUrl] - url of the broker, optional
+ * @param {Object} opts - see MqttClient#constructor
+ */
+declare function connect(brokerUrl?: string | any, opts?: ClientOptions): MqttClient;
+export { connect };
+export { MqttClient };
+export { protocols };

--- a/types/lib/connect/index.d.ts
+++ b/types/lib/connect/index.d.ts
@@ -1,12 +1,12 @@
-import { MqttClient, ClientOptions } from '../client';
-declare const protocols: any;
+import { IClientOptions, MqttClient } from '../client'
+declare const protocols: any
 /**
  * connect - connect to an MQTT broker.
  *
  * @param {String} [brokerUrl] - url of the broker, optional
  * @param {Object} opts - see MqttClient#constructor
  */
-declare function connect(brokerUrl?: string | any, opts?: ClientOptions): MqttClient;
-export { connect };
-export { MqttClient };
-export { protocols };
+declare function connect (brokerUrl?: string | any, opts?: IClientOptions): MqttClient
+export { connect }
+export { MqttClient }
+export { protocols }

--- a/types/lib/connect/tcp.d.ts
+++ b/types/lib/connect/tcp.d.ts
@@ -1,0 +1,3 @@
+import { MqttClient, ClientOptions } from '../client';
+declare function buildBuilder(client: MqttClient, opts: ClientOptions): any;
+export { buildBuilder };

--- a/types/lib/connect/tcp.d.ts
+++ b/types/lib/connect/tcp.d.ts
@@ -1,3 +1,3 @@
-import { MqttClient, ClientOptions } from '../client';
-declare function buildBuilder(client: MqttClient, opts: ClientOptions): any;
-export { buildBuilder };
+import { IClientOptions, MqttClient } from '../client'
+declare function buildBuilder (client: MqttClient, opts: IClientOptions): any
+export { buildBuilder }

--- a/types/lib/connect/tls.d.ts
+++ b/types/lib/connect/tls.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import { MqttClient, ClientOptions } from '../client';
-import tls = require('tls');
-declare function buildBuilder(mqttClient: MqttClient, opts: ClientOptions): tls.ClearTextStream;
-export { buildBuilder };
+import { IClientOptions, MqttClient } from '../client'
+import tls = require('tls')
+declare function buildBuilder (mqttClient: MqttClient, opts: IClientOptions): tls.ClearTextStream
+export { buildBuilder }

--- a/types/lib/connect/tls.d.ts
+++ b/types/lib/connect/tls.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="node" />
+import { MqttClient, ClientOptions } from '../client';
+import tls = require('tls');
+declare function buildBuilder(mqttClient: MqttClient, opts: ClientOptions): tls.ClearTextStream;
+export { buildBuilder };

--- a/types/lib/connect/ws.d.ts
+++ b/types/lib/connect/ws.d.ts
@@ -1,5 +1,5 @@
-import { MqttClient, ClientOptions } from '../client';
-export declare function buildBuilderNormal(client: MqttClient, opts: ClientOptions): any;
-export declare function buildBuilderBrowser(client: any, opts: any): any;
-declare const buildBuilder: (typeof buildBuilderNormal);
-export { buildBuilder };
+import { IClientOptions, MqttClient } from '../client'
+export declare function buildBuilderNormal (client: MqttClient, opts: IClientOptions): any
+export declare function buildBuilderBrowser (client: MqttClient, opts: IClientOptions): any
+declare const buildBuilder: (typeof buildBuilderNormal)
+export { buildBuilder }

--- a/types/lib/connect/ws.d.ts
+++ b/types/lib/connect/ws.d.ts
@@ -1,0 +1,5 @@
+import { MqttClient, ClientOptions } from '../client';
+export declare function buildBuilderNormal(client: MqttClient, opts: ClientOptions): any;
+export declare function buildBuilderBrowser(client: any, opts: any): any;
+declare const buildBuilder: (typeof buildBuilderNormal);
+export { buildBuilder };

--- a/types/lib/store.d.ts
+++ b/types/lib/store.d.ts
@@ -1,0 +1,32 @@
+/**
+ * In-memory implementation of the message store
+ * This can actually be saved into files.
+ *
+ */
+declare class Store {
+    constructor();
+    /**
+     * Adds a packet to the store, a packet is
+     * anything that has a messageId property.
+     *
+     */
+    put(packet: any, cb?: any): this;
+    /**
+     * Creates a stream with all the packets in the store
+     *
+     */
+    createStream(): any;
+    /**
+     * deletes a packet from the store.
+     */
+    del(packet: any, cb: any): this;
+    /**
+     * get a packet from the store.
+     */
+    get(packet: any, cb: any): this;
+    /**
+     * Close the store
+     */
+    close(cb: any): void;
+}
+export { Store };

--- a/types/lib/store.d.ts
+++ b/types/lib/store.d.ts
@@ -4,29 +4,34 @@
  *
  */
 declare class Store {
-    constructor();
-    /**
-     * Adds a packet to the store, a packet is
-     * anything that has a messageId property.
-     *
-     */
-    put(packet: any, cb?: any): this;
-    /**
-     * Creates a stream with all the packets in the store
-     *
-     */
-    createStream(): any;
-    /**
-     * deletes a packet from the store.
-     */
-    del(packet: any, cb: any): this;
-    /**
-     * get a packet from the store.
-     */
-    get(packet: any, cb: any): this;
-    /**
-     * Close the store
-     */
-    close(cb: any): void;
+  constructor ()
+
+  /**
+   * Adds a packet to the store, a packet is
+   * anything that has a messageId property.
+   *
+   */
+  public put (packet: any, cb?: Function): this
+
+  /**
+   * Creates a stream with all the packets in the store
+   *
+   */
+  public createStream (): any
+
+  /**
+   * deletes a packet from the store.
+   */
+  public del (packet: any, cb: Function): this
+
+  /**
+   * get a packet from the store.
+   */
+  public get (packet: any, cb: Function): this
+
+  /**
+   * Close the store
+   */
+  public close (cb: Function): void
 }
-export { Store };
+export { Store }

--- a/types/lib/types.d.ts
+++ b/types/lib/types.d.ts
@@ -1,0 +1,77 @@
+/// <reference types="node" />
+export declare type QoS = 0 | 1 | 2;
+export declare type PacketCmd = 'connack' | 'connect' | 'disconnect' | 'pingreq' | 'pingresp' | 'puback' | 'pubcomp' | 'publish' | 'pubrel' | 'pubrec' | 'suback' | 'subscribe' | 'unsuback' | 'unsubscribe';
+export interface IPacket {
+    cmd: PacketCmd;
+    messageId?: number;
+    length?: number;
+}
+export interface ConnectPacket extends IPacket {
+    cmd: 'connect';
+    clientId: string;
+    protocolVersion?: 4 | 3;
+    protocolId?: 'MQTT' | 'MQIsdp';
+    clean?: boolean;
+    keepalive?: number;
+    username?: string;
+    password?: Buffer;
+    will?: {
+        topic: string;
+        payload: Buffer;
+        qos?: QoS;
+        retain?: boolean;
+    };
+}
+export interface PublishPacket extends IPacket {
+    cmd: 'publish';
+    qos: QoS;
+    dup: boolean;
+    retain: boolean;
+    topic: string;
+    payload: string | Buffer;
+}
+export interface ConnackPacket extends IPacket {
+    cmd: 'connack';
+    returnCode: number;
+    sessionPresent: boolean;
+}
+export interface SubscribePacket extends IPacket {
+    cmd: 'subscribe';
+    subscriptions: Array<{
+        topic: string;
+        qos: QoS;
+    }>;
+}
+export interface SubackPacket extends IPacket {
+    cmd: 'suback';
+    granted: number[];
+}
+export interface UnsubscribePacket extends IPacket {
+    cmd: 'unsubscribe';
+    unsubscriptions: string[];
+}
+export interface UnsubackPacket extends IPacket {
+    cmd: 'unsuback';
+}
+export interface PubackPacket extends IPacket {
+    cmd: 'puback';
+}
+export interface PubcompPacket extends IPacket {
+    cmd: 'pubcomp';
+}
+export interface PubrelPacket extends IPacket {
+    cmd: 'pubrel';
+}
+export interface PubrecPacket extends IPacket {
+    cmd: 'pubrec';
+}
+export interface PingreqPacket extends IPacket {
+    cmd: 'pingreq';
+}
+export interface PingrespPacket extends IPacket {
+    cmd: 'pingresp';
+}
+export interface DisconnectPacket extends IPacket {
+    cmd: 'disconnect';
+}
+export declare type Packet = ConnectPacket | PublishPacket | ConnackPacket | SubscribePacket | SubackPacket | UnsubscribePacket | UnsubackPacket | PubackPacket | PubcompPacket | PubrelPacket | PingreqPacket | PingrespPacket | DisconnectPacket | PubrecPacket;

--- a/types/lib/types.d.ts
+++ b/types/lib/types.d.ts
@@ -1,77 +1,104 @@
 /// <reference types="node" />
-export declare type QoS = 0 | 1 | 2;
-export declare type PacketCmd = 'connack' | 'connect' | 'disconnect' | 'pingreq' | 'pingresp' | 'puback' | 'pubcomp' | 'publish' | 'pubrel' | 'pubrec' | 'suback' | 'subscribe' | 'unsuback' | 'unsubscribe';
+export declare type QoS = 0 | 1 | 2
+export declare type PacketCmd = 'connack' |
+  'connect' |
+  'disconnect' |
+  'pingreq' |
+  'pingresp' |
+  'puback' |
+  'pubcomp' |
+  'publish' |
+  'pubrel' |
+  'pubrec' |
+  'suback' |
+  'subscribe' |
+  'unsuback' |
+  'unsubscribe'
 export interface IPacket {
-    cmd: PacketCmd;
-    messageId?: number;
-    length?: number;
+  cmd: PacketCmd
+  messageId?: number
+  length?: number
 }
-export interface ConnectPacket extends IPacket {
-    cmd: 'connect';
-    clientId: string;
-    protocolVersion?: 4 | 3;
-    protocolId?: 'MQTT' | 'MQIsdp';
-    clean?: boolean;
-    keepalive?: number;
-    username?: string;
-    password?: Buffer;
-    will?: {
-        topic: string;
-        payload: Buffer;
-        qos?: QoS;
-        retain?: boolean;
-    };
-}
-export interface PublishPacket extends IPacket {
-    cmd: 'publish';
-    qos: QoS;
-    dup: boolean;
-    retain: boolean;
+export interface IConnectPacket extends IPacket {
+  cmd: 'connect'
+  clientId: string
+  protocolVersion?: 4 | 3
+  protocolId?: 'MQTT' | 'MQIsdp'
+  clean?: boolean
+  keepalive?: number
+  username?: string
+  password?: Buffer
+  will?: {
     topic: string;
-    payload: string | Buffer;
+    payload: Buffer;
+    qos?: QoS;
+    retain?: boolean;
+  }
 }
-export interface ConnackPacket extends IPacket {
-    cmd: 'connack';
-    returnCode: number;
-    sessionPresent: boolean;
+export interface IPublishPacket extends IPacket {
+  cmd: 'publish'
+  qos: QoS
+  dup: boolean
+  retain: boolean
+  topic: string
+  payload: string | Buffer
 }
-export interface SubscribePacket extends IPacket {
-    cmd: 'subscribe';
-    subscriptions: Array<{
-        topic: string;
-        qos: QoS;
-    }>;
+export interface IConnackPacket extends IPacket {
+  cmd: 'connack'
+  returnCode: number
+  sessionPresent: boolean
 }
-export interface SubackPacket extends IPacket {
-    cmd: 'suback';
-    granted: number[];
+export interface ISubscribePacket extends IPacket {
+  cmd: 'subscribe'
+  subscriptions: Array<{
+    topic: string;
+    qos: QoS;
+  }>
 }
-export interface UnsubscribePacket extends IPacket {
-    cmd: 'unsubscribe';
-    unsubscriptions: string[];
+export interface ISubackPacket extends IPacket {
+  cmd: 'suback'
+  granted: number[]
 }
-export interface UnsubackPacket extends IPacket {
-    cmd: 'unsuback';
+export interface IUnsubscribePacket extends IPacket {
+  cmd: 'unsubscribe'
+  unsubscriptions: string[]
 }
-export interface PubackPacket extends IPacket {
-    cmd: 'puback';
+export interface IUnsubackPacket extends IPacket {
+  cmd: 'unsuback'
 }
-export interface PubcompPacket extends IPacket {
-    cmd: 'pubcomp';
+export interface IPubackPacket extends IPacket {
+  cmd: 'puback'
 }
-export interface PubrelPacket extends IPacket {
-    cmd: 'pubrel';
+export interface IPubcompPacket extends IPacket {
+  cmd: 'pubcomp'
 }
-export interface PubrecPacket extends IPacket {
-    cmd: 'pubrec';
+export interface IPubrelPacket extends IPacket {
+  cmd: 'pubrel'
 }
-export interface PingreqPacket extends IPacket {
-    cmd: 'pingreq';
+export interface IPubrecPacket extends IPacket {
+  cmd: 'pubrec'
 }
-export interface PingrespPacket extends IPacket {
-    cmd: 'pingresp';
+export interface IPingreqPacket extends IPacket {
+  cmd: 'pingreq'
 }
-export interface DisconnectPacket extends IPacket {
-    cmd: 'disconnect';
+export interface IPingrespPacket extends IPacket {
+  cmd: 'pingresp'
 }
-export declare type Packet = ConnectPacket | PublishPacket | ConnackPacket | SubscribePacket | SubackPacket | UnsubscribePacket | UnsubackPacket | PubackPacket | PubcompPacket | PubrelPacket | PingreqPacket | PingrespPacket | DisconnectPacket | PubrecPacket;
+export interface IDisconnectPacket extends IPacket {
+  cmd: 'disconnect'
+}
+
+export declare type Packet = IConnectPacket |
+  IPublishPacket |
+  IConnackPacket |
+  ISubscribePacket |
+  ISubackPacket |
+  IUnsubscribePacket |
+  IUnsubackPacket |
+  IPubackPacket |
+  IPubcompPacket |
+  IPubrelPacket |
+  IPingreqPacket |
+  IPingrespPacket |
+  IDisconnectPacket |
+  IPubrecPacket

--- a/types/lib/validations.d.ts
+++ b/types/lib/validations.d.ts
@@ -1,7 +1,7 @@
 /**
  * Validate an array of topics to see if any of them is valid or not
-  * @param {Array} topics - Array of topics
+ * @param {Array} topics - Array of topics
  * @returns {String} If the topics is valid, returns null. Otherwise, returns the invalid one
  */
-declare function validateTopics(topics: any): any;
-export { validateTopics };
+declare function validateTopics (topics: any): any
+export { validateTopics }

--- a/types/lib/validations.d.ts
+++ b/types/lib/validations.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Validate an array of topics to see if any of them is valid or not
+  * @param {Array} topics - Array of topics
+ * @returns {String} If the topics is valid, returns null. Otherwise, returns the invalid one
+ */
+declare function validateTopics(topics: any): any;
+export { validateTopics };


### PR DESCRIPTION
These headers are exported from a branch where I converted the lib/**/*.js to TypeScript. The tests all passed, when I modified them slightly to make sure they referenced package.json `main` pointing to the tsconfig.compilerOptions.outDir.
