### PR TITLE
fix: do not emit 'error' on client upon TLS connection failure

### DIFF
--- a/lib/connect/tls.js
+++ b/lib/connect/tls.js
@@ -20,12 +20,7 @@ function buildBuilder (mqttClient, opts) {
     }
   })
 
-  function handleTLSerrors (err) {
-    // How can I get verify this error is a tls error?
-    if (opts.rejectUnauthorized) {
-      mqttClient.emit('error', err)
-    }
-
+  function handleTLSerrors () {
     // close this connection to match the behaviour of net
     // otherwise all we get is an error from the connection
     // and close event doesn't fire. This is a work around


### PR DESCRIPTION
Closes #614  
Closes #996  

Currently an `error` is emitted on the `MqttClient` instance if
* `rejectUnauthorized` is set to `true`, and
* the TLS connection attempt fails for whatever reason.

This behavior is caused by the following:
https://github.com/mqttjs/MQTT.js/blob/98e9a464ac47e1d80e0499ca5c72747eb9bb193c/lib/connect/tls.js#L24-L27

There seems to be no good reason for doing this, especially since
* it breaks the auto-reconnect functionality for TLS connections;
* it is inconsistent with the way connection errors are handled on insecure TCP streams;
* it is inconsistent with the way errors are handled once the secure connection is established;
* using the `rejectUnauthorized` flag to drive behavior also when non-authentication errors occur is confusing;
* and since we terminate the connection afterwards using `connection.end()`, it also does not seem to enhance security in any way.

This PR removes this `if` statement, allowing the connection to be closed and then the auto-reconnect to happen as intended even if `rejectUnauthorized` is enabled.