### PR TITLE
Add duplicate flag to publish options on the TypeScript definition

### DIFF
--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -106,6 +106,10 @@ export interface IClientPublishOptions {
    * the retain flag
    */
   retain?: boolean
+  /**
+   * whether or not mark a message as duplicate
+   */
+  dup?: boolean
 }
 export interface IClientSubscribeOptions {
   /**


### PR DESCRIPTION
The same change as #603 should be also applied on the TypeScript definition.