### PR TITLE
订正mqttjs使用支付宝小程序mqtt连接时出错

### DIFF
--- a/lib/connect/ali.js
+++ b/lib/connect/ali.js
@@ -13,8 +13,10 @@ var isInitialized = false
 function buildProxy () {
   var proxy = new Transform()
   proxy._write = function (chunk, encoding, next) {
+    const _data = chunk.toString('base64'); //订正mqttjs支付宝小程序使用错误，支付宝data需要传入base64 string
     my.sendSocketMessage({
-      data: chunk.buffer,
+      data: _data,  //订正mqttjs支付宝小程序使用错误，支付宝data需要传入base64 string
+			isBuffer: 1,  //订正mqttjs支付宝小程序使用错误，isbuffer设置为1
       success: function () {
         next()
       },
@@ -114,9 +116,17 @@ function buildStream (client, opts) {
 
   var url = buildUrl(opts, client)
   my = opts.my
-  my.connectSocket({
+  // my.connectSocket({
+  //   url: url,
+  //   protocols: websocketSubProtocol
+  // })
+	
+	// 订正mqttjs使用支付宝api错误，protocols参数导致socket被拦截
+	my.connectSocket({
     url: url,
-    protocols: websocketSubProtocol
+    headers : {
+      "Sec-WebSocket-Protocol" : "mqtt"
+    }
   })
 
   proxy = buildProxy()


### PR DESCRIPTION
我来自阿里云IoT事业部，提供jssdk给开发者用于连接阿里云物联网平台（https://github.com/aliyun/alibabacloud-iot-device-sdk），最近发现阿里小程序的用户无法正常使用，定位到原因是因为mqttjs使用了支付宝api不规范导致（这个问题是和支付宝小程序容器开发同学蕴峰一起定位）所以提出正确的修改方式如下：

订正mqttjs使用支付宝小程序mqtt连接时出错
1：my.connectSocket 传入protocols会被拦截，需要增加headers参数
2：sendSocketMessage data 需要为base64 string ，并且需要isBuffer:1