### PR TITLE
Add duplicate flag to publish options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ![mqtt.js](https://raw.githubusercontent.com/mqttjs/MQTT.js/137ee0e3940c1f01049a30248c70f24dc6e6f829/MQTT.js.png)
 =======
 
-Allow setting "dup" flag when publishing a message
-
 [![Build Status](https://travis-ci.org/mqttjs/MQTT.js.svg)](https://travis-ci.org/mqttjs/MQTT.js) [![codecov](https://codecov.io/gh/mqttjs/MQTT.js/branch/master/graph/badge.svg)](https://codecov.io/gh/mqttjs/MQTT.js)
 
 [![NPM](https://nodei.co/npm-dl/mqtt.png)](https://nodei.co/npm/mqtt/) [![NPM](https://nodei.co/npm/mqtt.png)](https://nodei.co/npm/mqtt/)
@@ -315,6 +313,7 @@ Publish a message to a topic
 * `options` is the options to publish with, including:
   * `qos` QoS level, `Number`, default `0`
   * `retain` retain flag, `Boolean`, default `false`
+  * `dup` mark as duplicate flag, `Boolean`, default `false`
 * `callback` - `function (err)`, fired when the QoS handling completes,
   or at the next tick if QoS 0. An error occurs if client is disconnecting.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![mqtt.js](https://raw.githubusercontent.com/mqttjs/MQTT.js/137ee0e3940c1f01049a30248c70f24dc6e6f829/MQTT.js.png)
 =======
 
+Allow setting "dup" flag when publishing a message
+
 [![Build Status](https://travis-ci.org/mqttjs/MQTT.js.svg)](https://travis-ci.org/mqttjs/MQTT.js) [![codecov](https://codecov.io/gh/mqttjs/MQTT.js/branch/master/graph/badge.svg)](https://codecov.io/gh/mqttjs/MQTT.js)
 
 [![NPM](https://nodei.co/npm-dl/mqtt.png)](https://nodei.co/npm/mqtt/) [![NPM](https://nodei.co/npm/mqtt.png)](https://nodei.co/npm/mqtt/)

--- a/lib/client.js
+++ b/lib/client.js
@@ -331,6 +331,7 @@ MqttClient.prototype._checkDisconnecting = function (callback) {
  * @param {Object} [opts] - publish options, includes:
  *    {Number} qos - qos level to publish on
  *    {Boolean} retain - whether or not to retain the message
+ *    {Boolean} dup - whether or not mark a message as duplicate
  * @param {Function} [callback] - function(err){}
  *    called when publish succeeds or fails
  * @returns {MqttClient} this - for chaining
@@ -338,7 +339,7 @@ MqttClient.prototype._checkDisconnecting = function (callback) {
  *
  * @example client.publish('topic', 'message');
  * @example
- *     client.publish('topic', 'message', {qos: 1, retain: true});
+ *     client.publish('topic', 'message', {qos: 1, retain: true, dup: true});
  * @example client.publish('topic', 'message', console.log);
  */
 MqttClient.prototype.publish = function (topic, message, opts, callback) {
@@ -352,7 +353,7 @@ MqttClient.prototype.publish = function (topic, message, opts, callback) {
 
   // Default opts
   if (!opts) {
-    opts = {qos: 0, retain: false}
+    opts = {qos: 0, retain: false, dup: false}
   }
 
   if (this._checkDisconnecting(callback)) {
@@ -365,7 +366,8 @@ MqttClient.prototype.publish = function (topic, message, opts, callback) {
     payload: message,
     qos: opts.qos,
     retain: opts.retain,
-    messageId: this._nextId()
+    messageId: this._nextId(),
+    dup: opts.dup
   }
 
   switch (opts.qos) {

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -531,6 +531,32 @@ module.exports = function (server, config) {
           packet.payload.toString().should.equal(payload)
           packet.qos.should.equal(opts.qos, 'incorrect qos')
           packet.retain.should.equal(opts.retain, 'incorrect ret')
+          packet.dup.should.equal(false, 'incorrect dup')
+          client.end()
+          done()
+        })
+      })
+    })
+
+    it('should mark a message as  duplicate when "dup" option is set', function (done) {
+      var client = connect()
+      var payload = 'duplicated-test'
+      var topic = 'test'
+      var opts = {
+        retain: true,
+        qos: 1,
+        dup: true
+      }
+
+      client.once('connect', function () {
+        client.publish(topic, payload, opts)
+      })
+
+      server.once('client', function (serverClient) {
+        serverClient.once('publish', function (packet) {
+          packet.topic.should.equal(topic)
+          packet.payload.toString().should.equal(payload)
+          packet.dup.should.equal(opts.dup, 'incorrect dup')
           client.end()
           done()
         })


### PR DESCRIPTION
For a specific problem I require to mark a message as duplicate when publishing to a topic. With this change the flag can be added to the options when publishing messages.