### PR TITLE
Add a flag to control re-subscribe functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ the `connect` event. Typically a `net.Socket`.
   * `transformWsUrl` : optional `(url, options, client) => url` function
         For ws/wss protocols only. Can be used to implement signing
         urls which upon reconnect can have become expired.
+  * `resubscribe` : if connection is broken and reconnects,
+     subscribed topics are automatically subscribed again (default `true`)
 
 In case mqtts (mqtt over tls) is required, the `options` object is
 passed through to

--- a/lib/client.js
+++ b/lib/client.js
@@ -94,6 +94,9 @@ function MqttClient (streamBuilder, options) {
   // map of subscribed topics to support reconnection
   this._resubscribeTopics = {}
 
+  // map of a subscribe messageId and a topic
+  this.messageIdToTopic = {}
+
   // Ping timer, setup in _setupPingTimer
   this.pingTimer = null
   // Is the client connected?
@@ -492,11 +495,14 @@ MqttClient.prototype.subscribe = function () {
 
   // subscriptions to resubscribe to in case of disconnect
   if (this.options.resubscribe) {
+    var topics = []
     subs.forEach(function (sub) {
       if (that.options.reconnectPeriod > 0) {
         that._resubscribeTopics[sub.topic] = sub.qos
+        topics.push(sub.topic)
       }
     })
+    that.messageIdToTopic[packet.messageId] = topics
   }
 
   this.outgoing[packet.messageId] = function (err, packet) {
@@ -939,6 +945,15 @@ MqttClient.prototype._handleAck = function (packet) {
       break
     case 'suback':
       delete this.outgoing[mid]
+      if (packet.granted.length === 1 && (packet.granted[0] & 0x80) !== 0) {
+        // suback with Failure status
+        var topics = this.messageIdToTopic[mid]
+        if (topics) {
+          topics.forEach(function (topic) {
+            delete that._resubscribeTopics[topic]
+          })
+        }
+      }
       cb(null, packet)
       break
     case 'unsuback':

--- a/lib/client.js
+++ b/lib/client.js
@@ -23,7 +23,8 @@ var defaultConnectOptions = {
   protocolVersion: 4,
   reconnectPeriod: 1000,
   connectTimeout: 30 * 1000,
-  clean: true
+  clean: true,
+  resubscribe: true
 }
 
 function defaultId () {
@@ -196,8 +197,12 @@ function MqttClient (streamBuilder, options) {
     if (!firstConnection &&
         this.options.clean &&
         Object.keys(this._resubscribeTopics).length > 0) {
-      this._resubscribeTopics.resubscribe = true
-      this.subscribe(this._resubscribeTopics)
+      if (this.options.resubscribe) {
+        this._resubscribeTopics.resubscribe = true
+        this.subscribe(this._resubscribeTopics)
+      } else {
+        this._resubscribeTopics = {}
+      }
     }
 
     firstConnection = false
@@ -486,9 +491,13 @@ MqttClient.prototype.subscribe = function () {
   }
 
   // subscriptions to resubscribe to in case of disconnect
-  subs.forEach(function (sub) {
-    that._resubscribeTopics[sub.topic] = sub.qos
-  })
+  if (this.options.resubscribe) {
+    subs.forEach(function (sub) {
+      if (that.options.reconnectPeriod > 0) {
+        that._resubscribeTopics[sub.topic] = sub.qos
+      }
+    })
+  }
 
   this.outgoing[packet.messageId] = function (err, packet) {
     if (!err) {
@@ -536,9 +545,11 @@ MqttClient.prototype.unsubscribe = function (topic, callback) {
     packet.unsubscriptions = topic
   }
 
-  packet.unsubscriptions.forEach(function (topic) {
-    delete that._resubscribeTopics[topic]
-  })
+  if (this.options.resubscribe) {
+    packet.unsubscriptions.forEach(function (topic) {
+      delete that._resubscribeTopics[topic]
+    })
+  }
 
   this.outgoing[packet.messageId] = callback
 

--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -63,6 +63,10 @@ export interface IClientOptions extends ISecureClientOptions {
     port: number;
   }>
   /**
+   * true, set to false to disable re-subscribe functionality
+   */
+  resubscribe?: boolean
+  /**
    * a message that will sent by the broker automatically when the client disconnect badly.
    */
   will?: {


### PR DESCRIPTION
This pull request implements a option `resubscribe` for controlling re-subscribe.
The default value of `resubscribe` is true. It doesn't break current behavior.
It will fix #664 partially. Partially means, if `suback` has error payload, then re-subscribe topics should be removed. It is a different issue.
