### PR TITLE
feat!: improve `connect(brokerUrl)` parsing

### DIFF
--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -21,16 +21,85 @@ protocols.wss = require('./ws')
  *
  * @param {Object} [opts] option object
  */
-function parseAuthOptions (opts) {
+function parseAuthOptions (auth, opts) {
   var matches
-  if (opts.auth) {
-    matches = opts.auth.match(/^(.+):(.+)$/)
+  if (auth) {
+    matches = auth.match(/^(.+):(.+)$/)
     if (matches) {
       opts.username = matches[1]
       opts.password = matches[2]
     } else {
-      opts.username = opts.auth
+      opts.username = auth
     }
+  }
+}
+
+function parseBrokerUrl (brokerUrl) {
+  var opts = {}
+  var parsed = url.parse(brokerUrl, /* parseQueryString = */ true)
+  if (parsed.port != null) {
+    opts.port = Number(parsed.port)
+  }
+  if (parsed.protocol) {
+    opts.protocol = parsed.protocol.replace(/:$/, '')
+  }
+
+  // Parse username/password
+  parseAuthOptions(parsed.auth, opts)
+
+  // Support clientId passed in the query string of the url
+  if (parsed.query && typeof parsed.query.clientId === 'string') {
+    opts.clientId = parsed.query.clientId
+  }
+
+  return xtend(
+    opts,
+      // username
+      // password
+      // port
+      // protocol
+      // clientId
+    {
+      // NOTE: we use JUST the host, not parsed.host which includes the port
+      host: parsed.hostname,
+      path: parsed.path || '/',
+      // TODO: remove
+      hostname: parsed.hostname
+    })
+}
+
+function warnHostNameDeprecation () {
+  // The test uses hostname twice, once in `connect` when checking passed in
+  // opts and once in the acutall test to check the value is correct.
+  console.warn('Use of mqtt.Client ' +
+    '`opts.hostname` is deprecated. Use `opts.host`.\n' +
+    // Note we clone options in connect/ssl and delete 'hostname'
+    // so hostname isn't used.
+    patchHostName.usages +
+    ' usages detected.')
+}
+
+patchHostName.usages = 0
+function patchHostName (opts) {
+  if (!patchHostName.setHandler) {
+    process.once('exit', warnHostNameDeprecation)
+    patchHostName.setHandler = true
+  }
+
+  if (opts.hostname) {
+    var _hostname = opts.hostname
+    delete opts['hostname']
+    Object.defineProperty(opts, 'hostname', {
+      get: function () {
+        patchHostName.usages++
+        return _hostname
+      },
+      set: function (value) {
+        _hostname = value
+      },
+      configurable: true,
+      enumerable: true
+    })
   }
 }
 
@@ -48,27 +117,26 @@ function connect (brokerUrl, opts) {
 
   opts = opts || {}
 
+  if (opts.hostname) {
+    opts.host = opts.hostname
+    patchHostName.usages++
+    // For testing
+    warnHostNameDeprecation()
+  }
+
   if (brokerUrl) {
-    var parsed = url.parse(brokerUrl, true)
-    if (parsed.port != null) {
-      parsed.port = Number(parsed.port)
-    }
-
-    opts = xtend(parsed, opts)
-
-    if (opts.protocol === null) {
+    // Options object always override brokerUrl specified options
+    opts = xtend(parseBrokerUrl(brokerUrl), opts)
+    if (!opts.protocol) {
       throw new Error('Missing protocol')
     }
-    opts.protocol = opts.protocol.replace(/:$/, '')
   }
 
-  // merge in the auth options if supplied
-  parseAuthOptions(opts)
+  patchHostName(opts)
 
-  // support clientId passed in the query string of the url
-  if (opts.query && typeof opts.query.clientId === 'string') {
-    opts.clientId = opts.query.clientId
-  }
+  // Someone out in the wild might be using {auth: 'user:pass'} out in the wild
+  // Keep old behaviour? Tests actually pass without this.
+  parseAuthOptions(opts.auth, opts)
 
   if (opts.cert && opts.key) {
     if (opts.protocol) {
@@ -130,7 +198,6 @@ function connect (brokerUrl, opts) {
 
       opts.host = opts.servers[client._reconnectCount].host
       opts.port = opts.servers[client._reconnectCount].port
-      opts.hostname = opts.host
 
       client._reconnectCount++
     }

--- a/lib/connect/tcp.js
+++ b/lib/connect/tcp.js
@@ -8,10 +8,10 @@ var net = require('net')
 function buildBuilder (client, opts) {
   var port, host
   opts.port = opts.port || 1883
-  opts.hostname = opts.hostname || opts.host || 'localhost'
+  opts.host = opts.host || 'localhost'
 
   port = opts.port
-  host = opts.hostname
+  host = opts.host
 
   return net.createConnection(port, host)
 }

--- a/lib/connect/tls.js
+++ b/lib/connect/tls.js
@@ -1,10 +1,17 @@
 'use strict'
 var tls = require('tls')
 
-function buildBuilder (mqttClient, opts) {
+function buildBuilder (mqttClient, opts_) {
+  var opts = Object.keys(opts_).reduce(function (acc, k) {
+    if (k !== 'hostname') {
+      acc[k] = opts_[k]
+    }
+    return acc
+  }, {})
+
   var connection
   opts.port = opts.port || 8883
-  opts.host = opts.hostname || opts.host || 'localhost'
+  opts.host = opts.host || 'localhost'
 
   opts.rejectUnauthorized = opts.rejectUnauthorized !== false
 

--- a/lib/connect/ws.js
+++ b/lib/connect/ws.js
@@ -13,7 +13,7 @@ var WSS_OPTIONS = [
 var IS_BROWSER = process.title === 'browser'
 
 function buildUrl (opts, client) {
-  var url = opts.protocol + '://' + opts.hostname + ':' + opts.port + opts.path
+  var url = opts.protocol + '://' + opts.host + ':' + opts.port + opts.path
   if (typeof (opts.transformWsUrl) === 'function') {
     url = opts.transformWsUrl(url, opts, client)
   }
@@ -21,8 +21,8 @@ function buildUrl (opts, client) {
 }
 
 function setDefaultOpts (opts) {
-  if (!opts.hostname) {
-    opts.hostname = 'localhost'
+  if (!opts.host) {
+    opts.host = 'localhost'
   }
   if (!opts.port) {
     if (opts.protocol === 'wss') {
@@ -64,22 +64,19 @@ function buildBuilder (client, opts) {
 }
 
 function buildBuilderBrowser (client, opts) {
-  if (!opts.hostname) {
-    opts.hostname = opts.host
-  }
-
-  if (!opts.hostname) {
-    // Throwing an error in a Web Worker if no `hostname` is given, because we
-    // can not determine the `hostname` automatically.  If connecting to
-    // localhost, please supply the `hostname` as an argument.
+  if (!opts.host) {
+    // Throwing an error in a Web Worker if no `host` is given, because we
+    // can not determine the `host` automatically.  If connecting to
+    // localhost, please supply the `host` as an argument.
     if (typeof (document) === 'undefined') {
-      throw new Error('Could not determine host. Specify host manually.')
+      throw new Error('Could not determine host. Specify `host` manually.')
     }
-    var parsed = urlModule.parse(document.URL)
-    opts.hostname = parsed.hostname
+    var parsed = urlModule.parse(document.URL, true)
+
+    opts.host = parsed.hostname
 
     if (!opts.port) {
-      opts.port = parsed.port
+      opts.port = Number(parsed.port)
     }
   }
   return createWebSocket(client, opts)

--- a/test/mqtt.js
+++ b/test/mqtt.js
@@ -13,6 +13,25 @@ describe('mqtt', function () {
       c.should.be.instanceOf(mqtt.MqttClient)
     })
 
+    it('should warn that `hostname` is deprecated, while still honouring it', function () {
+      var oldWarn = console.warn
+      try {
+        var asserted = false
+        console.warn = function (s) {
+          asserted = true
+          s.split('\n')[0].should.be.equal(
+            'Use of mqtt.Client `opts.hostname` is deprecated. Use `opts.host`.')
+        }
+        var c = mqtt.connect('mqtt://localhost:1883', {hostname: 'test'})
+        asserted.should.be.equal(true)
+        c.should.be.instanceOf(mqtt.MqttClient)
+        c.options.hostname.should.be.equal('test')
+        c.options.host.should.be.equal('test')
+      } finally {
+        console.warn = oldWarn
+      }
+    })
+
     it('should throw an error when called with no protocol specified', function () {
       (function () {
         mqtt.connect('foo.bar.com')
@@ -56,7 +75,7 @@ describe('mqtt', function () {
     it('should return an MqttClient with correct host when called with a host and port', function () {
       var c = mqtt.connect('tcp://user:pass@localhost:1883')
 
-      c.options.should.have.property('hostname', 'localhost')
+      c.options.should.have.property('host', 'localhost')
       c.options.should.have.property('port', 1883)
     })
 


### PR DESCRIPTION
This pull request attempts to tidy up the client options object, by pulling in only relevant information from `url.parse(brokerUrl)` which the `client.options` gets extended with by use of `xtend` in the `connect()` function.

There are a lot of properties here that aren't really relevant.

```
> u.parse('mqtt://www.broker.com')
Url {
  protocol: 'mqtt:',
  slashes: true,
  auth: null,
  host: 'www.broker.com',
  port: null,
  hostname: 'www.broker.com',
  hash: null,
  search: null,
  query: null,
  pathname: null,
  path: null,
  href: 'mqtt://www.broker.com' }
```

Now the options object will only get extended with these properties:

* username
* password
* port
* protocol
* path
* host
* hostname
* clientId

`host` is set to `hostname` as the url.parse(...).host property includes the port.

Near as I can tell, once the various stream builders were updated to use `host` the only place in the code that uses `hostname` is in the tls.js where tls.connect() seems to access `hostname` in precedence over `host`. 

Note that the `servers` option is an array of `{port, host}` objects.  

I think it makes sense to deprecate `hostname`, for consistency sake, though if removal of the other options warrants a semver `breaking` change bump then may as well just remove it now? 