### PR TITLE
Clear `outgoing` on close.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -290,6 +290,7 @@ MqttClient.prototype._setupStream = function () {
 
   // Echo stream close
   this.stream.on('close', function () {
+    that.outgoing = {}
     that.emit('close')
   })
 


### PR DESCRIPTION
If `outgoing` was is cleared on close from the server, there is no
chance to call callbacks in `outgoing`. `outgoing` entries exist
invalidly after closing.

That prevents `end` function. In the `end` function, if `force` is not
set and `outgoing` exists, then wait `outgoingEmpty` event. However,
the event never happen because previous entries are not removed.

This update fixes the problem.