### PR TITLE
Update: weapp add port number back when not 80 or 443

### DIFF
--- a/lib/connect/wx.js
+++ b/lib/connect/wx.js
@@ -65,6 +65,9 @@ var urlModule = require('url')
 function buildUrl (opts, client) {
   var protocol = opts.protocol === 'wxs' ? 'wss' : 'ws'
   var url = protocol + '://' + opts.hostname + opts.path
+  if (opts.port && opts.port !== 80 && opts.port !== 443) {
+    url = protocol + '://' + opts.hostname + ':' + opts.port + opts.path
+  }
   if (typeof (opts.transformWsUrl) === 'function') {
     url = opts.transformWsUrl(url, opts, client)
   }


### PR DESCRIPTION
Directly remove weapp port number (#811) may be confused for people using a mqtt server listen on port like 1883 in development. 

Although they can only use port 80 or 443 in weapp, we should let weapp throw the error, rather than conceal it.