### PR TITLE
fix: mini Program connection on real devic

### DIFF
--- a/lib/connect/ali.js
+++ b/lib/connect/ali.js
@@ -105,18 +105,12 @@ function buildStream (client, opts) {
     throw new Error('Could not determine host. Specify host manually.')
   }
 
-  var websocketSubProtocol =
-    (opts.protocolId === 'MQIsdp') && (opts.protocolVersion === 3)
-      ? 'mqttv3.1'
-      : 'mqtt'
-
   setDefaultOpts(opts)
 
   var url = buildUrl(opts, client)
   my = opts.my
   my.connectSocket({
-    url: url,
-    protocols: websocketSubProtocol
+    url: url
   })
 
   proxy = buildProxy()

--- a/lib/connect/wx.js
+++ b/lib/connect/wx.js
@@ -99,7 +99,7 @@ function buildStream (client, opts) {
   var url = buildUrl(opts, client)
   socketTask = wx.connectSocket({
     url: url,
-    protocols: websocketSubProtocol
+    protocols: [websocketSubProtocol]
   })
 
   proxy = buildProxy()


### PR DESCRIPTION
This PR fix the connection based SSL on my simulator and especially real device.    
这个PR修复了在模拟器、尤其是真机上基于SSL的mqtt连接

Besides, It is according to the official documentation of [WeChat Mini Program](https://developers.weixin.qq.com/miniprogram/dev/api/network/websocket/wx.connectSocket.html) and [Ali Mini Program](https://opendocs.alipay.com/mini/api/vx19c3) on api  ```connectSocket```    
同时它也是根据微信、支付宝小程序官方文档里对api ```connectSocket``` 做的调整，已经在我本地验证通过

WeChat Mini Program document screenshots：    
![image](https://user-images.githubusercontent.com/2062355/76697235-b6d69100-66cf-11ea-8e79-5f887a266a25.png)

Alipay Mini Program document screenshots：    
![image](https://user-images.githubusercontent.com/2062355/76697258-fd2bf000-66cf-11ea-8165-8ec79126ab59.png)


Fixes  #923



