### PR TITLE
remove unused, undocumented "disconnected" property from MqttClient

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -117,10 +117,6 @@ function MqttClient (streamBuilder, options) {
 
   // Mark connected on connect
   this.on('connect', function () {
-    if (this.disconnected) {
-      return
-    }
-
     this.connected = true
     var outStore = null
     outStore = this.outgoingStore.createStream()
@@ -582,7 +578,7 @@ MqttClient.prototype.end = function (force, cb) {
   }
 
   function closeStores () {
-    that.disconnected = true
+    that.connected = false
     that.incomingStore.close(function () {
       that.outgoingStore.close(cb)
     })


### PR DESCRIPTION
While probing around for the root cause of another bug, I discovered the `disconnected` property, which is incongruous with the documented `connected`, and also seemingly unnecessary.  

Prior to this change, situation arises where the `connected` property is `true` even if a call to `end()` has completed, which seems incorrect.  This *may* be the source of my bug, but haven't tested yet :smile:

The changes below don't seem to affect the test outcomes, since the `disconnected` property is not referenced anywhere other than the two places seen in this diff.