### PR TITLE
perform nextTick work only if work needs to be done

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -256,7 +256,13 @@ MqttClient.prototype._setupStream = function () {
   })
 
   function nextTickWork () {
-    process.nextTick(work)
+    if (packets.length) {
+      process.nextTick(work)
+    } else {
+      var done = completeParse
+      completeParse = null
+      done()
+    }
   }
 
   function work () {

--- a/lib/client.js
+++ b/lib/client.js
@@ -267,13 +267,13 @@ MqttClient.prototype._setupStream = function () {
 
   function work () {
     var packet = packets.shift()
-    var done = completeParse
 
     if (packet) {
       that._handlePacket(packet, nextTickWork)
     } else {
+      var done = completeParse
       completeParse = null
-      done()
+      if (done) done()
     }
   }
 


### PR DESCRIPTION
This addresses the memory leak discussed in issue #791 
Alongside, it is more efficient as timer objects are created only if it's necessary.
