### PR TITLE
ci: add debug logs to tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,3 +29,4 @@ jobs:
     - run: npm test
       env:
         CI: true
+        DEBUG: "mqttjs*"


### PR DESCRIPTION
This is a minor change to the workflow that will add debug log output on the test runs. Currently when a flakey test fails there is no possible way to debug why it is happening, the error logs are not useful enough. So adding debug logs will fix some of this.