### PR TITLE
fix a bug that you can not reconnect on wechat

### DIFF
--- a/lib/connect/wx.js
+++ b/lib/connect/wx.js
@@ -15,7 +15,6 @@ function sendSocketMessage (msg) {
 }
 
 function WebSocket (url, protocols) {
-
   var ws = {
     OPEN: 1,
     CLOSING: 2,
@@ -49,12 +48,12 @@ function WebSocket (url, protocols) {
   wx.onSocketClose(function () {
     ws.onclose && ws.onclose.apply(ws, arguments)
     ws.readyState = ws.CLOSED
-    socketOpen = false;
+    socketOpen = false
   })
   wx.onSocketError(function () {
     ws.onerror && ws.onerror.apply(ws, arguments)
     ws.readyState = ws.CLOSED
-    socketOpen = false;
+    socketOpen = false
   })
 
   return ws

--- a/lib/connect/wx.js
+++ b/lib/connect/wx.js
@@ -49,9 +49,11 @@ function WebSocket (url, protocols) {
   })
   wx.onSocketClose(function () {
     ws.readyState = ws.CLOSED
+    socketOpen = false;
     ws.onclose && ws.onclose.apply(ws, arguments)
   })
   wx.onSocketError(function () {
+    socketOpen = false;
     ws.onerror && ws.onerror.apply(ws, arguments)
   })
 

--- a/lib/connect/wx.js
+++ b/lib/connect/wx.js
@@ -15,7 +15,6 @@ function sendSocketMessage (msg) {
 }
 
 function WebSocket (url, protocols) {
-  console.log('creating WebSocket...', arguments)
 
   var ws = {
     OPEN: 1,
@@ -48,13 +47,14 @@ function WebSocket (url, protocols) {
     ws.onmessage && ws.onmessage.apply(ws, arguments)
   })
   wx.onSocketClose(function () {
+    ws.onclose && ws.onclose.apply(ws, arguments)
     ws.readyState = ws.CLOSED
     socketOpen = false;
-    ws.onclose && ws.onclose.apply(ws, arguments)
   })
   wx.onSocketError(function () {
-    socketOpen = false;
     ws.onerror && ws.onerror.apply(ws, arguments)
+    ws.readyState = ws.CLOSED
+    socketOpen = false;
   })
 
   return ws


### PR DESCRIPTION
On wechat, if the socket is closed, the socketOpen mark is not set to false , so you might send data before the websocket is opened, and the following codes will result in error:

```
function sendSocketMessage (msg) {
  if (socketOpen) {
    wx.sendSocketMessage({
      data: msg
    })
  } else {
    socketMsgQueue.push(msg)
  }
}
```

BTW, why are we pushing msg into a msg queue when the socket is not opened? If we send some message to socket before mqtt connection is done, those messages will be send to server, will it result in error?