### PR TITLE
fix: delete completed incoming QOS 2 messages

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1215,18 +1215,14 @@ MqttClient.prototype._handlePubrel = function (packet, callback) {
   var comp = {cmd: 'pubcomp', messageId: mid}
 
   that.incomingStore.get(packet, function (err, pub) {
-    if (!err && pub.cmd !== 'pubrel') {
+    if (!err) {
       that.emit('message', pub.topic, pub.payload, pub)
       that.handleMessage(pub, function (err) {
         if (err) {
           return callback(err)
         }
-        that._sendPacket(comp, function (err) {
-          if (err) {
-            return callback(err)
-          }
-          that.incomingStore.del(packet, callback)
-        })
+        that.incomingStore.del(pub, nop)
+        that._sendPacket(comp, callback)
       })
     } else {
       that._sendPacket(comp, callback)

--- a/lib/client.js
+++ b/lib/client.js
@@ -1217,15 +1217,15 @@ MqttClient.prototype._handlePubrel = function (packet, callback) {
   that.incomingStore.get(packet, function (err, pub) {
     if (!err && pub.cmd !== 'pubrel') {
       that.emit('message', pub.topic, pub.payload, pub)
-      that.incomingStore.del(packet, function (err) {
+      that.handleMessage(pub, function (err) {
         if (err) {
           return callback(err)
         }
-        that.handleMessage(pub, function (err) {
+        that._sendPacket(comp, function (err) {
           if (err) {
             return callback(err)
           }
-          that._sendPacket(comp, callback)
+          that.incomingStore.del(packet, callback)
         })
       })
     } else {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1217,7 +1217,7 @@ MqttClient.prototype._handlePubrel = function (packet, callback) {
   that.incomingStore.get(packet, function (err, pub) {
     if (!err && pub.cmd !== 'pubrel') {
       that.emit('message', pub.topic, pub.payload, pub)
-      that.incomingStore.put(packet, function (err) {
+      that.incomingStore.del(packet, function (err) {
         if (err) {
           return callback(err)
         }

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -1008,7 +1008,7 @@ module.exports = function (server, config) {
           return new AsyncStore()
         }
       }
-      AsyncStore.prototype.put = function (packet, cb) {
+      AsyncStore.prototype.del = function (packet, cb) {
         process.nextTick(function () {
           cb(new Error('Error'))
         })
@@ -1031,15 +1031,15 @@ module.exports = function (server, config) {
     })
 
     it('should handle success with async incoming store in QoS 2 `handlePubrel` method', function (done) {
-      var putComplete = false
+      var delComplete = false
       function AsyncStore () {
         if (!(this instanceof AsyncStore)) {
           return new AsyncStore()
         }
       }
-      AsyncStore.prototype.put = function (packet, cb) {
+      AsyncStore.prototype.del = function (packet, cb) {
         process.nextTick(function () {
-          putComplete = true
+          delComplete = true
           cb(null)
         })
       }
@@ -1055,7 +1055,7 @@ module.exports = function (server, config) {
         messageId: 1,
         qos: 2
       }, function () {
-        putComplete.should.equal(true)
+        delComplete.should.equal(true)
         done()
         client.end()
       })


### PR DESCRIPTION
I ran into an issue where my store was being filled with incoming QOS 2 messages, even though those messages had completed the QOS 2 handshake. If I understand the last point of `[MQTT-4.3.3-2]` in the MQTT spec correctly, the client should forget incoming QOS 2 messages once the `PUBCOMP` message has been sent.

@mcollina I noticed you also saw this issue when [you commented that this put should be a delete](https://github.com/mqttjs/MQTT.js/pull/416#discussion_r65729673). Do you know of any issues doing so could cause?