### PR TITLE
The protocols parameter of wx.connectSocket should be Array.

### DIFF
--- a/lib/connect/wx.js
+++ b/lib/connect/wx.js
@@ -99,7 +99,7 @@ function buildStream (client, opts) {
   var url = buildUrl(opts, client)
   socketTask = wx.connectSocket({
     url: url,
-    protocols: websocketSubProtocol
+    protocols: [websocketSubProtocol]
   })
 
   proxy = buildProxy()


### PR DESCRIPTION
Wechat mini app document url:
https://developers.weixin.qq.com/miniprogram/dev/api/network/websocket/wx.connectSocket.html.

If the protocols value is 'mqtt' instead of ['mqtt'], it will be failed if
you use the android device, the interesting thing is iOS works.

Both android and ios works if the value is an array.