### PR TITLE
Fixes #675 packet queuing only if "clean session" is false

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -709,7 +709,8 @@ MqttClient.prototype._cleanUp = function (forced, done) {
  */
 MqttClient.prototype._sendPacket = function (packet, cb) {
   if (!this.connected) {
-    if (((packet.qos || 0) === 0 && this.queueQoSZero) || packet.cmd !== 'publish') {
+    if (((packet.qos || 0) === 0 && this.queueQoSZero) ||
+        (packet.cmd !== 'publish' && this.options.clean === false)) {
       this.queue.push({ packet: packet, cb: cb })
     } else if (packet.qos > 0) {
       this.outgoingStore.put(packet, function (err) {


### PR DESCRIPTION
in #675, there are too many replay packets.
I think the client will replay after reconnect when `clean session` is true.
So, replay packets could be queued only if `clean session` is false.
