### PR TITLE
Publish types to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "bin",
     "examples",
     "test",
+    "types",
     "mqtt.js"
   ],
   "engines": {


### PR DESCRIPTION
The published package has `"types"` specified in its `package.json`, but doesn't include them.