### PR TITLE
Add a callback for the end function

### DIFF
--- a/types/lib/client.d.ts
+++ b/types/lib/client.d.ts
@@ -41,6 +41,7 @@ export declare type OnMessageCallback = (topic: string, payload: Buffer, packet:
 export declare type OnPacketCallback = (packet: Packet) => void
 export declare type OnErrorCallback = (error: Error) => void
 export declare type PacketCallback = (error?: Error, packet?: Packet) => any
+export declare type CloseCallback = () => void
 
 export interface IStream extends events.EventEmitter {
   pipe (to: any): any
@@ -148,7 +149,7 @@ export declare class MqttClient extends events.EventEmitter {
    *
    * @api public
    */
-  public end (force?: boolean, cb?: Function): this
+  public end (force?: boolean, cb?: CloseCallback): this
 
   /**
    * Handle messages with backpressure support, one at a time.


### PR DESCRIPTION
fixes #571 

I think that the callback for the end functions should be explicitly defined as the same as the other callbacks.