### PR TITLE
fix: better options debugging

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1093,7 +1093,7 @@ MqttClient.prototype._storePacket = function (packet, cb, cbStorePut) {
  * @api private
  */
 MqttClient.prototype._setupPingTimer = function () {
-  debug('_setupPingTimer :: keepalive %d (seconds)', keepalive)
+  debug('_setupPingTimer :: keepalive %d (seconds)', this.options.keepalive)
   var that = this
 
   if (!this.pingTimer && this.options.keepalive) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -87,18 +87,18 @@ function defaultId () {
 }
 
 function sendPacket (client, packet, cb) {
-  debug('sendPacket: packet: %O', packet)
-  debug('sendPacket: emitting `packetsend`')
+  debug('sendPacket :: packet: %O', packet)
+  debug('sendPacket :: emitting `packetsend`')
   client.emit('packetsend', packet)
 
-  debug('sendPacket: writing to stream')
+  debug('sendPacket :: writing to stream')
   var result = mqttPacket.writeToStream(packet, client.stream, client.options)
-  debug('sendPacket: writeToStream result %s', result)
+  debug('sendPacket :: writeToStream result %s', result)
   if (!result && cb) {
-    debug('sendPacket: handle events on `drain` once through callback.')
+    debug('sendPacket :: handle events on `drain` once through callback.')
     client.stream.once('drain', cb)
   } else if (cb) {
-    debug('sendPacket: invoking cb')
+    debug('sendPacket :: invoking cb')
     cb()
   }
 }
@@ -117,7 +117,7 @@ function flush (queue) {
 
 function flushVolatile (queue) {
   if (queue) {
-    debug('flushVolatile: queue exists? %s', !!(queue))
+    debug('flushVolatile :: deleting volatile messages from the queue and setting their callbacks as error function')
     Object.keys(queue).forEach(function (messageId) {
       if (queue[messageId].volatile && typeof queue[messageId].cb === 'function') {
         queue[messageId].cb(new Error('Connection closed'))
@@ -128,7 +128,7 @@ function flushVolatile (queue) {
 }
 
 function storeAndSend (client, packet, cb, cbStorePut) {
-  debug('storeAndSend: store packet with cmd: %s to outgoingStore', packet.cmd)
+  debug('storeAndSend :: store packet with cmd %s to outgoingStore', packet.cmd)
   client.outgoingStore.put(packet, function storedPacket (err) {
     if (err) {
       return cb && cb(err)
@@ -139,7 +139,7 @@ function storeAndSend (client, packet, cb, cbStorePut) {
 }
 
 function nop (error) {
-  debug('nop hit: %o', error)
+  debug('nop ::', error)
 }
 
 /**
@@ -226,12 +226,11 @@ function MqttClient (streamBuilder, options) {
 
   // Send queued packets
   this.on('connect', function () {
-    debug('MqttClient:connect')
     var queue = this.queue
 
     function deliver () {
       var entry = queue.shift()
-      debug('MqttClient:deliver: entry %o', entry)
+      debug('deliver :: entry %o', entry)
       var packet = null
 
       if (!entry) {
@@ -239,7 +238,7 @@ function MqttClient (streamBuilder, options) {
       }
 
       packet = entry.packet
-      debug('MqttClient:deliver: call _sendPacket for %o', packet)
+      debug('deliver :: call _sendPacket for %o', packet)
       that._sendPacket(
         packet,
         function (err) {
@@ -251,26 +250,29 @@ function MqttClient (streamBuilder, options) {
       )
     }
 
+    debug('connect :: sending queued packets')
     deliver()
   })
 
   this.on('close', function () {
-    debug('MqttClient: close event. Mark disconnected.')
+    debug('close :: connected set to `false`')
     this.connected = false
+
+    debug('close :: clearing connackTimer')
     clearTimeout(this.connackTimer)
 
-    debug('MqttClient:close: clear ping timer')
+    debug('close :: clearing ping timer')
     if (that.pingTimer !== null) {
       that.pingTimer.clear()
       that.pingTimer = null
     }
 
-    debug('MqttClient:close: call _setupReconnect')
+    debug('close :: calling _setupReconnect')
     this._setupReconnect()
   })
   EventEmitter.call(this)
 
-  debug('MqttClient: call _setupStream')
+  debug('MqttClient :: setting up stream')
   this._setupStream()
 }
 inherits(MqttClient, EventEmitter)
@@ -288,14 +290,14 @@ MqttClient.prototype._setupStream = function () {
   var completeParse = null
   var packets = []
 
-  debug('_setupStream: calling method to clear reconnect')
+  debug('_setupStream :: calling method to clear reconnect')
   this._clearReconnect()
 
-  debug('_setupStream: setting stream builder')
+  debug('_setupStream :: using streamBuilder provided to client to create stream')
   this.stream = this.streamBuilder(this)
 
   parser.on('packet', function (packet) {
-    debug('parser: on packet push to packets array.')
+    debug('parser :: on packet push to packets array.')
     packets.push(packet)
   })
 
@@ -310,29 +312,30 @@ MqttClient.prototype._setupStream = function () {
   }
 
   function work () {
-    debug('stream:work: called')
+    debug('work :: getting next packet in queue')
     var packet = packets.shift()
 
     if (packet) {
-      debug('stream:work: calling _handlePacket')
+      debug('work :: packet pulled from queue')
       that._handlePacket(packet, nextTickWork)
     } else {
+      debug('work :: no packets in queue')
       var done = completeParse
       completeParse = null
-      debug('stream:work: done is %s', !!(done))
+      debug('work :: done flag is %s', !!(done))
       if (done) done()
     }
   }
 
   writable._write = function (buf, enc, done) {
     completeParse = done
-    debug('stream:writable:_write: parsing buffer')
+    debug('writable stream :: parsing buffer')
     parser.parse(buf)
     work()
   }
 
   function streamErrorHandler (error) {
-    debug('stream error')
+    debug('streamErrorHandler :: error', error.message)
     if (socketErrors.includes(error.code)) {
       // handle error
       debug('streamErrorHandler :: emitting error')
@@ -342,7 +345,7 @@ MqttClient.prototype._setupStream = function () {
     }
   }
 
-  debug('_setupStream: piping stream to writable')
+  debug('_setupStream :: pipe stream to writable stream')
   this.stream.pipe(writable)
 
   // Suppress connection errors
@@ -385,13 +388,12 @@ MqttClient.prototype._setupStream = function () {
 
   clearTimeout(this.connackTimer)
   this.connackTimer = setTimeout(function () {
-    debug('connectTimeout hit! Calling _cleanUp with force `true`')
+    debug('!!connectTimeout hit!! Calling _cleanUp with force `true`')
     that._cleanUp(true)
   }, this.options.connectTimeout)
 }
 
 MqttClient.prototype._handlePacket = function (packet, done) {
-  debug('_handlePacket')
   var options = this.options
 
   if (options.protocolVersion === 5 && options.properties && options.properties.maximumPacketSize && options.properties.maximumPacketSize < packet.length) {
@@ -399,7 +401,7 @@ MqttClient.prototype._handlePacket = function (packet, done) {
     this.end({reasonCode: 149, properties: { reasonString: 'Maximum packet size was exceeded' }})
     return this
   }
-  debug('_handlePacket: emitting packetreceive')
+  debug('_handlePacket :: emitting packetreceive')
   this.emit('packetreceive', packet)
 
   switch (packet.cmd) {
@@ -469,7 +471,7 @@ MqttClient.prototype._checkDisconnecting = function (callback) {
  * @example client.publish('topic', 'message', console.log);
  */
 MqttClient.prototype.publish = function (topic, message, opts, callback) {
-  debug('MqttClient:publish `%s` to topic `%s`', message, topic)
+  debug('publish :: message `%s` to topic `%s`', message, topic)
   var packet
   var options = this.options
 
@@ -512,6 +514,7 @@ MqttClient.prototype.publish = function (topic, message, opts, callback) {
     }
   }
 
+  debug('publish :: qos', opts.qos)
   switch (opts.qos) {
     case 1:
     case 2:
@@ -670,7 +673,7 @@ MqttClient.prototype.subscribe = function () {
 
   // subscriptions to resubscribe to in case of disconnect
   if (this.options.resubscribe) {
-    debug('subscribe: resubscribe true')
+    debug('subscribe :: resubscribe true')
     var topics = []
     subs.forEach(function (sub) {
       if (that.options.reconnectPeriod > 0) {
@@ -701,7 +704,7 @@ MqttClient.prototype.subscribe = function () {
       callback(err, subs)
     }
   }
-  debug('subscribe: calling _sendPacket')
+  debug('subscribe :: call _sendPacket')
   this._sendPacket(packet)
 
   return this
@@ -768,7 +771,7 @@ MqttClient.prototype.unsubscribe = function () {
     cb: callback
   }
 
-  debug('unsubscribe: send packet')
+  debug('unsubscribe: call _sendPacket')
   this._sendPacket(packet)
 
   return this
@@ -785,6 +788,8 @@ MqttClient.prototype.unsubscribe = function () {
  */
 MqttClient.prototype.end = function (force, opts, cb) {
   var that = this
+
+  debug('end :: (%s)', this.opts.clientId)
 
   if (force == null || typeof force !== 'boolean') {
     cb = opts || nop
@@ -808,14 +813,14 @@ MqttClient.prototype.end = function (force, opts, cb) {
   cb = cb || nop
 
   function closeStores () {
-    debug('end :: (%s) :: closeStores: closing incoming and outgoing stores', that.options.clientId)
+    debug('end :: closeStores: closing incoming and outgoing stores')
     that.disconnected = true
     that.incomingStore.close(function () {
       that.outgoingStore.close(function () {
-        debug('end :: (%s) :: closeStores: emitting end', that.options.clientId)
+        debug('end :: closeStores: emitting end')
         that.emit('end')
         if (cb) {
-          debug('end :: (%s) :: closeStores: invoking callback with args', that.options.clientId)
+          debug('end :: closeStores: invoking callback with args')
           cb()
         }
       })
@@ -930,18 +935,18 @@ MqttClient.prototype._reconnect = function () {
  * _setupReconnect - setup reconnect timer
  */
 MqttClient.prototype._setupReconnect = function () {
-  debug('_setupReconnect')
   var that = this
 
   if (!that.disconnecting && !that.reconnectTimer && (that.options.reconnectPeriod > 0)) {
     if (!this.reconnecting) {
-      debug('_setupReconnect :: emitting offline state')
+      debug('_setupReconnect :: emit `offline` state')
       this.emit('offline')
+      debug('_setupReconnect :: set `reconnecting` to `true`')
       this.reconnecting = true
     }
     debug('_setupReconnect :: setting reconnectTimer for %d ms', that.options.reconnectPeriod)
     that.reconnectTimer = setInterval(function () {
-      debug('reconnectTimer calling _reconnect()')
+      debug('reconnectTimer :: reconnect triggered!')
       that._reconnect()
     }, that.options.reconnectPeriod)
   } else {
@@ -953,7 +958,7 @@ MqttClient.prototype._setupReconnect = function () {
  * _clearReconnect - clear the reconnect timer
  */
 MqttClient.prototype._clearReconnect = function () {
-  debug('_clearReconnect called. clearing reconnectTimer')
+  debug('_clearReconnect : clearing reconnect timer')
   if (this.reconnectTimer) {
     clearInterval(this.reconnectTimer)
     this.reconnectTimer = null
@@ -967,20 +972,20 @@ MqttClient.prototype._clearReconnect = function () {
 MqttClient.prototype._cleanUp = function (forced, done) {
   var opts = arguments[2]
   if (done) {
-    debug('_cleanUp: done callback provided for on stream close')
+    debug('_cleanUp :: done callback provided for on stream close')
     this.stream.on('close', done)
   }
 
-  debug('_cleanUp: forced? %s', forced)
+  debug('_cleanUp :: forced? %s', forced)
   if (forced) {
     if ((this.options.reconnectPeriod === 0) && this.options.clean) {
       flush(this.outgoing)
     }
-    debug('(%s)_cleanUp: destroying stream', this.options.clientId)
+    debug('_cleanUp :: (%s) :: destroying stream', this.options.clientId)
     this.stream.destroy()
   } else {
     var packet = xtend({ cmd: 'disconnect' }, opts)
-    debug('(%s)_cleanUp: sending disconnect packet', this.options.clientId)
+    debug('_cleanUp :: (%s) :: call _sendPacket with disconnect packet', this.options.clientId)
     this._sendPacket(
       packet,
       setImmediate.bind(
@@ -991,19 +996,19 @@ MqttClient.prototype._cleanUp = function (forced, done) {
   }
 
   if (!this.disconnecting) {
-    debug('_cleanUp: client not disconnecting. Clearing and resetting reconnect.')
+    debug('_cleanUp :: client not disconnecting. Clearing and resetting reconnect.')
     this._clearReconnect()
     this._setupReconnect()
   }
 
   if (this.pingTimer !== null) {
-    debug('_cleanUp: clearing pingTimer')
+    debug('_cleanUp :: clearing pingTimer')
     this.pingTimer.clear()
     this.pingTimer = null
   }
 
   if (done && !this.connected) {
-    debug('(%s)_cleanUp: removing stream `done` callback `close` listener', this.options.clientId)
+    debug('_cleanUp :: (%s) :: removing stream `done` callback `close` listener', this.options.clientId)
     this.stream.removeListener('close', done)
     done()
   }
@@ -1292,7 +1297,6 @@ MqttClient.prototype.handleMessage = function (packet, callback) {
  */
 
 MqttClient.prototype._handleAck = function (packet) {
-  debug('handling ack packet')
   /* eslint no-fallthrough: "off" */
   var messageId = packet.messageId
   var type = packet.cmd
@@ -1302,13 +1306,13 @@ MqttClient.prototype._handleAck = function (packet) {
   var err
 
   if (!cb) {
-    debug('Server sent an ack in error. Ignoring.')
+    debug('_handleAck :: Server sent an ack in error. Ignoring.')
     // Server sent an ack in error, ignore it.
     return
   }
 
   // Process
-  debug('ack packet of type: %s', type)
+  debug('_handleAck :: packet type', type)
   switch (type) {
     case 'pubcomp':
       // same thing as puback for QoS 2

--- a/lib/client.js
+++ b/lib/client.js
@@ -158,7 +158,6 @@ function MqttClient (streamBuilder, options) {
   }
 
   this.options = options || {}
-  debug('MqttClient :: options: %o', options)
 
   // Defaults
   for (k in defaultConnectOptions) {
@@ -169,9 +168,16 @@ function MqttClient (streamBuilder, options) {
     }
   }
 
+  debug('MqttClient :: options.protocol', options.protocol)
+  debug('MqttClient :: options.protocolVersion', options.protocolVersion)
+  debug('MqttClient :: options.username', options.username)
+  debug('MqttClient :: options.keepalive', options.keepalive)
+  debug('MqttClient :: options.reconnectPeriod', options.reconnectPeriod)
+  debug('MqttClient :: options.rejectUnauthorized', options.rejectUnauthorized)
+
   this.options.clientId = (typeof options.clientId === 'string') ? options.clientId : defaultId()
 
-  debug('MqttClient: clientId', this.options.clientId)
+  debug('MqttClient :: clientId', this.options.clientId)
 
   this.options.customHandleAcks = (options.protocolVersion === 5 && options.customHandleAcks) ? options.customHandleAcks : function () { arguments[3](0) }
 
@@ -1087,6 +1093,7 @@ MqttClient.prototype._storePacket = function (packet, cb, cbStorePut) {
  * @api private
  */
 MqttClient.prototype._setupPingTimer = function () {
+  debug('_setupPingTimer :: keepalive %d (seconds)', keepalive)
   var that = this
 
   if (!this.pingTimer && this.options.keepalive) {

--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -4,6 +4,8 @@ var MqttClient = require('../client')
 var Store = require('../store')
 var url = require('url')
 var xtend = require('xtend')
+var debug = require('debug')('mqttjs')
+
 var protocols = {}
 
 if (process.title !== 'browser') {
@@ -48,6 +50,7 @@ function parseAuthOptions (opts) {
  * @param {Object} opts - see MqttClient#constructor
  */
 function connect (brokerUrl, opts) {
+  debug('connecting to an MQTT broker...')
   if ((typeof brokerUrl === 'object') && !opts) {
     opts = brokerUrl
     brokerUrl = null
@@ -98,7 +101,7 @@ function connect (brokerUrl, opts) {
         }
       }
     } else {
-      // don't know what protocol he want to use, mqtts or wss
+      // A cert and key was provided, however no protocol was specified, so we will throw an error.
       throw new Error('Missing secure protocol key')
     }
   }
@@ -145,6 +148,7 @@ function connect (brokerUrl, opts) {
       client._reconnectCount++
     }
 
+    debug('calling streambuilder for',opts.protocol)
     return protocols[opts.protocol](client, opts)
   }
   var client = new MqttClient(wrapper, opts)

--- a/lib/connect/tcp.js
+++ b/lib/connect/tcp.js
@@ -1,5 +1,6 @@
 'use strict'
 var net = require('net')
+var debug = require('debug')('mqttjs:tcp')
 
 /*
   variables port and host can be removed since
@@ -13,6 +14,7 @@ function streamBuilder (client, opts) {
   port = opts.port
   host = opts.hostname
 
+  debug('port %d and host %s', port, host)
   return net.createConnection(port, host)
 }
 

--- a/lib/connect/tls.js
+++ b/lib/connect/tls.js
@@ -1,5 +1,7 @@
 'use strict'
 var tls = require('tls')
+var debug = require('debug')('mqttjs:tls')
+
 
 function buildBuilder (mqttClient, opts) {
   var connection
@@ -10,6 +12,8 @@ function buildBuilder (mqttClient, opts) {
   opts.rejectUnauthorized = opts.rejectUnauthorized !== false
 
   delete opts.path
+
+  debug('port %d host %s rejectUnauthorized %b', opts.port, opts.host, opts.rejectUnauthorized)
 
   connection = tls.connect(opts)
   /* eslint no-use-before-define: [2, "nofunc"] */

--- a/lib/connect/ws.js
+++ b/lib/connect/ws.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var debug = require('debug')('mqttjs:connect:ws')
+var debug = require('debug')('mqttjs:ws')
 var websocket = require('websocket-stream')
 var urlModule = require('url')
 var WSS_OPTIONS = [
@@ -51,7 +51,6 @@ function setDefaultOpts (opts) {
 
 function createWebSocket (client, opts) {
   debug('createWebSocket')
-  debug('opts: %o', opts)
   var websocketSubProtocol =
     (opts.protocolId === 'MQIsdp') && (opts.protocolVersion === 3)
       ? 'mqttv3.1'
@@ -59,7 +58,7 @@ function createWebSocket (client, opts) {
 
   setDefaultOpts(opts)
   var url = buildUrl(opts, client)
-  debug('creating new Websocket for url: %s and protocol: %s', url, websocketSubProtocol)
+  debug('url %s protocol %s', url, websocketSubProtocol)
   return websocket(url, [websocketSubProtocol], opts.wsOptions)
 }
 

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -2376,8 +2376,9 @@ module.exports = function (server, config) {
 
     var reconnectPeriodTests = [ {period: 200}, {period: 2000}, {period: 4000} ]
     reconnectPeriodTests.forEach((test) => {
-      it('should allow specification of a reconnect period', function (done) {
+      it('should allow specification of a reconnect period (' + test.period + 'ms)', function (done) {
         var end
+        var reconnectSlushTime = 200
         var client = connect({reconnectPeriod: test.period})
         var reconnect = false
         var start = Date.now()
@@ -2389,11 +2390,12 @@ module.exports = function (server, config) {
           } else {
             end = Date.now()
             client.end(() => {
-              if (end - start >= test.period - 200 && end - start <= test.period + 200) {
+              let reconnectPeriodDuringTest = end - start
+              if (reconnectPeriodDuringTest >= test.period - reconnectSlushTime && reconnectPeriodDuringTest <= test.period + reconnectSlushTime) {
                 // give the connection a 200 ms slush window
                 done()
               } else {
-                done(new Error('Strange reconnect period'))
+                done(new Error('Strange reconnect period: ' + reconnectPeriodDuringTest))
               }
             })
           }


### PR DESCRIPTION
there is a security vulnerability created by outputting the whole options object in the debugs. In order to not do this we replace the line for debug to multiple single lines accessing the important options values.