### PR TITLE
Started brokers integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ before_install:
 - docker run --rm -d --name mosquitto -p 2011:1883 -p 2012:9001 toke/mosquitto
 - docker run --rm -d --name emq -p 2021:1883 -p 2022:8083 sneck/emqttd:latest
 
-env:
-# For compiling optional extensions
 addons:
   apt:
     sources:
@@ -29,12 +27,11 @@ addons:
     packages:
       - g++-4.8
 env:
-  - RUN_BROKER_TESTS=true
-
   global:
   - secure: ODwb1nuf12e0Ja/HgPwZh4aU01G8tTYZliSHI7ZWmYzGv3Yde6UnATeFG8sxGnWPRXTmaZelZfzhq7Aco1fEUnPm31af3z/iaV60iNmz6E1ifTR+oX7jxIvCDtHwBrgevrmIH8vrEUm/kQqDnFNrGG8Cc2xw/LjsNUG1wuWD+I4=
   - secure: buYrn01nPzsiduIQ5oqYTlBdDtM9WKP6gqoyq7IsutHb9sfwh9I6pUYsLibUo4Fq2um9QeXRZ4h1JLKK9xzDVSBpIGGaVzI4ClenfNt9O20IBGBnXcmEKPiRNYF4DkrqZzgx/OVWa6xzcRQI2R1ASQfoyfdpPAnqWXbfalSNkzs=
   - secure: IJRxzV03o76uiL4tCw/Zk0Es6tS/ATlQNIpQxZOyRLBoGTmZfZRKRxiESCKUASHudJgNIlw0kar2/LSJjMlYC4KnlrMJOLCYakXW+CWySe4q/f+qbrcdSK1+DZpjyr6Rmo654td/DD5KjNF3UgwBbi1GkE5fd4UL9HI5mPqDpqw=
   - CXX=g++-4.8
+  - RUN_BROKER_TESTS=true
 script:
   - npm run ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,18 @@ node_js:
 - '7'
 - '8'
 - '9'
+
+services:
+  - docker
+
+before_install:
+- docker pull matteocollina/mosca
+- docker pull toke/mosquitto
+- docker pull sneck/emqttd:latest
+- docker run --rm -d --name mosca -p 2001:1883 -p 2002:80 -v /var/db/mosca:/db matteocollina/mosca
+- docker run --rm -d --name mosquitto -p 2011:1883 -p 2012:9001 toke/mosquitto
+- docker run --rm -d --name emq -p 2021:1883 -p 2022:8083 sneck/emqttd:latest
+
 env:
 # For compiling optional extensions
 addons:
@@ -17,6 +29,8 @@ addons:
     packages:
       - g++-4.8
 env:
+  - RUN_BROKER_TESTS=true
+
   global:
   - secure: ODwb1nuf12e0Ja/HgPwZh4aU01G8tTYZliSHI7ZWmYzGv3Yde6UnATeFG8sxGnWPRXTmaZelZfzhq7Aco1fEUnPm31af3z/iaV60iNmz6E1ifTR+oX7jxIvCDtHwBrgevrmIH8vrEUm/kQqDnFNrGG8Cc2xw/LjsNUG1wuWD+I4=
   - secure: buYrn01nPzsiduIQ5oqYTlBdDtM9WKP6gqoyq7IsutHb9sfwh9I6pUYsLibUo4Fq2um9QeXRZ4h1JLKK9xzDVSBpIGGaVzI4ClenfNt9O20IBGBnXcmEKPiRNYF4DkrqZzgx/OVWa6xzcRQI2R1ASQfoyfdpPAnqWXbfalSNkzs=

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "browser-test": "zuul --server test/browser/server.js --local --open test/browser/test.js",
     "weapp-test": "zuul --server test/browser/server.js --local --open test/browser/wx.js",
     "sauce-test": "zuul --server test/browser/server.js --tunnel ngrok -- test/browser/test.js",
