### PR TITLE
Use Store for qos>0 packets

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -666,7 +666,7 @@ MqttClient.prototype._sendPacket = function (packet, cb) {
     if ((packet.qos === 0 && this.queueQoSZero) || packet.cmd !== 'publish') {
       this.queue.push({ packet: packet, cb: cb })
     } else if (packet.qos > 0) {
-      storePacket(this, packet, cb);
+      storePacket(this, packet, cb)
     } else if (cb) {
       cb(new Error('No connection to broker'))
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -41,6 +41,14 @@ function sendPacket (client, packet, cb) {
   }
 }
 
+function storePacket (client, packet, cb) {
+  client.outgoingStore.put(packet, function storedPacket (err) {
+    if (err) {
+      return cb && cb(err)
+    }
+  })
+}
+
 function storeAndSend (client, packet, cb) {
   client.outgoingStore.put(packet, function storedPacket (err) {
     if (err) {
@@ -655,8 +663,10 @@ MqttClient.prototype._cleanUp = function (forced, done) {
  */
 MqttClient.prototype._sendPacket = function (packet, cb) {
   if (!this.connected) {
-    if (packet.qos > 0 || packet.cmd !== 'publish' || this.queueQoSZero) {
+    if ((packet.qos === 0 && this.queueQoSZero) || packet.cmd !== 'publish') {
       this.queue.push({ packet: packet, cb: cb })
+    } else if (packet.qos > 0) {
+      storePacket(this, packet, cb);
     } else if (cb) {
       cb(new Error('No connection to broker'))
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -41,10 +41,6 @@ function sendPacket (client, packet, cb) {
   }
 }
 
-function storePacket (client, packet, cb) {
-  client.outgoingStore.put(packet, cb)
-}
-
 function storeAndSend (client, packet, cb) {
   client.outgoingStore.put(packet, function storedPacket (err) {
     if (err) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -42,11 +42,7 @@ function sendPacket (client, packet, cb) {
 }
 
 function storePacket (client, packet, cb) {
-  client.outgoingStore.put(packet, function storedPacket (err) {
-    if (err) {
-      return cb && cb(err)
-    }
-  })
+  client.outgoingStore.put(packet, cb)
 }
 
 function storeAndSend (client, packet, cb) {
@@ -666,7 +662,11 @@ MqttClient.prototype._sendPacket = function (packet, cb) {
     if ((packet.qos === 0 && this.queueQoSZero) || packet.cmd !== 'publish') {
       this.queue.push({ packet: packet, cb: cb })
     } else if (packet.qos > 0) {
-      storePacket(this, packet, cb)
+      storePacket(this, packet, function (err) {
+        if (err) {
+          return cb && cb(err)
+        }
+      })
     } else if (cb) {
       cb(new Error('No connection to broker'))
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -662,7 +662,7 @@ MqttClient.prototype._sendPacket = function (packet, cb) {
     if ((packet.qos === 0 && this.queueQoSZero) || packet.cmd !== 'publish') {
       this.queue.push({ packet: packet, cb: cb })
     } else if (packet.qos > 0) {
-      storePacket(this, packet, function (err) {
+      this.outgoingStore.put(packet, function (err) {
         if (err) {
           return cb && cb(err)
         }

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -387,14 +387,14 @@ module.exports = function (server, config) {
       client.end(true, done)
     })
 
-    it('should still queue qos != 0 messages if queueQoSZero is false', function (done) {
+    it('should not queue qos != 0 messages', function (done) {
       var client = connect({queueQoSZero: false})
 
       client.publish('test', 'test', {qos: 1})
       client.publish('test', 'test', {qos: 2})
       client.subscribe('test')
       client.unsubscribe('test')
-      client.queue.length.should.equal(4)
+      client.queue.length.should.equal(2)
       client.end(true, done)
     })
 


### PR DESCRIPTION
`QOS=0` packets are buffered in-memory if `queueQoSZero` as before, however `QOS>0` packets are persisted in Store to survive client process crash.

Fixes #607 
Fixes #398 