### PR TITLE
Replace `pubrel` with `pubcomp`.

### DIFF
--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -803,7 +803,7 @@ module.exports = function (server, config) {
       done()
     })
 
-    it('should not send a `pubrel` if the execution of `handleMessage` fails for messages with QoS `2`', function (done) {
+    it('should not send a `pubcomp` if the execution of `handleMessage` fails for messages with QoS `2`', function (done) {
       var client = connect()
 
       var messageId = Math.floor(65535 * Math.random())


### PR DESCRIPTION
In QoS2 sequence,
when the client receives `publish`, the messege is stored into
`incomingStore` and sends pack `pubrec`. Then the server sends `pubrel`
to the client. Finally,  the client calls `handleMessage` with stored
message. If no errors are hannpened, `pubcomp` will be sent, but any errors
are happened, `pubcomp` shouldn't be sent.
This test is for the error case, so I replaced the description.