### PR TITLE
Add protocol string to array

### DIFF
--- a/lib/connect/wx.js
+++ b/lib/connect/wx.js
@@ -99,7 +99,7 @@ function buildStream (client, opts) {
   var url = buildUrl(opts, client)
   socketTask = wx.connectSocket({
     url: url,
-    protocols: websocketSubProtocol
+    protocols: [websocketSubProtocol]
   })
 
   proxy = buildProxy()


### PR DESCRIPTION
Fixes issue #987 

The protocol is now added to an array inside the `wx.connectSocket` function call.