### PR TITLE
Fixed #729: weapp url should not have the port number, remove it from weapp url builder

### DIFF
--- a/lib/connect/wx.js
+++ b/lib/connect/wx.js
@@ -64,7 +64,7 @@ var urlModule = require('url')
 
 function buildUrl (opts, client) {
   var protocol = opts.protocol === 'wxs' ? 'wss' : 'ws'
-  var url = protocol + '://' + opts.hostname + ':' + opts.port + opts.path
+  var url = protocol + '://' + opts.hostname  + opts.path
   if (typeof (opts.transformWsUrl) === 'function') {
     url = opts.transformWsUrl(url, opts, client)
   }
@@ -74,13 +74,6 @@ function buildUrl (opts, client) {
 function setDefaultOpts (opts) {
   if (!opts.hostname) {
     opts.hostname = 'localhost'
-  }
-  if (!opts.port) {
-    if (opts.protocol === 'wss') {
-      opts.port = 443
-    } else {
-      opts.port = 80
-    }
   }
   if (!opts.path) {
     opts.path = '/'

--- a/lib/connect/wx.js
+++ b/lib/connect/wx.js
@@ -64,7 +64,7 @@ var urlModule = require('url')
 
 function buildUrl (opts, client) {
   var protocol = opts.protocol === 'wxs' ? 'wss' : 'ws'
-  var url = protocol + '://' + opts.hostname  + opts.path
+  var url = protocol + '://' + opts.hostname + opts.path
   if (typeof (opts.transformWsUrl) === 'function') {
     url = opts.transformWsUrl(url, opts, client)
   }


### PR DESCRIPTION
As the weapp document mentioned [here](https://developers.weixin.qq.com/miniprogram/dev/api/api-network.html):
>域名不能使用 IP 地址或 localhost，且不能带端口号；
(The domain name cannot use the IP address or localhost, and cannot have the port number.)

We should not add port on the url, weapp will use default port 80 for `ws` and port 443 for `wss`.
In fact, we can only use these port for weapp client.

If we add port on the url, it will cause the error like this:
```
error: ws://api.xxx.com:80 不在以下 socket 合法域名列表中
(error: ws://api.xxx.com:80 not in socket legal domain name list)
```

And that's why this issue #729 happens.