### PR TITLE
refactor: remove depedency on zuul

### DIFF
--- a/.airtaprc.yml
+++ b/.airtaprc.yml
@@ -1,3 +1,4 @@
+sauce_connect: true
 ui: mocha-bdd
 browsers:
   - name: chrome
@@ -7,4 +8,6 @@ browsers:
   - name: opera
     version: latest
   - name: internet explorer
+    version: latest
+  - name: microsoftedge
     version: latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ node_js:
 env:
 # For compiling optional extensions
 addons:
+  sauce_connect: true
   apt:
     sources:
       - ubuntu-toolchain-r-test

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "mocha": "^4.1.0",
     "mqtt-connection": "^4.0.0",
     "pre-commit": "^1.2.2",
+    "rimraf": "^3.0.2",
     "safe-buffer": "^5.1.2",
     "should": "^13.2.1",
     "sinon": "~1.17.7",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "typescript-compile-test": "tsc -p test/typescript/tsconfig.json",
     "typescript-compile-execute": "node test/typescript/*.js",
     "typescript-test": "npm run typescript-compile-test && npm run typescript-compile-execute",
-    "prepare": "npm run browser-build",
     "browser-build": "rimraf dist/ && mkdirp dist/ && browserify mqtt.js -s mqtt > dist/mqtt.js && uglifyjs < dist/mqtt.js > dist/mqtt.min.js",
-    "browser-test": "zuul --server test/browser/server.js --local --open test/browser/test.js",
-    "sauce-test": "zuul --server test/browser/server.js --tunnel ngrok -- test/browser/test.js",
+    "prepare": "npm run browser-build",
+    "browser-test": "airtap --server test/browser/server.js --local --open test/browser/test.js",
+    "sauce-test": "airtap --server test/browser/server.js -- test/browser/test.js",
     "ci": "npm run tslint && npm run typescript-compile-test && npm run test && codecov"
   },
   "pre-commit": [
@@ -81,6 +81,7 @@
   },
   "devDependencies": {
     "@types/node": "^10.0.0",
+    "airtap": "^3.0.0",
     "browserify": "^16.2.2",
     "codecov": "^3.0.4",
     "global": "^4.3.2",
@@ -89,7 +90,6 @@
     "mocha": "^4.1.0",
     "mqtt-connection": "^4.0.0",
     "pre-commit": "^1.2.2",
-    "rimraf": "^2.6.2",
     "safe-buffer": "^5.1.2",
     "should": "^13.2.1",
     "sinon": "~1.17.7",
@@ -100,9 +100,7 @@
     "tslint-config-standard": "^8.0.1",
     "typescript": "^3.2.2",
     "uglify-js": "^3.4.5",
-    "ws": "^3.3.3",
-    "zuul": "^3.12.0",
-    "zuul-ngrok": "^4.0.0"
+    "ws": "^3.3.3"
   },
   "standard": {
     "env": [

--- a/test/browser/server.js
+++ b/test/browser/server.js
@@ -122,11 +122,11 @@ function start (startPort, done) {
 }
 
 if (require.main === module) {
-  start(process.env.PORT || process.env.ZUUL_PORT, function (err) {
+  start(process.env.PORT || process.env.AIRTAP_PORT, function (err) {
     if (err) {
       console.error(err)
       return
     }
-    console.log('tunnelled server started on port', process.env.PORT || process.env.ZUUL_PORT)
+    console.log('tunnelled server started on port', process.env.PORT || process.env.AIRTAP_PORT)
   })
 }


### PR DESCRIPTION
Currently the support for zuul and ngrok are broken and npm install fails as a result. This removes those dependencies and upgrades our browser testing to airtap