### PR TITLE
update mocha to v4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "global": "^4.3.2",
     "istanbul": "^0.4.5",
     "mkdirp": "^0.5.1",
-    "mocha": "^3.5.3",
+    "mocha": "^4.1.0",
     "mqtt-connection": "^3.0.0",
     "nsp": "^3.1.0",
     "pre-commit": "^1.2.2",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,5 @@
 --growl
 --check-leaks
 --timeout 5000
+--exit
+


### PR DESCRIPTION
- uses `--exit` to hack around non-exiting process
* * *
This is a temporary fix for #703.

*Actual* fixes as [mentioned here](https://github.com/mqttjs/MQTT.js/issues/703#issuecomment-357872112) are another issue entirely.