### PR TITLE
refactor: callbacks on end()

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -777,12 +777,8 @@ MqttClient.prototype.unsubscribe = function () {
  *
  * @api public
  */
-MqttClient.prototype.end = function () {
+MqttClient.prototype.end = function (force, opts, cb) {
   var that = this
-
-  var force = arguments[0]
-  var opts = arguments[1]
-  var cb = arguments[2]
 
   if (force == null || typeof force !== 'boolean') {
     cb = opts || nop
@@ -814,7 +810,7 @@ MqttClient.prototype.end = function () {
         that.emit('end')
         if (cb) {
           debug('end :: (%s) :: closeStores: invoking callback with args', that.options.clientId)
-          cb.apply(null, arguments)
+          cb()
         }
       })
     })
@@ -836,6 +832,7 @@ MqttClient.prototype.end = function () {
   }
 
   if (this.disconnecting) {
+    cb()
     return this
   }
 

--- a/test/client_mqtt5.js
+++ b/test/client_mqtt5.js
@@ -51,8 +51,7 @@ describe('MQTT 5.0', function () {
       assert.strictEqual(error.message, 'Packet has no Authentication Method')
       // client will not be connected, so we will call done.
       assert.isTrue(client.disconnected, 'validate client is disconnected')
-      client.end(true)
-      done()
+      client.end(true, done)
     })
   })
 


### PR DESCRIPTION
There are a few historical PRs that I looked through related to this PR: https://github.com/mqttjs/MQTT.js/pull/771/files
https://github.com/mqttjs/MQTT.js/pull/827/files

This PR addresses some of the flakiness in tests seen in the build system, both by adding a minor adjustment to a test but more importantly by adjusting the way `end()` calls it's callbacks.

If the `end()` method is disconnecting, it will simply return and never invoke the callback passed to it... This seems like flawed behavior since the callback passed is unique to that call to `end()`. This PR changes how `end()` works, so that the callback is invoked regardless if the client is disconnecting or not. Additionally, it removes the use of arguments that was introduced in the above two PRs, as I could find no logical justification for the use of arguments over actual defined parameters? Finally, I could find no logical justification of just returning the arguments object as a parameter of the callback, so that is changed where the callback is simply invoked.

I thought about adding information into the callback, like if the client is `disconnecting`, `connected`, or `disconnected`, but because the `end` event is emitted once the stores are closed we can use that in tandem with the callback to determine if the client is actually disconnected. If the callback is invoked on a call to end but the `end` event has not yet been emitted then the user can know that the client is in the process of disconnecting but has not fully disconnected yet.