-    "ci": "npm run tslint && npm run typescript-test && npm run test && codecov"
+    "brokers-test": "mocha test/brokers/brokers.js",
+    "ci": "npm run tslint && npm run typescript-test && npm run test && codecov && npm run broker-test"
   },
   "pre-commit": [
     "test",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "weapp-test": "zuul --server test/browser/server.js --local --open test/browser/wx.js",
     "sauce-test": "zuul --server test/browser/server.js --tunnel ngrok -- test/browser/test.js",
     "brokers-test": "mocha test/brokers/brokers.js",
-    "ci": "npm run tslint && npm run typescript-test && npm run test && codecov && npm run broker-test"
+    "ci": "npm run tslint && npm run typescript-test && npm run test && codecov && npm run brokers-test"
   },
   "pre-commit": [
     "test",

--- a/test/brokers/brokers.js
+++ b/test/brokers/brokers.js
@@ -3,190 +3,191 @@
 const mqtt = require('../../')
 const brokers = require('./brokers.json')
 const should = require('should')
+should() // to disable unused jslint error
 
-function buildUrl(protocol) {
+function buildUrl (protocol) {
   return protocol.name + '://localhost:' + protocol.port + (protocol.route || '')
 }
 
-describe('broker compatibility', () => {
-  brokers.forEach(broker => {
-    describe(broker.name, () => {
-      broker.protocols.forEach(protocol => {
-        describe('protocol ' + protocol.name, () => {
+if (process.env.RUN_BROKER_TESTS) {
+  describe('broker compatibility', () => {
+    brokers.forEach(broker => {
+      describe(broker.name, () => {
+        broker.protocols.forEach(protocol => {
+          describe('protocol ' + protocol.name, () => {
+            let client
+            const pretopic = '/' + broker.name + '/' + protocol.name
 
-          let client
-          const pretopic = '/' + broker.name + '/' + protocol.name
+            afterEach(() => {
+              if (client) {
+                client.end()
+                client = undefined
+              }
+            })
 
-          afterEach(() => {
-            if (client) {
-              client.end(true)
-              client = undefined
+            it('should be able to connect to the broker', (done) => {
+              client = mqtt.connect(buildUrl(protocol))
+              client.on('connect', () => {
+                client.connected.should.equal(true)
+                done()
+              })
+            })
+
+            it('should be able to disconnect from the broker', (done) => {
+              client = mqtt.connect(buildUrl(protocol))
+              client.on('connect', () => {
+                client.end(true)
+              })
+              client.on('close', () => {
+                done()
+              })
+            })
+
+            it('should be able to publish in QoS 0', (done) => {
+              client = mqtt.connect(buildUrl(protocol))
+              client.on('connect', () => {
+                client.subscribe(pretopic + '/testqos0', () => {
+                  client.publish(pretopic + '/testqos0', 'QoS 0 works')
+                })
+              })
+              client.on('message', (topic, content, packet) => {
+                topic.should.equal(pretopic + '/testqos0')
+                content.toString().should.equal('QoS 0 works')
+                packet.qos.should.equal(0)
+                done()
+              })
+            })
+
+            it('should be able to publish in QoS 1', (done) => {
+              client = mqtt.connect(buildUrl(protocol))
+              const receivedPubAck = new Promise((resolve, reject) => {
+                client.on('connect', () => {
+                  client.subscribe(pretopic + '/testqos1', {qos: 1}, () => {
+                    client.publish(pretopic + '/testqos1', 'QoS 1 works', {qos: 1},
+                      () => resolve())
+                  })
+                })
+              })
+              const receivedMessage = new Promise((resolve, reject) => {
+                client.on('message', (topic, content, packet) => {
+                  topic.should.equal(pretopic + '/testqos1')
+                  content.toString().should.equal('QoS 1 works')
+                  packet.qos.should.equal(1)
+                  resolve()
+                })
+              })
+
+              Promise.all([receivedPubAck, receivedMessage])
+              .then(() => {
+                done()
+              })
+            })
+
+            if (!broker.NO_QOS2) {
+              it('should be able to publish in QoS 2', (done) => {
+                client = mqtt.connect(buildUrl(protocol))
+                const receivedPubAck = new Promise((resolve, reject) => {
+                  client.on('connect', () => {
+                    client.subscribe(pretopic + '/testqos2', {qos: 2}, () => {
+                      client.publish(pretopic + '/testqos2', 'QoS 2 works', {qos: 2},
+                        () => resolve())
+                    })
+                  })
+                })
+
+                const receivedMessage = new Promise((resolve, reject) => {
+                  client.on('message', (topic, content, packet) => {
+                    topic.should.equal(pretopic + '/testqos2')
+                    content.toString().should.equal('QoS 2 works')
+                    packet.qos.should.equal(2)
+                    resolve()
+                  })
+                })
+
+                Promise.all([receivedPubAck, receivedMessage])
+                .then(() => {
+                  done()
+                })
+              })
             }
-          });
 
-          it('should be able to connect to the broker', (done) => {
-            client = mqtt.connect(buildUrl(protocol))
-            client.on('connect', () => {
-              client.connected.should.be.true
-              done()
+            it('should be able to downgrade the QoS while subscribing', (done) => {
+              client = mqtt.connect(buildUrl(protocol))
+              client.on('connect', () => {
+                client.subscribe(pretopic + '/testqosdowngrade', {qos: 0})
+                client.publish(pretopic + '/testqosdowngrade', 'QoS downgrade works', {qos: 2})
+              })
+              client.on('message', (topic, content, packet) => {
+                topic.should.equal(pretopic + '/testqosdowngrade')
+                content.toString().should.equal('QoS downgrade works')
+                packet.qos.should.equal(0)
+                done()
+              })
+            })
+
+            it('should be able to unsubscribe', (done) => {
+              client = mqtt.connect(buildUrl(protocol))
+              let messagesReceived = 0
+
+              client.on('connect', () => {
+                client.subscribe(pretopic + '/testunsubscribe', () => {
+                  client.publish(pretopic + '/testunsubscribe', 'First Message')
+                })
+              })
+
+              client.on('message', (topic, content, packet) => {
+                messagesReceived.should.equal(0)
+                ++messagesReceived
+                client.unsubscribe(pretopic + '/testunsubscribe', () => {
+                  client.publish('testunsubscribe', 'Second Message', () => {
+                    setTimeout(() => {
+                      done()
+                    }, 200) // Wait for the message to arrive
+                  })
+                })
+              })
+            })
+
+            it('should handle last-will', (done) => {
+              const dyingClient = mqtt.connect(buildUrl(protocol), {
+                will: {
+                  topic: pretopic + '/lwt',
+                  payload: 'byebye',
+                  qos: 1
+                },
+                keepalive: 1
+              })
+
+              client = mqtt.connect(buildUrl(protocol))
+
+              const dyingConnected = new Promise((resolve, reject) => {
+                dyingClient.on('connect', () => {
+                  resolve()
+                })
+              })
+              const clientConnected = new Promise((resolve, reject) => {
+                client.on('connect', () => {
+                  resolve()
+                })
+              })
+
+              Promise.all([dyingConnected, clientConnected])
+              .then(() => {
+                client.on('message', (topic, content) => {
+                  console.log('message received')
+                  topic.should.equal(pretopic + '/lwt')
+                  content.toString().should.equal('byebye')
+                  done()
+                })
+
+                client.subscribe(pretopic + '/lwt', () => {
+                  dyingClient.end(true) // simulates a disconnection
+                })
+              })
             })
           })
-
-          // it('should be able to disconnect from the broker', (done) => {
-          //   client = mqtt.connect(buildUrl(protocol))
-          //   client.on('connect', () => {
-          //     client.end(true)
-          //   })
-          //   client.on('close', () => {
-          //     done()
-          //   })
-          // })
-          //
-          // it('should be able to publish in QoS 0', (done) => {
-          //   client = mqtt.connect(buildUrl(protocol))
-          //   client.on('connect', () => {
-          //     client.subscribe(pretopic + '/testqos0', () => {
-          //       client.publish(pretopic + '/testqos0', 'QoS 0 works')
-          //     })
-          //   })
-          //   client.on('message', (topic, content, packet) => {
-          //     topic.should.equal(pretopic + '/testqos0')
-          //     content.toString().should.equal('QoS 0 works')
-          //     packet.qos.should.equal(0)
-          //     done()
-          //   })
-          // })
-          //
-          // it('should be able to publish in QoS 1', (done) => {
-          //   client = mqtt.connect(buildUrl(protocol))
-          //   const receivedPubAck = new Promise((accept, reject) => {
-          //     client.on('connect', () => {
-          //       client.subscribe(pretopic + '/testqos1', {qos: 1}, () => {
-          //         client.publish(pretopic + '/testqos1', 'QoS 1 works', {qos: 1},
-          //           () => accept())
-          //       })
-          //     })
-          //   })
-          //   const receivedMessage = new Promise((accept, reject) => {
-          //     client.on('message', (topic, content, packet) => {
-          //       topic.should.equal(pretopic + '/testqos1')
-          //       content.toString().should.equal('QoS 1 works')
-          //       packet.qos.should.equal(1)
-          //       accept()
-          //     })
-          //   })
-          //
-          //   Promise.all([receivedPubAck, receivedMessage])
-          //   .then(() => {
-          //     done()
-          //   })
-          // })
-          //
-          // if (!broker.NO_QOS2) {
-          //   it('should be able to publish in QoS 2', (done) => {
-          //     client = mqtt.connect(buildUrl(protocol))
-          //     const receivedPubAck = new Promise((accept, reject) => {
-          //       client.on('connect', () => {
-          //         client.subscribe(pretopic + '/testqos2', {qos: 2}, () => {
-          //           client.publish(pretopic + '/testqos2', 'QoS 2 works', {qos: 2},
-          //             () => accept())
-          //         })
-          //       })
-          //     })
-          //
-          //     const receivedMessage = new Promise((accept, reject) => {
-          //       client.on('message', (topic, content, packet) => {
-          //         topic.should.equal(pretopic + '/testqos2')
-          //         content.toString().should.equal('QoS 2 works')
-          //         packet.qos.should.equal(2)
-          //         accept()
-          //       })
-          //     })
-          //
-          //     Promise.all([receivedPubAck, receivedMessage])
-          //     .then(() => {
-          //       done()
-          //     })
-          //   })
-          // }
-          //
-          // it('should be able to downgrade the QoS while subscribing', (done) => {
-          //   client = mqtt.connect(buildUrl(protocol))
-          //   client.on('connect', () => {
-          //     client.subscribe(pretopic + '/testqosdowngrade', {qos: 0})
-          //     client.publish(pretopic + '/testqosdowngrade', 'QoS downgrade works', {qos: 2})
-          //   })
-          //   client.on('message', (topic, content, packet) => {
-          //     topic.should.equal(pretopic + '/testqosdowngrade')
-          //     content.toString().should.equal('QoS downgrade works')
-          //     packet.qos.should.equal(0)
-          //     done()
-          //   })
-          // })
-          //
-          // it('should be able to unsubscribe', (done) => {
-          //   client = mqtt.connect(buildUrl(protocol))
-          //   let messagesReceived = 0
-          //
-          //   client.on('connect', () => {
-          //     client.subscribe(pretopic + '/testunsubscribe', () => {
-          //       client.publish(pretopic + '/testunsubscribe', 'First Message')
-          //     })
-          //   })
-          //
-          //   client.on('message', (topic, content, packet) => {
-          //     messagesReceived.should.equal(0)
-          //     ++messagesReceived
-          //     client.unsubscribe(pretopic + '/testunsubscribe', () => {
-          //       client.publish('testunsubscribe', 'Second Message', () => {
-          //         setTimeout(() => {
-          //           done()
-          //         }, 200) // Wait for the message to arrive
-          //       })
-          //     })
-          //   })
-          // })
-          //
-          // it('should handle last-will', (done) => {
-          //   const dyingClient = mqtt.connect(buildUrl(protocol),
-          //   {
-          //     will: {
-          //       topic: pretopic + '/lwt',
-          //       payload: 'byebye',
-          //       qos: 2
-          //     },
-          //     keepalive: 1
-          //   })
-          //
-          //   client = mqtt.connect(buildUrl(protocol))
-          //
-          //   const dyingConnected = new Promise((accept, reject) => {
-          //     dyingClient.on('connect', () => {
-          //       accept()
-          //     })
-          //   })
-          //   const clientConnected = new Promise((accept, reject) => {
-          //     client.on('connect', () => {
-          //       accept()
-          //     })
-          //   })
-          //
-          //   Promise.all([dyingConnected, clientConnected])
-          //   .then(() => {
-          //     client.on('message', (topic, content) => {
-          //       console.log('message received')
-          //       topic.should.equal(pretopic + '/lwt')
-          //       content.toString().should.equal('byebye')
-          //       done()
-          //     })
-          //
-          //     client.subscribe(pretopic + '/lwt', () => {
-          //       dyingClient.end(true)
-          //     })
-          //   })
-          // })
         })
       })
     })
   })
-})
+}

--- a/test/brokers/brokers.js
+++ b/test/brokers/brokers.js
@@ -1,0 +1,192 @@
+'use strict'
+
+const mqtt = require('../../')
+const brokers = require('./brokers.json')
+const should = require('should')
+
+function buildUrl(protocol) {
+  return protocol.name + '://localhost:' + protocol.port + (protocol.route || '')
+}
+
+describe('broker compatibility', () => {
+  brokers.forEach(broker => {
+    describe(broker.name, () => {
+      broker.protocols.forEach(protocol => {
+        describe('protocol ' + protocol.name, () => {
+
+          let client
+          const pretopic = '/' + broker.name + '/' + protocol.name
+
+          afterEach(() => {
+            if (client) {
+              client.end(true)
+              client = undefined
+            }
+          });
+
+          it('should be able to connect to the broker', (done) => {
+            client = mqtt.connect(buildUrl(protocol))
+            client.on('connect', () => {
+              client.connected.should.be.true
+              done()
+            })
+          })
+
+          // it('should be able to disconnect from the broker', (done) => {
+          //   client = mqtt.connect(buildUrl(protocol))
+          //   client.on('connect', () => {
+          //     client.end(true)
+          //   })
+          //   client.on('close', () => {
+          //     done()
+          //   })
+          // })
+          //
+          // it('should be able to publish in QoS 0', (done) => {
+          //   client = mqtt.connect(buildUrl(protocol))
+          //   client.on('connect', () => {
+          //     client.subscribe(pretopic + '/testqos0', () => {
+          //       client.publish(pretopic + '/testqos0', 'QoS 0 works')
+          //     })
+          //   })
+          //   client.on('message', (topic, content, packet) => {
+          //     topic.should.equal(pretopic + '/testqos0')
+          //     content.toString().should.equal('QoS 0 works')
+          //     packet.qos.should.equal(0)
+          //     done()
+          //   })
+          // })
+          //
+          // it('should be able to publish in QoS 1', (done) => {
+          //   client = mqtt.connect(buildUrl(protocol))
+          //   const receivedPubAck = new Promise((accept, reject) => {
+          //     client.on('connect', () => {
+          //       client.subscribe(pretopic + '/testqos1', {qos: 1}, () => {
+          //         client.publish(pretopic + '/testqos1', 'QoS 1 works', {qos: 1},
+          //           () => accept())
+          //       })
+          //     })
+          //   })
+          //   const receivedMessage = new Promise((accept, reject) => {
+          //     client.on('message', (topic, content, packet) => {
+          //       topic.should.equal(pretopic + '/testqos1')
+          //       content.toString().should.equal('QoS 1 works')
+          //       packet.qos.should.equal(1)
+          //       accept()
+          //     })
+          //   })
+          //
+          //   Promise.all([receivedPubAck, receivedMessage])
+          //   .then(() => {
+          //     done()
+          //   })
+          // })
+          //
+          // if (!broker.NO_QOS2) {
+          //   it('should be able to publish in QoS 2', (done) => {
+          //     client = mqtt.connect(buildUrl(protocol))
+          //     const receivedPubAck = new Promise((accept, reject) => {
+          //       client.on('connect', () => {
+          //         client.subscribe(pretopic + '/testqos2', {qos: 2}, () => {
+          //           client.publish(pretopic + '/testqos2', 'QoS 2 works', {qos: 2},
+          //             () => accept())
+          //         })
+          //       })
+          //     })
+          //
+          //     const receivedMessage = new Promise((accept, reject) => {
+          //       client.on('message', (topic, content, packet) => {
+          //         topic.should.equal(pretopic + '/testqos2')
+          //         content.toString().should.equal('QoS 2 works')
+          //         packet.qos.should.equal(2)
+          //         accept()
+          //       })
+          //     })
+          //
+          //     Promise.all([receivedPubAck, receivedMessage])
+          //     .then(() => {
+          //       done()
+          //     })
+          //   })
+          // }
+          //
+          // it('should be able to downgrade the QoS while subscribing', (done) => {
+          //   client = mqtt.connect(buildUrl(protocol))
+          //   client.on('connect', () => {
+          //     client.subscribe(pretopic + '/testqosdowngrade', {qos: 0})
+          //     client.publish(pretopic + '/testqosdowngrade', 'QoS downgrade works', {qos: 2})
+          //   })
+          //   client.on('message', (topic, content, packet) => {
+          //     topic.should.equal(pretopic + '/testqosdowngrade')
+          //     content.toString().should.equal('QoS downgrade works')
+          //     packet.qos.should.equal(0)
+          //     done()
+          //   })
+          // })
+          //
+          // it('should be able to unsubscribe', (done) => {
+          //   client = mqtt.connect(buildUrl(protocol))
+          //   let messagesReceived = 0
+          //
+          //   client.on('connect', () => {
+          //     client.subscribe(pretopic + '/testunsubscribe', () => {
+          //       client.publish(pretopic + '/testunsubscribe', 'First Message')
+          //     })
+          //   })
+          //
+          //   client.on('message', (topic, content, packet) => {
+          //     messagesReceived.should.equal(0)
+          //     ++messagesReceived
+          //     client.unsubscribe(pretopic + '/testunsubscribe', () => {
+          //       client.publish('testunsubscribe', 'Second Message', () => {
+          //         setTimeout(() => {
+          //           done()
+          //         }, 200) // Wait for the message to arrive
+          //       })
+          //     })
+          //   })
+          // })
+          //
+          // it('should handle last-will', (done) => {
+          //   const dyingClient = mqtt.connect(buildUrl(protocol),
+          //   {
+          //     will: {
+          //       topic: pretopic + '/lwt',
+          //       payload: 'byebye',
+          //       qos: 2
+          //     },
+          //     keepalive: 1
+          //   })
+          //
+          //   client = mqtt.connect(buildUrl(protocol))
+          //
+          //   const dyingConnected = new Promise((accept, reject) => {
+          //     dyingClient.on('connect', () => {
+          //       accept()
+          //     })
+          //   })
+          //   const clientConnected = new Promise((accept, reject) => {
+          //     client.on('connect', () => {
+          //       accept()
+          //     })
+          //   })
+          //
+          //   Promise.all([dyingConnected, clientConnected])
+          //   .then(() => {
+          //     client.on('message', (topic, content) => {
+          //       console.log('message received')
+          //       topic.should.equal(pretopic + '/lwt')
+          //       content.toString().should.equal('byebye')
+          //       done()
+          //     })
+          //
+          //     client.subscribe(pretopic + '/lwt', () => {
+          //       dyingClient.end(true)
+          //     })
+          //   })
+          // })
+        })
+      })
+    })
+  })
+})

--- a/test/brokers/brokers.js
+++ b/test/brokers/brokers.js
@@ -174,7 +174,6 @@ if (process.env.RUN_BROKER_TESTS) {
               Promise.all([dyingConnected, clientConnected])
               .then(() => {
                 client.on('message', (topic, content) => {
-                  console.log('message received')
                   topic.should.equal(pretopic + '/lwt')
                   content.toString().should.equal('byebye')
                   done()

--- a/test/brokers/brokers.json
+++ b/test/brokers/brokers.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "mosca",
+    "command": "docker run --rm -d --name mosca -p 2001:1883 -p 2002:80 -v /var/db/mosca:/db matteocollina/mosca",
+    "protocols": [
+      {
+        "name": "tcp",
+        "port": "2001"
+      },
+      {
+        "name": "ws",
+        "port": "2002"
+      }
+    ],
+    "NO_QOS2": true
+  },
+  {
+    "name": "mosquitto",
+    "command": "docker run --rm --name mosquitto -d -p 2011:1883 -p 2012:9001 toke/mosquitto",
+    "protocols": [
+      {
+        "name": "tcp",
+        "port": "2011"
+      },
+      {
+        "name": "ws",
+        "port": "2012"
+      }
+    ]
+  },
+  {
+    "name": "emq",
+    "command": "docker run --rm -d --name emq -p 2022:18083 -p 2021:1883 sneck/emqttd:latest",
+    "protocols": [
+      {
+        "name": "tcp",
+        "port": "2021"
+      },
+      {
+        "name": "ws",
+        "port": "2022",
+        "route": "/mqtt"
+      }
+    ]
+  }
+]

--- a/test/brokers/brokers.sh
+++ b/test/brokers/brokers.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # mosca
-docker run --rm -d --name mosca -p 2083:1883 -p 2080:80 -v /var/db/mosca:/db matteocollina/mosca
+docker run --rm -d --name mosca -p 2001:1883 -p 2002:80 -v /var/db/mosca:/db matteocollina/mosca
 # mosquitto
-docker run --rm -d --name mosquitto eclipse-mosquitto -p 2183:1883 2180:80
+docker run --rm -d --name mosquitto -p 2011:1883 -p 2012:9001 toke/mosquitto
 # emq
-docker run --rm -d --name emq -p 2022:8083 -p 2021:1883 sneck/emqttd:latest
+docker run --rm -d --name emq -p 2021:1883 -p 2022:8083 sneck/emqttd:latest

--- a/test/brokers/brokers.sh
+++ b/test/brokers/brokers.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# mosca
+docker run --rm -d --name mosca -p 2083:1883 -p 2080:80 -v /var/db/mosca:/db matteocollina/mosca
+# mosquitto
+docker run --rm -d --name mosquitto eclipse-mosquitto -p 2183:1883 2180:80
+# emq
+docker run --rm -d --name emq -p 2022:8083 -p 2021:1883 sneck/emqttd:latest


### PR DESCRIPTION
I started working on the issue #505.

This PR allows travis-ci to run tests on different brokers: EMQ, mosca and mosquitto, which are each in their own docker containers, in order to improve reproducibility.

However, currently, I only have **very few** tests.

You can either choose to merge this PR, for other people to add tests later, or ask for tests in the comments, and I can try to implement them while I have the time to do so.

#### PS: First, I will try to fix the fact that the tests fail on EMQ in travis