### PR TITLE
Add new callback called when message is put into `outgoingStore`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ and connections
 
 -------------------------------------------------------
 <a name="publish"></a>
-### mqtt.Client#publish(topic, message, [options], [callback], [cbStorePut])
+### mqtt.Client#publish(topic, message, [options], [callback])
 
 Publish a message to a topic
 
@@ -362,9 +362,9 @@ Publish a message to a topic
     * `userProperties`: The User Property is allowed to appear multiple times to represent multiple name, value pairs `object`,
     * `subscriptionIdentifier`: representing the identifier of the subscription `number`,
     * `contentType`: String describing the content of the Application Message `string`
+  * `cbStorePut` - `function ()`, fired when message is put into `outgoingStore` if QoS is `1` or `2`.
 * `callback` - `function (err)`, fired when the QoS handling completes,
   or at the next tick if QoS 0. An error occurs if client is disconnecting.
-* `cbStorePut` - `function ()`, fired when message is put into `outgoingStore` if QoS is `1` or `2`.
 
 -------------------------------------------------------
 <a name="subscribe"></a>

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ and connections
 
 -------------------------------------------------------
 <a name="publish"></a>
-### mqtt.Client#publish(topic, message, [options], [callback])
+### mqtt.Client#publish(topic, message, [options], [callback], [cbStorePut])
 
 Publish a message to a topic
 
@@ -364,6 +364,7 @@ Publish a message to a topic
     * `contentType`: String describing the content of the Application Message `string`
 * `callback` - `function (err)`, fired when the QoS handling completes,
   or at the next tick if QoS 0. An error occurs if client is disconnecting.
+* `cbStorePut` - `function ()`, fired when message is put into `outgoingStore` if QoS is `1` or `2`.
 
 -------------------------------------------------------
 <a name="subscribe"></a>

