### PR TITLE
Improved example with subscribe callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,11 @@ var mqtt = require('mqtt')
 var client  = mqtt.connect('mqtt://test.mosquitto.org')
 
 client.on('connect', function () {
-  client.subscribe('presence')
-  client.publish('presence', 'Hello mqtt')
+  client.subscribe('presence', function (err) {
+    if (!err) {
+      client.publish('presence', 'Hello mqtt')
+    }
+  })
 })
 
 client.on('message', function (topic, message) {


### PR DESCRIPTION
I have setup a small mqtt cluster with 2 nodes on Kubernetes. If I try to run your example I sometime miss the `Hello mqtt` message, and the sample app just keep running.
If I change the example by moving the publish inside the callback I always get the message and the app correctly close.

Can this be caused by the fact that the publish doesn't wait the subscribe to be sucesfully? Maybe I connect to another node of the cluster or some concurrency issue?
Or this can be an issue on my cluster?

Can you confirm that it is better to wait for the subscriber before sending the message? I know that this is probably a not real world scenario, but...