### PR TITLE
Added checks for double subscription issue

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -443,6 +443,7 @@ MqttClient.prototype.subscribe = function () {
   if (!opts) {
     opts = { qos: 0 }
   }
+
   if (Array.isArray(obj)) {
     obj.forEach(function (topic) {
       if (that._resubscribeTopics[topic] < opts.qos ||

--- a/lib/client.js
+++ b/lib/client.js
@@ -195,6 +195,7 @@ function MqttClient (streamBuilder, options) {
     if (!firstConnection &&
         this.options.clean &&
         Object.keys(this._resubscribeTopics).length > 0) {
+      this._resubscribeTopics.resubscribe = true
       this.subscribe(this._resubscribeTopics)
     }
 
@@ -412,10 +413,13 @@ MqttClient.prototype.subscribe = function () {
   var args = Array.prototype.slice.call(arguments)
   var subs = []
   var obj = args.shift()
+  var resubscribe = obj.resubscribe
   var callback = args.pop() || nop
   var opts = args.pop()
   var invalidTopic
   var that = this
+
+  delete obj.resubscribe
 
   if (typeof obj === 'string') {
     obj = [obj]
@@ -439,22 +443,31 @@ MqttClient.prototype.subscribe = function () {
   if (!opts) {
     opts = { qos: 0 }
   }
-
   if (Array.isArray(obj)) {
     obj.forEach(function (topic) {
-      subs.push({
-        topic: topic,
-        qos: opts.qos
-      })
+      if (that._resubscribeTopics[topic] < opts.qos ||
+          !that._resubscribeTopics.hasOwnProperty(topic) ||
+          resubscribe
+        ) {
+        subs.push({
+          topic: topic,
+          qos: opts.qos
+        })
+      }
     })
   } else {
     Object
       .keys(obj)
       .forEach(function (k) {
-        subs.push({
-          topic: k,
-          qos: obj[k]
-        })
+        if (that._resubscribeTopics[k] < obj[k] ||
+            !that._resubscribeTopics.hasOwnProperty(k) ||
+            resubscribe
+          ) {
+          subs.push({
+            topic: k,
+            qos: obj[k]
+          })
+        }
       })
   }
 
@@ -465,6 +478,11 @@ MqttClient.prototype.subscribe = function () {
     retain: false,
     dup: false,
     messageId: this._nextId()
+  }
+
+  if (!subs.length) {
+    callback(null, [])
+    return
   }
 
   // subscriptions to resubscribe to in case of disconnect


### PR DESCRIPTION
This handles the double subscription issue on server restarts. This usually happens when the client has a subscribe call inside the connect event, ex the CLI <a>https://github.com/mqttjs/MQTT.js/blob/master/bin/sub.js#L90-L102</a> 
I'm not sure if this is the best way to handle this and open to a better way!