### PR TITLE
Fixed: weapp's real device environment can only send data of type String/ArrayBuffer

### DIFF
--- a/lib/connect/wx.js
+++ b/lib/connect/wx.js
@@ -7,7 +7,7 @@ var socketMsgQueue = []
 function sendSocketMessage (msg) {
   if (socketOpen) {
     wx.sendSocketMessage({
-      data: msg
+      data: msg.buffer || msg
     })
   } else {
     socketMsgQueue.push(msg)


### PR DESCRIPTION
As weapp doc [mentioned](https://developers.weixin.qq.com/miniprogram/dev/api/network-socket.html#wxsendsocketmessageobject),
`wx.sendSocketMessage` can only send data of type String or ArrayBuffer.
The `msg` got here will be type of TypedArray, which can be sent successfully in wechat devtool (browser environment), but failed in real device (not real browser envirment). 
This PR fix it.