### PR TITLE
Fixed invalid protocol definition in TLS client example.

### DIFF
--- a/examples/tls client/mqttclient.js
+++ b/examples/tls client/mqttclient.js
@@ -32,7 +32,7 @@ var options = {
   rejectUnauthorized: true,
   // The CA list will be used to determine if server is authorized
   ca: TRUSTED_CA_LIST,
-  protocol: 'ssl'
+  protocol: 'mqtts'
 }
 
 var client = mqtt.connect(options)


### PR DESCRIPTION
Related issue: #842 