### PR TITLE
feature: add secureOptions to ISecureClientOptions for TLS

### DIFF
--- a/test/secure_client.js
+++ b/test/secure_client.js
@@ -72,7 +72,7 @@ var server = new Server.SecureServer({
 }).listen(port)
 
 describe('MqttSecureClient', function () {
-  var config = { protocol: 'mqtts', port: port, rejectUnauthorized: false }
+  var config = { protocol: 'mqtts', port: port, rejectUnauthorized: false, secureContext: {} }
   abstractClientTests(server, config)
 
   describe('with secure parameters', function () {
@@ -150,6 +150,26 @@ describe('MqttSecureClient', function () {
 
       // TODO node v0.8.x emits multiple close events
       client.once('close', function () {
+        done()
+      })
+    })
+
+    it('should pass the secureContext to the TLS layer', function (done) {
+      var secureContext = { fakeContext: 'fakeValue' }
+      
+      var client = mqtt.connect({
+        protocol: 'mqtts',
+        port: port,
+        ca: [fs.readFileSync(CERT)],
+        rejectUnauthorized: true,
+        secureContext: secureContext
+      })
+
+      client.on('error', function (err) {
+        done(err)
+      })
+
+      server.once('connect', function () {
         done()
       })
     })

--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -125,15 +125,15 @@ export interface ISecureClientOptions {
    */
   cert?: string | string[] | Buffer | Buffer[]
   /**
-   * Optionally override the trusted CA certificates in PEM format
+   * optionally override the trusted CA certificates in PEM format
    */
   ca?: string | string[] | Buffer | Buffer[]
   /**
-   * Optionally override the TLS configuration to by default validate through trusted CA
+   * optionally override the TLS configuration to by default validate through trusted CA
    */
   rejectUnauthorized?: boolean
   /**
-   * Optionally affect OpenSSL protocol behavior through TLS options
+   * optionally affect OpenSSL protocol behavior through TLS options
    */
   secureOptions?: number
 

--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -133,9 +133,9 @@ export interface ISecureClientOptions {
    */
   rejectUnauthorized?: boolean
   /**
-   * optionally affect OpenSSL protocol behavior through TLS options
+   * optionally override default TLS security options
    */
-  secureOptions?: number
+  secureContext?: Object
 
 }
 export interface IClientPublishOptions {

--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -129,7 +129,7 @@ export interface ISecureClientOptions {
    */
   ca?: string | string[] | Buffer | Buffer[]
   /**
-   * optionally override the TLS configuration to by default validate through trusted CA
+   * optionally override the TLS configuration to not validate the trusted CA
    */
   rejectUnauthorized?: boolean
   /**

--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -128,7 +128,15 @@ export interface ISecureClientOptions {
    * Optionally override the trusted CA certificates in PEM format
    */
   ca?: string | string[] | Buffer | Buffer[]
+  /**
+   * Optionally override the TLS configuration to by default validate through trusted CA
+   */
   rejectUnauthorized?: boolean
+  /**
+   * Optionally affect OpenSSL protocol behavior through TLS options
+   */
+  secureOptions?: number
+
 }
 export interface IClientPublishOptions {
   /**


### PR DESCRIPTION
This PR addresses adding secureOptions to ISecureClientOptions. This addition gives the interface the ability to accept secureOptions for TLS, including TLS version enforcement and cipher suite lists.

MQTT over TLS does not currently support adding TLS secureOptions on connect, so this is a new that improves our ability to control security on the MQTT client..