### PR TITLE
Updated tls client example

### DIFF
--- a/examples/tls client/mqttclient.js
+++ b/examples/tls client/mqttclient.js
@@ -31,7 +31,8 @@ var options = {
   cert: CERT,
   rejectUnauthorized: true,
   // The CA list will be used to determine if server is authorized
-  ca: TRUSTED_CA_LIST
+  ca: TRUSTED_CA_LIST,
+  protocol: 'ssl'
 }
 
 var client = mqtt.connect(options)


### PR DESCRIPTION
Added protocol ssl. Without protocol parameter this example doesn't work.