### PR TITLE
tslint should be run on pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "ci": "npm run tslint && npm run test && codecov"
   },
   "pre-commit": [
-    "test"
+    "test",
+    "tslint"
   ],
   "bin": {
     "mqtt_pub": "./bin/pub.js",


### PR DESCRIPTION
This should avoid some mistakes of coding styles on TypeScript definitions.