### PR TITLE
Add cb in removeOutgoingMessage function arg

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -667,7 +667,7 @@ MqttClient.prototype.end = function (force, cb) {
 MqttClient.prototype.removeOutgoingMessage = function (mid) {
   var cb = this.outgoing[mid]
   delete this.outgoing[mid]
-  this.outgoingStore.del({messageId: mid}, function () {
+  this.outgoingStore.del({messageId: mid}, function (cb) {
     cb(new Error('Message removed'))
   })
   return this


### PR DESCRIPTION
cb was missing in the removeOutgoingMessage which threw the below:

cb(new Error('Message removed'))
    ^

TypeError: cb is not a function