### PR TITLE
Add check to ssl error handler to allow clean reconnect on non-ssl errors. Fixes #614

### DIFF
--- a/lib/connect/tls.js
+++ b/lib/connect/tls.js
@@ -21,8 +21,12 @@ function buildBuilder (mqttClient, opts) {
   })
 
   function handleTLSerrors (err) {
-    // How can I get verify this error is a tls error?
-    if (opts.rejectUnauthorized) {
+    // Allow connection errors
+    if (opts.rejectUnauthorized &&
+      (err.code !== 'ECONNREFUSED' ||
+       err.code !== 'ECONNRESET' ||
+       err.code !== 'ECONNABORTED')
+    ) {
       mqttClient.emit('error', err)
     }
 


### PR DESCRIPTION
This is a pretty simple PR to address #614. Basically during the reconn cycle for tls connections an error is thrown regardless of its reason if `rejectUnauthorized` is set to true.

The solution is to allow the common connection error types to not throw an error which is in parity with the code in `tcp.js`.