### PR TITLE
Added browser shim for process

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1,0 +1,5 @@
+var process
+process.nextTick = setTimeout
+process.title = 'browser'
+
+module.exports = process

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "browser": {
     "./mqtt.js": "./lib/connect/index.js",
+    "process": "./lib/process.js",
     "fs": false,
     "tls": false,
     "net": false


### PR DESCRIPTION
As requested in #804, here is a browser shim for process, which is needed to use mqtt.js with angular-cli >= 6.0.0, since they removed the node-shims.