### PR TITLE
Add support for SNI: Fixes #1049

### DIFF
--- a/lib/connect/tls.js
+++ b/lib/connect/tls.js
@@ -5,6 +5,7 @@ function buildBuilder (mqttClient, opts) {
   var connection
   opts.port = opts.port || 8883
   opts.host = opts.hostname || opts.host || 'localhost'
+  opts.servername = opts.host
 
   opts.rejectUnauthorized = opts.rejectUnauthorized !== false
 


### PR DESCRIPTION
Set `opts.servername` in lib/connect/tls.js

This enables connection to be established when SNI is required.

Fix for #1049