### PR TITLE
Fixed #854.

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -11,6 +11,8 @@ var defaultStoreOptions = {
   clean: true
 }
 
+var Map = require('es6-map')
+
 /**
  * In-memory implementation of the message store
  * This can actually be saved into files.
@@ -27,7 +29,7 @@ function Store (options) {
   // Defaults
   this.options = xtend(defaultStoreOptions, options)
 
-  this._inflights = {}
+  this._inflights = new Map()
 }
 
 /**
@@ -36,7 +38,7 @@ function Store (options) {
  *
  */
 Store.prototype.put = function (packet, cb) {
-  this._inflights[packet.messageId] = packet
+  this._inflights.set(packet.messageId, packet)
 
   if (cb) {
     cb()
@@ -51,14 +53,17 @@ Store.prototype.put = function (packet, cb) {
  */
 Store.prototype.createStream = function () {
   var stream = new Readable(streamsOpts)
-  var inflights = this._inflights
-  var ids = Object.keys(this._inflights)
   var destroyed = false
+  var values = []
   var i = 0
 
+  this._inflights.forEach(function (value, key) {
+    values.push(value)
+  })
+
   stream._read = function () {
-    if (!destroyed && i < ids.length) {
-      this.push(inflights[ids[i++]])
+    if (!destroyed && i < values.length) {
+      this.push(values[i++])
     } else {
       this.push(null)
     }
@@ -85,9 +90,9 @@ Store.prototype.createStream = function () {
  * deletes a packet from the store.
  */
 Store.prototype.del = function (packet, cb) {
-  packet = this._inflights[packet.messageId]
+  packet = this._inflights.get(packet.messageId)
   if (packet) {
-    delete this._inflights[packet.messageId]
+    this._inflights.delete(packet.messageId)
     cb(null, packet)
   } else if (cb) {
     cb(new Error('missing packet'))
@@ -100,7 +105,7 @@ Store.prototype.del = function (packet, cb) {
  * get a packet from the store.
  */
 Store.prototype.get = function (packet, cb) {
-  packet = this._inflights[packet.messageId]
+  packet = this._inflights.get(packet.messageId)
   if (packet) {
     cb(null, packet)
   } else if (cb) {

--- a/lib/store.js
+++ b/lib/store.js
@@ -11,6 +11,16 @@ var defaultStoreOptions = {
   clean: true
 }
 
+/**
+ * es6-map can preserve insertion order even if ES version is older.
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Description
+ * It should be noted that a Map which is a map of an object, especially
+ * a dictionary of dictionaries, will only map to the object's insertion
+ * order. In ES2015 this is ordered for objects but for older versions of
+ * ES, this may be random and not ordered.
+ *
+ */
 var Map = require('es6-map')
 
 /**

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "commist": "^1.0.0",
     "concat-stream": "^1.6.2",
     "end-of-stream": "^1.4.1",
+    "es6-map": "^0.1.5",
     "help-me": "^1.0.1",
     "inherits": "^2.0.3",
     "minimist": "^1.2.0",


### PR DESCRIPTION
Added preserving publish order functionality to `Store` using `es6-map`.

`es6-map` can preserve insertion order.
If target environment is ES6, `es6-map` is native ES6 Map, otherwise use
fallback implementation that has the same interface as ES6 Map.

Updated some tests that depends on Store's internal structure (_inflights).

Added test to check publish order when reconnects.