### PR TITLE
Force callbacks when pingresp not received or when end called with true.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ test/typescript/.idea/*
 test/typescript/*.js
 test/typescript/*.map
 package-lock.json
+# VS Code stuff
+**/typings/**
+**/.vscode/**

--- a/lib/client.js
+++ b/lib/client.js
@@ -43,6 +43,17 @@ function sendPacket (client, packet, cb) {
   }
 }
 
+function flush (queue) {
+  if (queue) {
+    Object.keys(queue).forEach(function (messageId) {
+      if (typeof queue[messageId] === 'function') {
+        queue[messageId](new Error('Connection closed'))
+        delete queue[messageId]
+      }
+    })
+  }
+}
+
 function storeAndSend (client, packet, cb) {
   client.outgoingStore.put(packet, function storedPacket (err) {
     if (err) {
@@ -135,7 +146,7 @@ function MqttClient (streamBuilder, options) {
           return
         }
 
-        // Avoid unnecesary stream read operations when disconnected
+        // Avoid unnecessary stream read operations when disconnected
         if (!that.disconnecting && !that.reconnectTimer && that.options.reconnectPeriod > 0) {
           outStore.read(0)
           cb = that.outgoing[packet.messageId]
@@ -722,6 +733,9 @@ MqttClient.prototype._cleanUp = function (forced, done) {
   }
 
   if (forced) {
+    if ((this.options.reconnectPeriod === 0) && this.options.clean) {
+      flush(this.outgoing)
+    }
     this.stream.destroy()
   } else {
     this._sendPacket(


### PR DESCRIPTION
When a pingresp does not occur, things are forced closed.  However, callbacks in the outgoing queue are not invoked.

Added code to the cleanup, so that in the case of forced argument of true, will invoke the callbacks with  an error.

Also fixed a few spelling errors.