### PR TITLE
Allow empty strings as clientId

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -80,7 +80,7 @@ function MqttClient (streamBuilder, options) {
     }
   }
 
-  this.options.clientId = this.options.hasOwnProperty("clientId") ? this.options.clientId : defaultId()
+  this.options.clientId = this.options.hasOwnProperty('clientId') ? this.options.clientId : defaultId()
 
   this.streamBuilder = streamBuilder
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -80,7 +80,7 @@ function MqttClient (streamBuilder, options) {
     }
   }
 
-  this.options.clientId = this.options.clientId || defaultId()
+  this.options.clientId = this.options.hasOwnProperty("clientId") ? this.options.clientId : defaultId()
 
   this.streamBuilder = streamBuilder
 


### PR DESCRIPTION
As specified by MQTT 3.1.1, empty strings are allowed as clientId