### PR TITLE
chore: change workflow to v10-14 and doc fixes

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
       fail-fast: false
 
     steps:

--- a/README.md
+++ b/README.md
@@ -27,35 +27,25 @@ Guide](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.
 <a name="notes"></a>
 ## Important notes for existing users
 
-v4.0.0 removes support for all end of life node versions, and now supports node v12 and v14. It also adds improvements to
+__v4.0.0__ (Released 04/2020) removes support for all end of life node versions, and now supports node v12 and v14. It also adds improvements to
 debug logging, along with some feature additions.
 
-v3.0.0 adds support for MQTT 5, support for node v10.x, and many fixes to improve reliability.
+As a __breaking change__, by default a error handler is built into the MQTT.js client, so if any
+errors are emitted and the user has not created an event handler on the client for errors, the client will
+not break as a result of unhandled errors. Additionally, typical TLS errors like `ECONNREFUSED`, `ECONNRESET` have been
+added to a list of TLS errors that will be emitted from the MQTT.js client, and so can be handled as connection errors.
 
-v2.0.0 removes support for node v0.8, v0.10 and v0.12, and it is 3x faster in sending
+__v3.0.0__ adds support for MQTT 5, support for node v10.x, and many fixes to improve reliability.
+
+__Note:__ MQTT v5 support is experimental as it has not been implemented by brokers yet.
+
+__v2.0.0__ removes support for node v0.8, v0.10 and v0.12, and it is 3x faster in sending
 packets. It also removes all the deprecated functionality in v1.0.0,
 mainly `mqtt.createConnection` and `mqtt.Server`. From v2.0.0,
 subscriptions are restored upon reconnection if `clean: true`.
 v1.x.x is now in *LTS*, and it will keep being supported as long as
 there are v0.8, v0.10 and v0.12 users.
 
-v1.0.0 improves the overall architecture of the project, which is now
-split into three components: MQTT.js keeps the Client,
-[mqtt-connection](http://npm.im/mqtt-connection) includes the barebone
-Connection code for server-side usage, and [mqtt-packet](http://npm.im/mqtt-packet)
-includes the protocol parser and generator. The new Client improves
-performance by a 30% factor, embeds Websocket support
-([MOWS](http://npm.im/mows) is now deprecated), and it has a better
-support for QoS 1 and 2. The previous API is still supported but
-deprecated, as such, it is not documented in this README.
-
-For v4.0.0:
-As a __breaking change__, by default a error handler is built into the MQTT.js client, so if any
-errors are emitted and the user has not created an event handler on the client for errors, the client will
-not break as a result of unhandled errors. Additionally, typical TLS errors like `ECONNREFUSED`, `ECONNRESET` have been
-added to a list of TLS errors that will be emitted from the MQTT.js client, and so can be handled as connection errors.
-
-For v2.0.0:
 As a __breaking change__, the `encoding` option in the old client is
 removed, and now everything is UTF-8 with the exception of the
 `password` in the CONNECT message and `payload` in the PUBLISH message,
@@ -64,7 +54,15 @@ which are `Buffer`.
 Another __breaking change__ is that MQTT.js now defaults to MQTT v3.1.1,
 so to support old brokers, please read the [client options doc](#client).
 
-MQTT v5 support is experimental as it has not been implemented by brokers yet.
+__v1.0.0__ improves the overall architecture of the project, which is now
+split into three components: MQTT.js keeps the Client,
+[mqtt-connection](http://npm.im/mqtt-connection) includes the barebone
+Connection code for server-side usage, and [mqtt-packet](http://npm.im/mqtt-packet)
+includes the protocol parser and generator. The new Client improves
+performance by a 30% factor, embeds Websocket support
+([MOWS](http://npm.im/mows) is now deprecated), and it has a better
+support for QoS 1 and 2. The previous API is still supported but
+deprecated, as such, it is not documented in this README.
 
 <a name="install"></a>
 ## Installation
@@ -327,6 +325,13 @@ Emitted when the client goes offline.
 
 Emitted when the client cannot connect (i.e. connack rc != 0) or when a
 parsing error occurs.
+
+The following TLS errors will be emitted as an `error` event:
+
+* `ECONNREFUSED`
+* `ECONNRESET`
+* `EADDRINUSE`
+* `ENOTFOUND`
 
 #### Event `'end'`
 


### PR DESCRIPTION
These are more minor doc fixes for the release of the v4 mqtt.js package