### PR TITLE
Fixed resource management on manual reconnect.

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,6 @@ After this function is called, the messageId is released and becomes reusable.
 ### mqtt.Client#reconnect()
 
 Connect again using the same options as connect()
-`incomingStore` and `outgoingStore` need to be ready before `reconnect()` calling.
 
 -------------------------------------------------------
 <a name="handleMessage"></a>

--- a/README.md
+++ b/README.md
@@ -374,7 +374,8 @@ After this function is called, the messageId is released and becomes reusable.
 <a name="reconnect"></a>
 ### mqtt.Client#reconnect()
 
-Connect again using the same options.
+Connect again using the same options as connect()
+`incomingStore` and `outgoingStore` need to be ready before `reconnect()` calling.
 
 -------------------------------------------------------
 <a name="handleMessage"></a>

--- a/lib/client.js
+++ b/lib/client.js
@@ -651,7 +651,7 @@ MqttClient.prototype.reconnect = function () {
     that._reconnect()
   }
 
-  if (this.disconnecting) {
+  if (this.disconnecting && !this.disconnected) {
     this.deferredReconnect = f
   } else {
     f()

--- a/lib/client.js
+++ b/lib/client.js
@@ -586,8 +586,8 @@ MqttClient.prototype.end = function (force, cb) {
     that.incomingStore.close(function () {
       that.outgoingStore.close(cb)
     })
-    if (that.deferredReconnect) {
-      that.deferredReconnect()
+    if (that._deferredReconnect) {
+      that._deferredReconnect()
     }
   }
 
@@ -647,12 +647,14 @@ MqttClient.prototype.reconnect = function () {
   var f = function () {
     that.disconnecting = false
     that.disconnected = false
-    that.deferredReconnect = null
+    that._deferredReconnect = null
+    that.incomingStore = new that.incomingStore.constructor(that.incomingStore.options)
+    that.outgoingStore = new that.outgoingStore.constructor(that.outgoingStore.options)
     that._reconnect()
   }
 
   if (this.disconnecting && !this.disconnected) {
-    this.deferredReconnect = f
+    this._deferredReconnect = f
   } else {
     f()
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -586,6 +586,9 @@ MqttClient.prototype.end = function (force, cb) {
     that.incomingStore.close(function () {
       that.outgoingStore.close(cb)
     })
+    if (that.deferredReconnect) {
+      that.deferredReconnect()
+    }
   }
 
   function finish () {
@@ -640,9 +643,19 @@ MqttClient.prototype.removeOutgoingMessage = function (mid) {
  * @api public
  */
 MqttClient.prototype.reconnect = function () {
-  this.disconnecting = false
-  this.disconnected = false
-  this._reconnect()
+  var that = this
+  var f = function () {
+    that.disconnecting = false
+    that.disconnected = false
+    that.deferredReconnect = null
+    that._reconnect()
+  }
+
+  if (this.disconnecting) {
+    this.deferredReconnect = f
+  } else {
+    f()
+  }
   return this
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -638,9 +638,9 @@ MqttClient.prototype.removeOutgoingMessage = function (mid) {
 /**
  * reconnect - connect again using the same options as connect()
  *
- * @param {Object} [opts] - reconnect options, includes:
- *    {Object} incomingStore - a store for the incoming packets
- *    {Object} outgoingStore - a store for the outgoing packets
+ * @param {Object} [opts] - optional reconnect options, includes:
+ *    {Store} incomingStore - a store for the incoming packets
+ *    {Store} outgoingStore - a store for the outgoing packets
  *    if opts is not given, current stores are used
  * @returns {MqttClient} this - for chaining
  *

--- a/lib/client.js
+++ b/lib/client.js
@@ -636,7 +636,8 @@ MqttClient.prototype.removeOutgoingMessage = function (mid) {
 }
 
 /**
- * reconnect - connect again using the same options
+ * reconnect - connect again using the same options as connect()
+ * `incomingStore` and `outgoingStore` need to be ready before `reconnect()` calling.
  *
  * @returns {MqttClient} this - for chaining
  *
@@ -648,8 +649,6 @@ MqttClient.prototype.reconnect = function () {
     that.disconnecting = false
     that.disconnected = false
     that._deferredReconnect = null
-    that.incomingStore = new that.incomingStore.constructor(that.incomingStore.options)
-    that.outgoingStore = new that.outgoingStore.constructor(that.outgoingStore.options)
     that._reconnect()
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -637,15 +637,27 @@ MqttClient.prototype.removeOutgoingMessage = function (mid) {
 
 /**
  * reconnect - connect again using the same options as connect()
- * `incomingStore` and `outgoingStore` need to be ready before `reconnect()` calling.
  *
+ * @param {Object} [opts] - reconnect options, includes:
+ *    {Object} incomingStore - a store for the incoming packets
+ *    {Object} outgoingStore - a store for the outgoing packets
+ *    if opts is not given, current stores are used
  * @returns {MqttClient} this - for chaining
  *
  * @api public
  */
-MqttClient.prototype.reconnect = function () {
+MqttClient.prototype.reconnect = function (opts) {
   var that = this
   var f = function () {
+    if (opts) {
+      that.options.incomingStore = opts.incomingStore
+      that.options.outgoingStore = opts.outgoingStore
+    } else {
+      that.options.incomingStore = null
+      that.options.outgoingStore = null
+    }
+    that.incomingStore = that.options.incomingStore || new Store()
+    that.outgoingStore = that.options.outgoingStore || new Store()
     that.disconnecting = false
     that.disconnected = false
     that._deferredReconnect = null

--- a/lib/store.js
+++ b/lib/store.js
@@ -115,7 +115,7 @@ Store.prototype.get = function (packet, cb) {
  */
 Store.prototype.close = function (cb) {
   if (this.options.clean) {
-    this._inflights = {}
+    this._inflights = null
   }
   if (cb) {
     cb()

--- a/lib/store.js
+++ b/lib/store.js
@@ -115,7 +115,7 @@ Store.prototype.get = function (packet, cb) {
  */
 Store.prototype.close = function (cb) {
   if (this.options.clean) {
-    this._inflights = null
+    this._inflights = {}
   }
   if (cb) {
     cb()

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -1975,6 +1975,8 @@ module.exports = function (server, config) {
     it('should preserved incomingStore after disconnecting if clean is false', function (done) {
       var reconnect = false
       var client = {}
+      var incomingStore = new mqtt.Store({ clean: false })
+      var outgoingStore = new mqtt.Store({ clean: false })
       var server2 = new Server(function (c) {
         c.on('connect', function (packet) {
           c.connack({returnCode: 0})
@@ -1993,7 +1995,10 @@ module.exports = function (server, config) {
         })
         c.on('pubrec', function (packet) {
           client.end(false, function () {
-            client.reconnect()
+            client.reconnect({
+              incomingStore: incomingStore,
+              outgoingStore: outgoingStore
+            })
           })
         })
         c.on('pubcomp', function (packet) {
@@ -2010,8 +2015,8 @@ module.exports = function (server, config) {
           clean: false,
           clientId: 'cid1',
           reconnectPeriod: 0,
-          incomingStore: new mqtt.Store({ clean: false }),
-          outgoingStore: new mqtt.Store({ clean: false })
+          incomingStore: incomingStore,
+          outgoingStore: outgoingStore
         })
 
         client.on('connect', function () {
@@ -2029,13 +2034,7 @@ module.exports = function (server, config) {
     })
 
     it('should be able to pub/sub if reconnect() is called at close handler', function (done) {
-      var client = connect({
-        clean: false,
-        clientId: 'cid1',
-        reconnectPeriod: 0,
-        incomingStore: new mqtt.Store({ clean: false }),
-        outgoingStore: new mqtt.Store({ clean: false })
-      })
+      var client = connect({ reconnectPeriod: 0 })
       var tryReconnect = true
       var reconnectEvent = false
 
@@ -2065,13 +2064,7 @@ module.exports = function (server, config) {
     })
 
     it('should be able to pub/sub if reconnect() is called at out of close handler', function (done) {
-      var client = connect({
-        clean: false,
-        clientId: 'cid1',
-        reconnectPeriod: 0,
-        incomingStore: new mqtt.Store({ clean: false }),
-        outgoingStore: new mqtt.Store({ clean: false })
-      })
+      var client = connect({ reconnectPeriod: 0 })
       var tryReconnect = true
       var reconnectEvent = false
 
@@ -2099,59 +2092,6 @@ module.exports = function (server, config) {
             client.end()
           })
         }
-      })
-    })
-
-    it('should be able to pub/sub if connect() is called at close handler', function (done) {
-      var client = connect({ reconnectPeriod: 0 })
-      var reconnectEvent = false
-      client.on('close', function () {
-        client = connect({ reconnectPeriod: 0 })
-        client.on('connect', function () {
-          client.subscribe('hello', function () {
-            client.end()
-          })
-        })
-        client.on('close', function () {
-          reconnectEvent.should.equal(false)
-          done()
-        })
-      })
-
-      client.on('reconnect', function () {
-        reconnectEvent = true
-      })
-
-      client.on('connect', function () {
-        client.end()
-      })
-    })
-
-    it('should be able to pub/sub if connect() is called at out of close handler', function (done) {
-      var client = connect({ reconnectPeriod: 0 })
-      var reconnectEvent = false
-
-      client.on('close', function () {
-        setTimeout(function () {
-          client = connect({ reconnectPeriod: 0 })
-          client.on('connect', function () {
-            client.subscribe('hello', function () {
-              client.end()
-            })
-          })
-          client.on('close', function () {
-            reconnectEvent.should.equal(false)
-            done()
-          })
-        }, 100)
-      })
-
-      client.on('reconnect', function () {
-        reconnectEvent = true
-      })
-
-      client.on('connect', function () {
-        client.end()
       })
     })
 

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -2028,6 +2028,36 @@ module.exports = function (server, config) {
       })
     })
 
+    it('should be able to pub/sub if reconnect() is called at close handler', function (done) {
+      var client = connect({ reconnectPeriod: 0 })
+      var tryReconnect = true
+      var reconnectEvent = false
+
+      client.on('close', function () {
+        if (tryReconnect) {
+          tryReconnect = false
+          client.reconnect()
+        } else {
+          reconnectEvent.should.equal(true)
+          done()
+        }
+      })
+
+      client.on('reconnect', function () {
+        reconnectEvent = true
+      })
+
+      client.on('connect', function () {
+        if (tryReconnect) {
+          client.end()
+        } else {
+          client.subscribe('hello', function () {
+            client.end()
+          })
+        }
+      })
+    })
+
     context('with alternate server client', function () {
       var cachedClientListeners
 

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -2029,7 +2029,13 @@ module.exports = function (server, config) {
     })
 
     it('should be able to pub/sub if reconnect() is called at close handler', function (done) {
-      var client = connect({ reconnectPeriod: 0 })
+      var client = connect({
+        clean: false,
+        clientId: 'cid1',
+        reconnectPeriod: 0,
+        incomingStore: new mqtt.Store({ clean: false }),
+        outgoingStore: new mqtt.Store({ clean: false })
+      })
       var tryReconnect = true
       var reconnectEvent = false
 
@@ -2059,7 +2065,13 @@ module.exports = function (server, config) {
     })
 
     it('should be able to pub/sub if reconnect() is called at out of close handler', function (done) {
-      var client = connect({ reconnectPeriod: 0 })
+      var client = connect({
+        clean: false,
+        clientId: 'cid1',
+        reconnectPeriod: 0,
+        incomingStore: new mqtt.Store({ clean: false }),
+        outgoingStore: new mqtt.Store({ clean: false })
+      })
       var tryReconnect = true
       var reconnectEvent = false
 
@@ -2087,6 +2099,59 @@ module.exports = function (server, config) {
             client.end()
           })
         }
+      })
+    })
+
+    it('should be able to pub/sub if connect() is called at close handler', function (done) {
+      var client = connect({ reconnectPeriod: 0 })
+      var reconnectEvent = false
+      client.on('close', function () {
+        client = connect({ reconnectPeriod: 0 })
+        client.on('connect', function () {
+          client.subscribe('hello', function () {
+            client.end()
+          })
+        })
+        client.on('close', function () {
+          reconnectEvent.should.equal(false)
+          done()
+        })
+      })
+
+      client.on('reconnect', function () {
+        reconnectEvent = true
+      })
+
+      client.on('connect', function () {
+        client.end()
+      })
+    })
+
+    it('should be able to pub/sub if connect() is called at out of close handler', function (done) {
+      var client = connect({ reconnectPeriod: 0 })
+      var reconnectEvent = false
+
+      client.on('close', function () {
+        setTimeout(function () {
+          client = connect({ reconnectPeriod: 0 })
+          client.on('connect', function () {
+            client.subscribe('hello', function () {
+              client.end()
+            })
+          })
+          client.on('close', function () {
+            reconnectEvent.should.equal(false)
+            done()
+          })
+        }, 100)
+      })
+
+      client.on('reconnect', function () {
+        reconnectEvent = true
+      })
+
+      client.on('connect', function () {
+        client.end()
       })
     })
 

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -2058,6 +2058,38 @@ module.exports = function (server, config) {
       })
     })
 
+    it('should be able to pub/sub if reconnect() is called at out of close handler', function (done) {
+      var client = connect({ reconnectPeriod: 0 })
+      var tryReconnect = true
+      var reconnectEvent = false
+
+      client.on('close', function () {
+        if (tryReconnect) {
+          tryReconnect = false
+          setTimeout(function () {
+            client.reconnect()
+          }, 100)
+        } else {
+          reconnectEvent.should.equal(true)
+          done()
+        }
+      })
+
+      client.on('reconnect', function () {
+        reconnectEvent = true
+      })
+
+      client.on('connect', function () {
+        if (tryReconnect) {
+          client.end()
+        } else {
+          client.subscribe('hello', function () {
+            client.end()
+          })
+        }
+      })
+    })
+
     context('with alternate server client', function () {
       var cachedClientListeners
 

--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -124,3 +124,13 @@ export interface IClientSubscribeOptions {
    */
   qos: QoS
 }
+export interface IClientReconnectOptions {
+  /**
+   * a Store for the incoming packets
+   */
+  incomingStore?: Store
+  /**
+   * a Store for the outgoing packets
+   */
+  outgoingStore?: Store
+}

--- a/types/lib/client.d.ts
+++ b/types/lib/client.d.ts
@@ -164,7 +164,8 @@ export declare class MqttClient extends events.EventEmitter {
   public removeOutgoingMessage (mid: number): this
 
   /**
-   * reconnect - connect again using the same options
+   * reconnect - connect again using the same options as connect()
+   * `incomingStore` and `outgoingStore` need to be ready before `reconnect()` calling.
    *
    * @returns {MqttClient} this - for chaining
    *

--- a/types/lib/client.d.ts
+++ b/types/lib/client.d.ts
@@ -165,7 +165,11 @@ export declare class MqttClient extends events.EventEmitter {
 
   /**
    * reconnect - connect again using the same options as connect()
-   * `incomingStore` and `outgoingStore` need to be ready before `reconnect()` calling.
+   *
+   * @param {Object} [opts] - reconnect options, includes:
+   *    {Object} incomingStore - a store for the incoming packets
+   *    {Object} outgoingStore - a store for the outgoing packets
+   *    if opts is not given, current stores are used
    *
    * @returns {MqttClient} this - for chaining
    *

--- a/types/lib/client.d.ts
+++ b/types/lib/client.d.ts
@@ -4,7 +4,8 @@ import * as events from 'events'
 import {
   IClientOptions,
   IClientPublishOptions,
-  IClientSubscribeOptions
+  IClientSubscribeOptions,
+  IClientReconnectOptions
 } from './client-options'
 import { Store } from './store'
 import { Packet, QoS } from './types'
@@ -166,16 +167,16 @@ export declare class MqttClient extends events.EventEmitter {
   /**
    * reconnect - connect again using the same options as connect()
    *
-   * @param {Object} [opts] - reconnect options, includes:
-   *    {Object} incomingStore - a store for the incoming packets
-   *    {Object} outgoingStore - a store for the outgoing packets
+   * @param {Object} [opts] - optional reconnect options, includes:
+   *    {Store} incomingStore - a store for the incoming packets
+   *    {Store} outgoingStore - a store for the outgoing packets
    *    if opts is not given, current stores are used
    *
    * @returns {MqttClient} this - for chaining
    *
    * @api public
    */
-  public reconnect (): this
+  public reconnect (opts?: IClientReconnectOptions): this
 
   /**
    * Handle messages with backpressure support, one at a time.


### PR DESCRIPTION
Store._inflights set to {} instead of null to prepare manual reconnect.
Deferred the timing of manual reconnect calling if reconnect() called
during disconnecting process.

NOTE: reconnect() function usually called from 'close' or 'error' handler.