### PR TITLE
Delayed emit timing of `connect` event.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -129,9 +129,6 @@ function MqttClient (streamBuilder, options) {
   // Inflight callbacks
   this.outgoing = {}
 
-  // Function to emit `connect` event
-  this.connectEmitter = null
-
   // True if connection is first time.
   this.firstConnection = true
 
@@ -842,11 +839,7 @@ MqttClient.prototype._handleConnack = function (packet) {
 
   if (rc === 0) {
     this.reconnecting = false
-    var that = this
-    this.connectEmitter = function () {
-      that.emit('connect', packet)
-    }
-    this._onConnect()
+    this._onConnect(packet)
   } else if (rc > 0) {
     var err = new Error('Connection refused: ' + errors[rc])
     err.code = rc
@@ -1072,9 +1065,9 @@ MqttClient.prototype._resubscribe = function () {
  *
  * @api private
  */
-MqttClient.prototype._onConnect = function () {
+MqttClient.prototype._onConnect = function (packet) {
   if (this.disconnected) {
-    this.connectEmitter()
+    this.emit('connect', packet)
     return
   }
 
@@ -1089,7 +1082,7 @@ MqttClient.prototype._onConnect = function () {
   this.once('close', remove)
   outStore.on('end', function () {
     that.removeListener('close', remove)
-    that.connectEmitter()
+    that.emit('connect', packet)
   })
   outStore.on('error', function (err) {
     that.removeListener('close', remove)

--- a/lib/client.js
+++ b/lib/client.js
@@ -129,77 +129,17 @@ function MqttClient (streamBuilder, options) {
   // Inflight callbacks
   this.outgoing = {}
 
+  // Function to emit `connect` event
   this.connectEmitter = null
 
-  // Mark connected on connect
-  this._onConnect = function () {
-    if (this.disconnected) {
-      this.connectEmitter()
-      return
-    }
-
-    this.connected = true
-    var outStore = this.outgoingStore.createStream()
-
-    this.once('close', remove)
-    outStore.on('end', function () {
-      that.removeListener('close', remove)
-      that.connectEmitter()
-    })
-    outStore.on('error', function (err) {
-      that.removeListener('close', remove)
-      that.emit('error', err)
-    })
-
-    function remove () {
-      outStore.destroy()
-      outStore = null
-    }
-
-    function storeDeliver () {
-      // edge case, we wrapped this twice
-      if (!outStore) {
-        return
-      }
-
-      var packet = outStore.read(1)
-      var cb
-
-      if (!packet) {
-        // read when data is available in the future
-        outStore.once('readable', storeDeliver)
-        return
-      }
-
-      // Avoid unnecessary stream read operations when disconnected
-      if (!that.disconnecting && !that.reconnectTimer) {
-        cb = that.outgoing[packet.messageId]
-        that.outgoing[packet.messageId] = function (err, status) {
-          // Ensure that the original callback passed in to publish gets invoked
-          if (cb) {
-            cb(err, status)
-          }
-
-          storeDeliver()
-        }
-        that._sendPacket(packet)
-      } else if (outStore.destroy) {
-        outStore.destroy()
-      }
-    }
-
-    // start flowing
-    storeDeliver()
-  }
+  // True if connection is first time.
+  this.firstConnection = true
 
   // Mark disconnected on stream close
   this.on('close', function () {
     this.connected = false
     clearTimeout(this.connackTimer)
   })
-
-  // Setup ping timer
-  this.on('connect', this._setupPingTimer)
 
   // Send queued packets
   this.on('connect', function () {
@@ -227,23 +167,6 @@ function MqttClient (streamBuilder, options) {
     }
 
     deliver()
-  })
-
-  var firstConnection = true
-  // resubscribe
-  this.on('connect', function () {
-    if (!firstConnection &&
-        this.options.clean &&
-        Object.keys(this._resubscribeTopics).length > 0) {
-      if (this.options.resubscribe) {
-        this._resubscribeTopics.resubscribe = true
-        this.subscribe(this._resubscribeTopics)
-      } else {
-        this._resubscribeTopics = {}
-      }
-    }
-
-    firstConnection = false
   })
 
   // Clear ping timer
@@ -1123,6 +1046,95 @@ MqttClient.prototype._nextId = function () {
  */
 MqttClient.prototype.getLastMessageId = function () {
   return (this.nextId === 1) ? 65535 : (this.nextId - 1)
+}
+
+/**
+ * _resubscribe
+ * @api private
+ */
+MqttClient.prototype._resubscribe = function () {
+  if (!this.firstConnection &&
+      this.options.clean &&
+      Object.keys(this._resubscribeTopics).length > 0) {
+    if (this.options.resubscribe) {
+      this._resubscribeTopics.resubscribe = true
+      this.subscribe(this._resubscribeTopics)
+    } else {
+      this._resubscribeTopics = {}
+    }
+  }
+
+  this.firstConnection = false
+}
+
+/**
+ * _onConnect
+ *
+ * @api private
+ */
+MqttClient.prototype._onConnect = function () {
+  if (this.disconnected) {
+    this.connectEmitter()
+    return
+  }
+
+  var that = this
+
+  this._setupPingTimer()
+  this._resubscribe()
+
+  this.connected = true
+  var outStore = this.outgoingStore.createStream()
+
+  this.once('close', remove)
+  outStore.on('end', function () {
+    that.removeListener('close', remove)
+    that.connectEmitter()
+  })
+  outStore.on('error', function (err) {
+    that.removeListener('close', remove)
+    that.emit('error', err)
+  })
+
+  function remove () {
+    outStore.destroy()
+    outStore = null
+  }
+
+  function storeDeliver () {
+    // edge case, we wrapped this twice
+    if (!outStore) {
+      return
+    }
+
+    var packet = outStore.read(1)
+    var cb
+
+    if (!packet) {
+      // read when data is available in the future
+      outStore.once('readable', storeDeliver)
+      return
+    }
+
+    // Avoid unnecessary stream read operations when disconnected
+    if (!that.disconnecting && !that.reconnectTimer) {
+      cb = that.outgoing[packet.messageId]
+      that.outgoing[packet.messageId] = function (err, status) {
+        // Ensure that the original callback passed in to publish gets invoked
+        if (cb) {
+          cb(err, status)
+        }
+
+        storeDeliver()
+      }
+      that._sendPacket(packet)
+    } else if (outStore.destroy) {
+      outStore.destroy()
+    }
+  }
+
+  // start flowing
+  storeDeliver()
 }
 
 module.exports = MqttClient

--- a/lib/client.js
+++ b/lib/client.js
@@ -129,9 +129,12 @@ function MqttClient (streamBuilder, options) {
   // Inflight callbacks
   this.outgoing = {}
 
+  this.connectEmitter = null
+
   // Mark connected on connect
-  this.on('connect', function () {
+  this._onConnect = function () {
     if (this.disconnected) {
+      this.connectEmitter()
       return
     }
 
@@ -141,6 +144,7 @@ function MqttClient (streamBuilder, options) {
     this.once('close', remove)
     outStore.on('end', function () {
       that.removeListener('close', remove)
+      that.connectEmitter()
     })
     outStore.on('error', function (err) {
       that.removeListener('close', remove)
@@ -186,7 +190,7 @@ function MqttClient (streamBuilder, options) {
 
     // start flowing
     storeDeliver()
-  })
+  }
 
   // Mark disconnected on stream close
   this.on('close', function () {
@@ -915,7 +919,11 @@ MqttClient.prototype._handleConnack = function (packet) {
 
   if (rc === 0) {
     this.reconnecting = false
-    this.emit('connect', packet)
+    var that = this
+    this.connectEmitter = function () {
+      that.emit('connect', packet)
+    }
+    this._onConnect()
   } else if (rc > 0) {
     var err = new Error('Connection refused: ' + errors[rc])
     err.code = rc

--- a/lib/client.js
+++ b/lib/client.js
@@ -130,7 +130,7 @@ function MqttClient (streamBuilder, options) {
   this.outgoing = {}
 
   // True if connection is first time.
-  this.firstConnection = true
+  this._firstConnection = true
 
   // Mark disconnected on stream close
   this.on('close', function () {
@@ -1046,7 +1046,7 @@ MqttClient.prototype.getLastMessageId = function () {
  * @api private
  */
 MqttClient.prototype._resubscribe = function () {
-  if (!this.firstConnection &&
+  if (!this._firstConnection &&
       this.options.clean &&
       Object.keys(this._resubscribeTopics).length > 0) {
     if (this.options.resubscribe) {
@@ -1057,7 +1057,7 @@ MqttClient.prototype._resubscribe = function () {
     }
   }
 
-  this.firstConnection = false
+  this._firstConnection = false
 }
 
 /**

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -1044,6 +1044,73 @@ module.exports = function (server, config) {
         })
       })
     })
+
+    it('should keep message order', function (done) {
+      var publishCount = 0
+      var reconnect = false
+      var client = {}
+      var incomingStore = new mqtt.Store({ clean: false })
+      var outgoingStore = new mqtt.Store({ clean: false })
+      var server2 = new Server(function (c) {
+        // errors are not interesting for this test
+        // but they might happen on some platforms
+        c.on('error', function () {})
+
+        c.on('connect', function (packet) {
+          c.connack({returnCode: 0})
+        })
+        c.on('publish', function (packet) {
+          c.puback({messageId: packet.messageId})
+          if (reconnect) {
+            switch (publishCount++) {
+              case 0:
+                packet.payload.toString().should.equal('payload1')
+                break
+              case 1:
+                packet.payload.toString().should.equal('payload2')
+                break
+              case 2:
+                packet.payload.toString().should.equal('payload3')
+                server2.close()
+                done()
+                break
+            }
+          }
+        })
+      })
+
+      server2.listen(port + 50, function () {
+        client = mqtt.connect({
+          port: port + 50,
+          host: 'localhost',
+          clean: false,
+          clientId: 'cid1',
+          reconnectPeriod: 0,
+          incomingStore: incomingStore,
+          outgoingStore: outgoingStore
+        })
+
+        client.on('connect', function () {
+          if (!reconnect) {
+            client.publish('topic', 'payload1', {qos: 1})
+            client.publish('topic', 'payload2', {qos: 1})
+            client.end(true)
+          } else {
+            client.publish('topic', 'payload3', {qos: 1})
+          }
+        })
+        client.on('close', function () {
+          if (!reconnect) {
+            client.reconnect({
+              clean: false,
+              incomingStore: incomingStore,
+              outgoingStore: outgoingStore
+            })
+            reconnect = true
+          }
+        })
+      })
+    })
   })
 
   describe('unsubscribing', function () {


### PR DESCRIPTION
Emit `connect` event after processing of `outgoingStore` is completed.

Problem:
When client publish new message during proccessing of publish/pubrel messages in `outgoingStore`, the newly published message interrupts the process. As a result, messages are not sent by published time order.

Outcomes:
Above message order problem is fixed by this commit. Added unit test verifies this case.