### PR TITLE
fix: set default servername in tls connect

### DIFF
--- a/lib/connect/tls.js
+++ b/lib/connect/tls.js
@@ -5,6 +5,7 @@ function buildBuilder (mqttClient, opts) {
   var connection
   opts.port = opts.port || 8883
   opts.host = opts.hostname || opts.host || 'localhost'
+  opts.servername = opts.servername || opts.host
 
   opts.rejectUnauthorized = opts.rejectUnauthorized !== false
 

--- a/test/secure_client.js
+++ b/test/secure_client.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var mqtt = require('..')
+var should = require('should')
 var path = require('path')
 var abstractClientTests = require('./abstract_client')
 var fs = require('fs')
@@ -152,6 +153,48 @@ describe('MqttSecureClient', function () {
       client.once('close', function () {
         done()
       })
+    })
+
+    it('should request the hostname as servername by default', function (done) {
+      var host = '127.0.0.1'
+
+      server.once('secureConnection', function (socket) {
+        should(socket.servername).be.equal(host)
+        socket.end()
+        done()
+      })
+
+      var client = mqtt.connect({
+        protocol: 'mqtts',
+        port: port,
+        host: host,
+        ca: [fs.readFileSync(CERT)],
+        rejectUnauthorized: true
+      })
+
+      client.on('error', function () {})
+      client.on('close', function () {})
+    })
+
+    it('should request the servername', function (done) {
+      var servername = 'some.example.com'
+
+      server.once('secureConnection', function (socket) {
+        should(socket.servername).be.equal(servername)
+        socket.end()
+        done()
+      })
+
+      var client = mqtt.connect({
+        protocol: 'mqtts',
+        port: port,
+        servername: servername,
+        ca: [fs.readFileSync(CERT)],
+        rejectUnauthorized: true
+      })
+
+      client.on('error', function () {})
+      client.on('close', function () {})
     })
   })
 })


### PR DESCRIPTION
Hey there,

I figured the best way to start this discussion was with a PR.

I have a scenario where I'm trying to talk to an MQTT broker that's behind a proxy. This proxy is performing SSL/TLS passthrough. Having read into [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) I discovered the `servername` option in the options for [tls.connect](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback).

I found that the only way to connect was by explicitly setting `servername` to the same value as `host` (the hostname for the proxy).

I'm wondering does it make any sense to set that as a default for convenience? Feel free to reject in any case 🙂