### PR TITLE
Remove unnecessary semicolons from TS declarations

### DIFF
--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -10,7 +10,7 @@ export interface IClientOptions extends ISecureClientOptions {
   protocol?: 'wss' | 'ws' | 'mqtt' | 'mqtts' | 'tcp' | 'ssl' | 'wx' | 'wxs'
 
   wsOptions?: {
-    [x: string]: any;
+    [x: string]: any
   }
   /**
    *  10 seconds, set to 0 to disable
@@ -59,8 +59,8 @@ export interface IClientOptions extends ISecureClientOptions {
   queueQoSZero?: boolean
   reschedulePings?: boolean
   servers?: Array<{
-    host: string;
-    port: number;
+    host: string
+    port: number
   }>
   /**
    * true, set to false to disable re-subscribe functionality
@@ -73,19 +73,19 @@ export interface IClientOptions extends ISecureClientOptions {
     /**
      * the topic to publish
      */
-    topic: string;
+    topic: string
     /**
      * the message to publish
      */
-    payload: string;
+    payload: string
     /**
      * the QoS
      */
-    qos: QoS;
+    qos: QoS
     /**
      * the retain flag
      */
-    retain: boolean;
+    retain: boolean
   }
   transformWsUrl?: (url: string, options: IClientOptions, client: MqttClient) => string
 }

--- a/types/lib/types.d.ts
+++ b/types/lib/types.d.ts
@@ -29,10 +29,10 @@ export interface IConnectPacket extends IPacket {
   username?: string
   password?: Buffer
   will?: {
-    topic: string;
-    payload: Buffer;
-    qos?: QoS;
-    retain?: boolean;
+    topic: string
+    payload: Buffer
+    qos?: QoS
+    retain?: boolean
   }
 }
 export interface IPublishPacket extends IPacket {
@@ -51,8 +51,8 @@ export interface IConnackPacket extends IPacket {
 export interface ISubscribePacket extends IPacket {
   cmd: 'subscribe'
   subscriptions: Array<{
-    topic: string;
-    qos: QoS;
+    topic: string
+    qos: QoS
   }>
 }
 export interface ISubackPacket extends IPacket {


### PR DESCRIPTION
Remove unnecessary semicolons from some of the Typescript declaration files - mostly where there are nested objects and arrays in the interfaces.

Addresses issue #740
