### PR TITLE
refactor: websocket-stream to ws 

### DIFF
--- a/lib/connect/ws.js
+++ b/lib/connect/ws.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var websocket = require('websocket-stream')
+var WebSocket = require('ws')
 var urlModule = require('url')
 var WSS_OPTIONS = [
   'rejectUnauthorized',
@@ -56,7 +56,9 @@ function createWebSocket (client, opts) {
 
   setDefaultOpts(opts)
   var url = buildUrl(opts, client)
-  return websocket(url, [websocketSubProtocol], opts.wsOptions)
+  // TODO (yodama): Add origin option to WebSocket connection to prevent Cross-Site WebSocket Hijacking
+  const ws = new WebSocket(url)
+  return WebSocket.createWebSocketStream(ws, { encoding: 'utf8' }, [websocketSubProtocol], opts.wsOptions)
 }
 
 function buildBuilder (client, opts) {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mqtt.js"
   ],
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=10.0.0"
   },
   "browser": {
     "./mqtt.js": "./lib/connect/index.js",
@@ -76,7 +76,7 @@
     "readable-stream": "^2.3.6",
     "reinterval": "^1.1.0",
     "split2": "^3.1.0",
-    "websocket-stream": "^5.1.2",
+    "ws": "^7.2.1",
     "xtend": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR removes the use of websocket-stream, an dinstead directly calls createWebsocketStream from the newer websocket API.