### PR TITLE
Fixed resend functionality.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -150,7 +150,7 @@ function MqttClient (streamBuilder, options) {
         }
 
         // Avoid unnecessary stream read operations when disconnected
-        if (!that.disconnecting && !that.reconnectTimer && that.options.reconnectPeriod > 0) {
+        if (!that.disconnecting && !that.reconnectTimer) {
           outStore.read(0)
           cb = that.outgoing[packet.messageId]
           that.outgoing[packet.messageId] = function (err, status) {
@@ -796,9 +796,15 @@ MqttClient.prototype._sendPacket = function (packet, cb) {
   // When sending a packet, reschedule the ping timer
   this._shiftPingInterval()
 
-  if (packet.cmd !== 'publish') {
-    sendPacket(this, packet, cb)
-    return
+  switch (packet.cmd) {
+    case 'publish':
+      break
+    case 'pubrel':
+      storeAndSend(this, packet, cb)
+      return
+    default:
+      sendPacket(this, packet, cb)
+      return
   }
 
   switch (packet.qos) {

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -2183,6 +2183,146 @@ module.exports = function (server, config) {
       })
     })
 
+    it('should resend in-flight QoS 1 publish messages from the client if clean is false', function (done) {
+      var reconnect = false
+      var client = {}
+      var incomingStore = new mqtt.Store({ clean: false })
+      var outgoingStore = new mqtt.Store({ clean: false })
+      var server2 = new Server(function (c) {
+        c.on('connect', function (packet) {
+          c.connack({returnCode: 0})
+        })
+        c.on('publish', function (packet) {
+          if (reconnect) {
+            server2.close()
+            done()
+          } else {
+            client.end(true, function () {
+              client.reconnect({
+                incomingStore: incomingStore,
+                outgoingStore: outgoingStore
+              })
+              reconnect = true
+            })
+          }
+        })
+      })
+
+      server2.listen(port + 50, function () {
+        client = mqtt.connect({
+          port: port + 50,
+          host: 'localhost',
+          clean: false,
+          clientId: 'cid1',
+          reconnectPeriod: 0,
+          incomingStore: incomingStore,
+          outgoingStore: outgoingStore
+        })
+
+        client.on('connect', function () {
+          if (!reconnect) {
+            client.publish('topic', 'payload', {qos: 1})
+          }
+        })
+        client.on('error', function () {})
+      })
+    })
+
+    it('should resend in-flight QoS 2 publish messages from the client if clean is false', function (done) {
+      var reconnect = false
+      var client = {}
+      var incomingStore = new mqtt.Store({ clean: false })
+      var outgoingStore = new mqtt.Store({ clean: false })
+      var server2 = new Server(function (c) {
+        c.on('connect', function (packet) {
+          c.connack({returnCode: 0})
+        })
+        c.on('publish', function (packet) {
+          if (reconnect) {
+            server2.close()
+            done()
+          } else {
+            client.end(true, function () {
+              client.reconnect({
+                incomingStore: incomingStore,
+                outgoingStore: outgoingStore
+              })
+              reconnect = true
+            })
+          }
+        })
+      })
+
+      server2.listen(port + 50, function () {
+        client = mqtt.connect({
+          port: port + 50,
+          host: 'localhost',
+          clean: false,
+          clientId: 'cid1',
+          reconnectPeriod: 0,
+          incomingStore: incomingStore,
+          outgoingStore: outgoingStore
+        })
+
+        client.on('connect', function () {
+          if (!reconnect) {
+            client.publish('topic', 'payload', {qos: 2})
+          }
+        })
+        client.on('error', function () {})
+      })
+    })
+
+    it('should resend in-flight QoS 2 pubrel messages from the client if clean is false', function (done) {
+      var reconnect = false
+      var client = {}
+      var incomingStore = new mqtt.Store({ clean: false })
+      var outgoingStore = new mqtt.Store({ clean: false })
+      var server2 = new Server(function (c) {
+        c.on('connect', function (packet) {
+          c.connack({returnCode: 0})
+        })
+        c.on('publish', function (packet) {
+          if (!reconnect) {
+            c.pubrec({messageId: packet.messageId})
+          }
+        })
+        c.on('pubrel', function () {
+          if (reconnect) {
+            server2.close()
+            done()
+          } else {
+            client.end(true, function () {
+              client.reconnect({
+                incomingStore: incomingStore,
+                outgoingStore: outgoingStore
+              })
+              reconnect = true
+            })
+          }
+        })
+      })
+
+      server2.listen(port + 50, function () {
+        client = mqtt.connect({
+          port: port + 50,
+          host: 'localhost',
+          clean: false,
+          clientId: 'cid1',
+          reconnectPeriod: 0,
+          incomingStore: incomingStore,
+          outgoingStore: outgoingStore
+        })
+
+        client.on('connect', function () {
+          if (!reconnect) {
+            client.publish('topic', 'payload', {qos: 2})
+          }
+        })
+        client.on('error', function () {})
+      })
+    })
+
     it('should be able to pub/sub if reconnect() is called at close handler', function (done) {
       var client = connect({ reconnectPeriod: 0 })
       var tryReconnect = true


### PR DESCRIPTION
Even if reconnectPeriod is 0, client should resend publish/purel
packet when clean is false.
So I removed `that.options.reconnectPeriod > 0` guard condition from
the connect handler.

Added resend from pubrel functionality.
In the following scenario, resend message should be pubrel.

1. Client connects to the broker with clean session false.
2. Client publishes QoS 2 message.
3. Broker receives the message and send pubrec to the client.
4. Client receives the pubrec message and send pubrel to the broker.
5. Client disconnects from the broker.
6. Client reconnects to the broker.
7. Client receives connack from the broker.
8. Client should resend pubrel automatically.

When `_sendPacket()` is called, if the packet type is `pubrel` then
call `storeAndSend()` instead of `send`acket()`.

Added tests for them.