### PR TITLE
Fix offline publish message interrupt.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -168,6 +168,8 @@ function MqttClient (streamBuilder, options) {
   this.connackTimer = null
   // Reconnect timer
   this.reconnectTimer = null
+  // Is processing store?
+  this.storeProcessing = false
   /**
    * MessageIDs starting with 1
    * ensure that nextId is min. 1, see https://github.com/mqttjs/MQTT.js/issues/810
@@ -433,10 +435,18 @@ MqttClient.prototype.publish = function (topic, message, opts, callback) {
     case 2:
       // Add to callbacks
       this.outgoing[packet.messageId] = callback || nop
-      this._sendPacket(packet, undefined, opts.cbStorePut)
+      if (this.storeProcessing) {
+        this._storePacket(packet, undefined, opts.cbStorePut)
+      } else {
+        this._sendPacket(packet, undefined, opts.cbStorePut)
+      }
       break
     default:
-      this._sendPacket(packet, callback, opts.cbStorePut)
+      if (this.storeProcessing) {
+        this._storePacket(packet, callback, opts.cbStorePut)
+      } else {
+        this._sendPacket(packet, callback, opts.cbStorePut)
+      }
       break
   }
 
@@ -880,20 +890,7 @@ MqttClient.prototype._sendPacket = function (packet, cb, cbStorePut) {
   cbStorePut = cbStorePut || nop
 
   if (!this.connected) {
-    if (((packet.qos || 0) === 0 && this.queueQoSZero) || packet.cmd !== 'publish') {
-      this.queue.push({ packet: packet, cb: cb })
-    } else if (packet.qos > 0) {
-      cb = this.outgoing[packet.messageId]
-      this.outgoingStore.put(packet, function (err) {
-        if (err) {
-          return cb && cb(err)
-        }
-        cbStorePut()
-      })
-    } else if (cb) {
-      cb(new Error('No connection to broker'))
-    }
-
+    this._storePacket(packet, cb, cbStorePut)
     return
   }
 
@@ -926,6 +923,32 @@ MqttClient.prototype._sendPacket = function (packet, cb, cbStorePut) {
     default:
       sendPacket(this, packet, cb)
       break
+  }
+}
+
+/**
+ * _storePacket - queue a packet
+ * @param {String} type - packet type (see `protocol`)
+ * @param {Object} packet - packet options
+ * @param {Function} cb - callback when the packet is sent
+ * @param {Function} cbStorePut - called when message is put into outgoingStore
+ * @api private
+ */
+MqttClient.prototype._storePacket = function (packet, cb, cbStorePut) {
+  cbStorePut = cbStorePut || nop
+
+  if (((packet.qos || 0) === 0 && this.queueQoSZero) || packet.cmd !== 'publish') {
+    this.queue.push({ packet: packet, cb: cb })
+  } else if (packet.qos > 0) {
+    cb = this.outgoing[packet.messageId]
+    this.outgoingStore.put(packet, function (err) {
+      if (err) {
+        return cb && cb(err)
+      }
+      cbStorePut()
+    })
+  } else if (cb) {
+    cb(new Error('No connection to broker'))
   }
 }
 
@@ -1296,10 +1319,12 @@ MqttClient.prototype._onConnect = function (packet) {
 
   this.once('close', remove)
   outStore.on('end', function () {
+    that.storeProcessing = false
     that.removeListener('close', remove)
     that.emit('connect', packet)
   })
   outStore.on('error', function (err) {
+    that.storeProcessing = false
     that.removeListener('close', remove)
     that.emit('error', err)
   })
@@ -1314,6 +1339,7 @@ MqttClient.prototype._onConnect = function (packet) {
     if (!outStore) {
       return
     }
+    that.storeProcessing = true
 
     var packet = outStore.read(1)
     var cb

--- a/lib/store.js
+++ b/lib/store.js
@@ -6,7 +6,7 @@
 var xtend = require('xtend')
 
 var Readable = require('readable-stream').Readable
-var streamsOpts = { objectMode: true }
+var streamsOpts = { objectMode: true, highWaterMark: 1 }
 var defaultStoreOptions = {
   clean: true
 }
@@ -64,18 +64,18 @@ Store.prototype.put = function (packet, cb) {
 Store.prototype.createStream = function () {
   var stream = new Readable(streamsOpts)
   var destroyed = false
-  var values = []
-  var i = 0
-
-  this._inflights.forEach(function (value, key) {
-    values.push(value)
-  })
+  var it = this._inflights.values()
 
   stream._read = function () {
-    if (!destroyed && i < values.length) {
-      this.push(values[i++])
-    } else {
+    if (destroyed) {
       this.push(null)
+    } else {
+      var result = it.next()
+      if (result.done) {
+        this.push(null)
+      } else {
+        this.push(result.value)
+      }
     }
   }
 


### PR DESCRIPTION
This pull request fixes the following case:

1. When client does offline publish as QoS 1 or 2, the packets are stored.
2. Then the client connects to the broker.
3. The client receives `connack` packet.
4. Then the client's internal state `connected` set to true.
5. Start `storeDeliver()` sequence that sends the stored publish messages.
6. The user code call `publish()`.
7. The publish function calls `_sendPacket()`.
8. `_sendPacket()` checks `connected` state, and it is true.
9. Then send publish message. This is interrupted message.
10. `storeDeliver()` seqence sends the next stored publish message.

In order to fix the problem, I introduced `storeProcessing` state. This state is true during `storeDeliver()` sequence processing. This state is checked when `publish()` is called. If the state is true, then call `_storePacket()` instead of `_sendPacket(). `_storePacket()` is for store only.

However, this is not enough.
`store`'s `createStream()` uses the snapshot of the store. See https://github.com/mqttjs/MQTT.js/blob/master/lib/store.js#L67
It is not good because the newly stored message during store processing has no chance to send. So I replaced the snapshot approach with the iteratoro approach for `store`. The iterator approach reflects up-to-date `store`. That means the new message that is added during store processing is sent as expected.
