### PR TITLE
Fixes #648

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -940,8 +940,6 @@ MqttClient.prototype._handlePubrel = function (packet, callback) {
     if (!err && pub.cmd !== 'pubrel') {
       that.emit('message', pub.topic, pub.payload, pub)
       that.incomingStore.put(packet)
-    } else {
-      that.incomingStore.del(packet)
     }
 
     that._sendPacket({cmd: 'pubcomp', messageId: mid}, callback)


### PR DESCRIPTION
Hi, I just removed the `store.del` because at that moment the package is not in the `this._inflights` object in the store.js file and so another `missing packet` error is thrown. I think just skipping the package should be fine, my bad I haven't double checked in the previous bux fix. 