### PR TITLE
Solves issue #810

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -120,8 +120,11 @@ function MqttClient (streamBuilder, options) {
   this.connackTimer = null
   // Reconnect timer
   this.reconnectTimer = null
-  // MessageIDs starting with 1
-  this.nextId = Math.floor(Math.random() * 65535)
+  /**
+   * MessageIDs starting with 1
+   * ensure that nextId is min. 1, see https://github.com/mqttjs/MQTT.js/issues/810
+   */
+  this.nextId = Math.max(1, Math.floor(Math.random() * 65535))
 
   // Inflight callbacks
   this.outgoing = {}
@@ -1070,11 +1073,13 @@ MqttClient.prototype._handlePubrel = function (packet, callback) {
 
 /**
  * _nextId
+ * @return unsigned int
  */
 MqttClient.prototype._nextId = function () {
+  // id becomes current state of this.nextId and increments afterwards
   var id = this.nextId++
-  // Ensure 16 bit unsigned int:
-  if (id === 65535) {
+  // Ensure 16 bit unsigned int (max 65535, nextId got one higher)
+  if (this.nextId === 65536) {
     this.nextId = 1
   }
   return id
@@ -1082,6 +1087,7 @@ MqttClient.prototype._nextId = function () {
 
 /**
  * getLastMessageId
+ * @return unsigned int
  */
 MqttClient.prototype.getLastMessageId = function () {
   return (this.nextId === 1) ? 65535 : (this.nextId - 1)


### PR DESCRIPTION
1: Set minimum of this.nextId initialisation to 1:
```
this.nextId = Math.max(1, Math.floor(Math.random() * 65535))
```

2. Missing slot 65536 is not the case, the previous function was the following:
```
  var id = this.nextId++
  // Ensure 16 bit unsigned int:
  if (id === 65535) {
    this.nextId = 1
  }
  return id
```

Which results into the following behaviour:
1. nextId is 65535
2. id becomes 65535
3. nextId becomes 65536
4. if(id === 65535) sets nextId to 1 while nextId is already 65536

It would be different with var id = ++this.nextId.

Nevertheless, it's  hard to read and not very explicit, id is a copy of nextId while nextId is changed which is not really clear (devil is here definitively in the detail) therefore I added a merge request to change the implementation to with the purpose of easier readability:
```
var id = this.nextId++
if(this.nextId === 65536) {
  this.nextId = 1
}
return id
```