--- a/lib/client.js
+++ b/lib/client.js
@@ -374,10 +374,9 @@ MqttClient.prototype._checkDisconnecting = function (callback) {
  *    {Number} qos - qos level to publish on
  *    {Boolean} retain - whether or not to retain the message
  *    {Boolean} dup - whether or not mark a message as duplicate
+ *    {Function} cbStorePut - function(){} called when message is put into `outgoingStore`
  * @param {Function} [callback] - function(err){}
  *    called when publish succeeds or fails
- * @param {Function} [cbStorePut] - function(){}
- *    called when message is put into outgoingStore
  * @returns {MqttClient} this - for chaining
  * @api public
  *
@@ -386,7 +385,7 @@ MqttClient.prototype._checkDisconnecting = function (callback) {
  *     client.publish('topic', 'message', {qos: 1, retain: true, dup: true});
  * @example client.publish('topic', 'message', console.log);
  */
-MqttClient.prototype.publish = function (topic, message, opts, callback, cbStorePut) {
+MqttClient.prototype.publish = function (topic, message, opts, callback) {
   var packet
   var options = this.options
 
@@ -434,10 +433,10 @@ MqttClient.prototype.publish = function (topic, message, opts, callback, cbStore
     case 2:
       // Add to callbacks
       this.outgoing[packet.messageId] = callback || nop
-      this._sendPacket(packet, undefined, cbStorePut)
+      this._sendPacket(packet, undefined, opts.cbStorePut)
       break
     default:
-      this._sendPacket(packet, callback, cbStorePut)
+      this._sendPacket(packet, callback, opts.cbStorePut)
       break
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -99,11 +99,12 @@ function flush (queue) {
   }
 }
 
-function storeAndSend (client, packet, cb) {
+function storeAndSend (client, packet, cb, cbStorePut) {
   client.outgoingStore.put(packet, function storedPacket (err) {
     if (err) {
       return cb && cb(err)
     }
+    cbStorePut()
     sendPacket(client, packet, cb)
   })
 }
@@ -375,6 +376,8 @@ MqttClient.prototype._checkDisconnecting = function (callback) {
  *    {Boolean} dup - whether or not mark a message as duplicate
  * @param {Function} [callback] - function(err){}
  *    called when publish succeeds or fails
+ * @param {Function} [cbStorePut] - function(){}
+ *    called when message is put into outgoingStore
  * @returns {MqttClient} this - for chaining
  * @api public
  *
@@ -383,7 +386,7 @@ MqttClient.prototype._checkDisconnecting = function (callback) {
  *     client.publish('topic', 'message', {qos: 1, retain: true, dup: true});
  * @example client.publish('topic', 'message', console.log);
  */
-MqttClient.prototype.publish = function (topic, message, opts, callback) {
+MqttClient.prototype.publish = function (topic, message, opts, callback, cbStorePut) {
   var packet
   var options = this.options
 
@@ -429,13 +432,12 @@ MqttClient.prototype.publish = function (topic, message, opts, callback) {
   switch (opts.qos) {
     case 1:
     case 2:
-
       // Add to callbacks
       this.outgoing[packet.messageId] = callback || nop
-      this._sendPacket(packet)
+      this._sendPacket(packet, undefined, cbStorePut)
       break
     default:
-      this._sendPacket(packet, callback)
+      this._sendPacket(packet, callback, cbStorePut)
       break
   }
 
@@ -868,9 +870,12 @@ MqttClient.prototype._cleanUp = function (forced, done) {
  * @param {String} type - packet type (see `protocol`)
  * @param {Object} packet - packet options
  * @param {Function} cb - callback when the packet is sent
+ * @param {Function} cbStorePut - called when message is put into outgoingStore
  * @api private
  */
-MqttClient.prototype._sendPacket = function (packet, cb) {
+MqttClient.prototype._sendPacket = function (packet, cb, cbStorePut) {
+  cbStorePut = cbStorePut || nop
+
   if (!this.connected) {
     if (((packet.qos || 0) === 0 && this.queueQoSZero) || packet.cmd !== 'publish') {
       this.queue.push({ packet: packet, cb: cb })
@@ -880,6 +885,7 @@ MqttClient.prototype._sendPacket = function (packet, cb) {
         if (err) {
           return cb && cb(err)
         }
+        cbStorePut()
       })
     } else if (cb) {
       cb(new Error('No connection to broker'))
@@ -895,7 +901,7 @@ MqttClient.prototype._sendPacket = function (packet, cb) {
     case 'publish':
       break
     case 'pubrel':
-      storeAndSend(this, packet, cb)
+      storeAndSend(this, packet, cb, cbStorePut)
       return
     default:
       sendPacket(this, packet, cb)
@@ -905,7 +911,7 @@ MqttClient.prototype._sendPacket = function (packet, cb) {
   switch (packet.qos) {
     case 2:
     case 1:
-      storeAndSend(this, packet, cb)
+      storeAndSend(this, packet, cb, cbStorePut)
       break
     /**
      * no need of case here since it will be caught by default

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -1232,14 +1232,17 @@ module.exports = function (server, config) {
       })
 
       var callbacks = []
+
+      function cbStorePut () {
+        callbacks.push('storeput')
+      }
+
       client.on('connect', function () {
-        client.publish('test', 'test', {qos: qos}, function (err) {
+        client.publish('test', 'test', {qos: qos, cbStorePut: cbStorePut}, function (err) {
           if (err) done(err)
           callbacks.push('publish')
           should.deepEqual(callbacks, expected)
           done()
-        }, function () {
-          callbacks.push('storeput') // do not call
         })
         client.end()
       })

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -1224,6 +1224,45 @@ module.exports = function (server, config) {
         })
       })
     })
+
+    function testCallbackStorePutByQoS (qos, clean, expected, done) {
+      var client = connect({
+        clean: clean,
+        clientId: 'testId'
+      })
+
+      var callbacks = []
+      client.on('connect', function () {
+        client.publish('test', 'test', {qos: qos}, function (err) {
+          if (err) done(err)
+          callbacks.push('publish')
+          should.deepEqual(callbacks, expected)
+          done()
+        }, function () {
+          callbacks.push('storeput') // do not call
+        })
+        client.end()
+      })
+    }
+
+    it('should not call cbStorePut when publishing message with QoS `0` and clean `true`', function (done) {
+      testCallbackStorePutByQoS(0, true, ['publish'], done)
+    })
+    it('should not call cbStorePut when publishing message with QoS `0` and clean `false`', function (done) {
+      testCallbackStorePutByQoS(0, false, ['publish'], done)
+    })
+    it('should call cbStorePut before publish completes when publishing message with QoS `1` and clean `true`', function (done) {
+      testCallbackStorePutByQoS(1, true, ['storeput', 'publish'], done)
+    })
+    it('should call cbStorePut before publish completes when publishing message with QoS `1` and clean `false`', function (done) {
+      testCallbackStorePutByQoS(1, false, ['storeput', 'publish'], done)
+    })
+    it('should call cbStorePut before publish completes when publishing message with QoS `2` and clean `true`', function (done) {
+      testCallbackStorePutByQoS(2, true, ['storeput', 'publish'], done)
+    })
+    it('should call cbStorePut before publish completes when publishing message with QoS `2` and clean `false`', function (done) {
+      testCallbackStorePutByQoS(2, false, ['storeput', 'publish'], done)
+    })
   })
 
   describe('unsubscribing', function () {

--- a/types/lib/client.d.ts
+++ b/types/lib/client.d.ts
@@ -71,6 +71,7 @@ export declare type OnMessageCallback = (topic: string, payload: Buffer, packet:
 export declare type OnPacketCallback = (packet: Packet) => void
 export declare type OnErrorCallback = (error: Error) => void
 export declare type PacketCallback = (error?: Error, packet?: Packet) => any
+export declare type StorePutCallback = () => void
 export declare type CloseCallback = () => void
 
 export interface IStream extends events.EventEmitter {
@@ -121,6 +122,9 @@ export declare class MqttClient extends events.EventEmitter {
    *
    * @param {Function} [callback] - function(err){}
    *    called when publish succeeds or fails
+   *
+   * @param {Function} [cbStorePut] - function(){}
+   *    called when message is put into outgoingStore
    * @returns {Client} this - for chaining
    * @api public
    *
@@ -130,9 +134,9 @@ export declare class MqttClient extends events.EventEmitter {
    * @example client.publish('topic', 'message', console.log)
    */
   public publish (topic: string, message: string | Buffer,
-                 opts: IClientPublishOptions, callback?: PacketCallback): this
+                 opts: IClientPublishOptions, callback?: PacketCallback, cbStorePut?: StorePutCallback): this
   public publish (topic: string, message: string | Buffer,
-                 callback?: PacketCallback): this
+                 callback?: PacketCallback, cbStorePut?: StorePutCallback): this
 
   /**
    * subscribe - subscribe to <topic>


### PR DESCRIPTION
Added new callback `cbStorePut` to `publish()`. `cbStorePut` is called when message is put into `outgoingStore`.

Problem:
When disconnection occures right after `publish()` but `callback` is not called, then reconnect, client can't know if the message is completely stored into `outgoingStore`.

Outcome:
This commit fixes above problem.
Client can know that message has been put into `outgoingStore` when `cbStorePut` is called.