### PR TITLE
Use protocol from server list if available.

### DIFF
--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -119,6 +119,10 @@ function connect (brokerUrl, opts) {
     throw new Error('Missing clientId for unclean clients')
   }
 
+  if (opts.protocol) {
+    opts.defaultProtocol = opts.protocol
+  }
+
   function wrapper (client) {
     if (opts.servers) {
       if (!client._reconnectCount || client._reconnectCount === opts.servers.length) {
@@ -127,7 +131,7 @@ function connect (brokerUrl, opts) {
 
       opts.host = opts.servers[client._reconnectCount].host
       opts.port = opts.servers[client._reconnectCount].port
-      opts.protocol = (!opts.servers[client._reconnectCount].protocol ? opts.protocol : opts.servers[client._reconnectCount].protocol)
+      opts.protocol = (!opts.servers[client._reconnectCount].protocol ? opts.defaultProtocol : opts.servers[client._reconnectCount].protocol)
       opts.hostname = opts.host
 
       client._reconnectCount++

--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -127,6 +127,7 @@ function connect (brokerUrl, opts) {
 
       opts.host = opts.servers[client._reconnectCount].host
       opts.port = opts.servers[client._reconnectCount].port
+      opts.protocol = (!opts.servers[client._reconnectCount].protocol ? opts.protocol : opts.servers[client._reconnectCount].protocol)
       opts.hostname = opts.host
 
       client._reconnectCount++

--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -61,6 +61,7 @@ export interface IClientOptions extends ISecureClientOptions {
   servers?: Array<{
     host: string
     port: number
+    protocol?: 'wss' | 'ws' | 'mqtt' | 'mqtts' | 'tcp' | 'ssl' | 'wx' | 'wxs'
   }>
   /**
    * true, set to false to disable re-subscribe functionality


### PR DESCRIPTION
Fixes #775 

- Note: Could in rare cases break poorly defined options.

## Works
```
                servers:[{
                    host: getMQTTBrokerHostname(),
                    port: 8883,
                    protocol: 'wss'
                },{
                    host: getMQTTBrokerHostname(),
                    port: 1884,
                    protocol: 'ws'
                }]
```
## Works
I imagine this is the most common use case.
```
                protocol: 'ws',
                servers:[{
                    host: getMQTTBrokerHostname(),
                    port: 1884
                }]
```

## Doesn't work
```
                protocol: 'ws',
                servers:[{
                    host: getMQTTBrokerHostname(),
                    port: 8883,
                    protocol: 'wss'
                },{
                    host: getMQTTBrokerHostname(),
                    port: 1884
                }]
```
This will not default the second attempt to the `ws`. The code will need to be refactor extensively in order to properly resolve protocols on a per attempt basis with a default. Alternatively the protocol for a server can be required instead of optional.