### PR TITLE
Supported `pause()` and `resume()` for `Store`'s stream.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -140,33 +140,20 @@ function MqttClient (streamBuilder, options) {
     outStore = this.outgoingStore.createStream()
 
     // Control of stored messages
-    outStore.once('readable', function () {
-      function storeDeliver () {
-        var packet = outStore.read(1)
-        var cb
-
-        if (!packet) {
-          return
-        }
-
-        // Avoid unnecessary stream read operations when disconnected
-        if (!that.disconnecting && !that.reconnectTimer) {
-          outStore.read(0)
-          cb = that.outgoing[packet.messageId]
-          that.outgoing[packet.messageId] = function (err, status) {
-            // Ensure that the original callback passed in to publish gets invoked
-            if (cb) {
-              cb(err, status)
-            }
-
-            storeDeliver()
+    outStore.on('data', function (packet) {
+      // Avoid unnecessary stream read operations when disconnected
+      if (!that.disconnecting && !that.reconnectTimer) {
+        var cb = that.outgoing[packet.messageId]
+        that.outgoing[packet.messageId] = function (err, status) {
+          // Ensure that the original callback passed in to publish gets invoked
+          if (cb) {
+            cb(err, status)
           }
-          that._sendPacket(packet)
-        } else if (outStore.destroy) {
-          outStore.destroy()
         }
+        that._sendPacket(packet)
+      } else if (outStore.destroy) {
+        outStore.destroy()
       }
-      storeDeliver()
     }).on('error', this.emit.bind(this, 'error'))
   })
 


### PR DESCRIPTION
If `pause()` and `resume()` can be used in `Store` implementation, it
is more flexible.
For example, `mqtt-level-store` can support preserving publish order
using `pause()` and `resume()`.

https://github.com/mcollina/mqtt-level-store

Here are the documentation of `pause()` and `resume()`.

https://nodejs.org/api/stream.html#stream_readable_pause
https://nodejs.org/api/stream.html#stream_readable_resume

According to the document, `pause()` and `resume()` work well with
'data' event, but not 'readable' event. So I replaced 'readable' with 'data'.