### PR TITLE
fix use of should.Array()

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -678,7 +678,7 @@ MqttClient.prototype._cleanUp = function (forced, done) {
   }
 
   if (forced) {
-    this.stream.destroy()
+    this.stream.end()
   } else {
     this._sendPacket(
       { cmd: 'disconnect' },

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -320,7 +320,7 @@ module.exports = function (server, config) {
           if (err) {
             return done()
           }
-          granted2.should.Array([])
+          granted2.should.Array()
           done()
         })
       })


### PR DESCRIPTION
When running the test suite, I'm getting:

```
TypeError: This assertion does not expect any arguments. You may need to check your code
    at Assertion.assertZeroArguments (node_modules/should/cjs/should.js:280:13)
    at Assertion.<anonymous> (node_modules/should/cjs/should.js:1261:10)
    at Assertion.value [as Array] (node_modules/should/cjs/should.js:337:14)
    at test/abstract_client.js:323:27
    at MqttClient.subscribe (lib/client.js:488:5)
    at test/abstract_client.js:319:16
...etc
```

This fixes the problem.

Not sure if `should` broke semver here, but the installed version is ~~13.1.0~~ 13.1.1.

**UPDATE**:

[The last build failed](https://travis-ci.org/mqttjs/MQTT.js/builds/282832614) due to reasons unknown--I believe it's indicative of a bug either in `websocket-stream` or `ws`.

I've added 0d2dc50 which fixes this failing test, but *I don't really know why*.  The Node.js docs [suggest that `socket#destroy()` is not appropriate](https://nodejs.org/api/net.html#net_socket_destroy_exception) where we were using it, since there's not necessarily an "error" involved.

It may make sense to call `socket#destroy()` in some circumstances, but an explicit `client.end(true)` is *not* one of them.