### PR TITLE
feat: unix sockets

### DIFF
--- a/examples/unix-socket/unix-socket-client.js
+++ b/examples/unix-socket/unix-socket-client.js
@@ -1,0 +1,38 @@
+var mqtt = require('../..')
+
+const fs = require('fs')
+const connections = {}
+let client
+
+// prevent duplicate exit messages
+var SHUTDOWN = false;
+
+// Our socket
+const SOCKETFILE = '/tmp/unix.sock';
+
+console.info('Loading interprocess communications test');
+console.info('Socket: %s \n  Process: %s',SOCKETFILE,process.pid);
+
+// Connect to server.
+console.log("Connecting to server.");
+let opts = { protocol: 'file' }
+client = mqtt.connect(SOCKETFILE, opts)
+
+client.subscribe('presence')
+client.publish('presence', 'Hello mqtt')
+
+client.on('message', function (topic, message) {
+  console.log(message.toString())
+})
+
+client.end()
+
+
+function cleanup(){
+    if(!SHUTDOWN){ SHUTDOWN = true;
+        console.log('\n',"Terminating.",'\n');
+        client.end();
+        process.exit(0);
+    }
+}
+process.on('SIGINT', cleanup);

--- a/examples/unix-socket/unix-socket-server.js
+++ b/examples/unix-socket/unix-socket-server.js
@@ -1,0 +1,125 @@
+var MqttServer = require('../../test/server').MqttServer
+
+const fs = require('fs')
+const connections = {}
+let server
+
+// prevent duplicate exit messages
+var SHUTDOWN = false;
+
+// Our socket
+const SOCKETFILE = '/tmp/unix.sock';
+
+console.info('Loading interprocess communications test');
+console.info(' Socket: %s \n  Process: %s',SOCKETFILE,process.pid);
+
+function createServer(socket){
+  console.log('Creating server.');
+  let server = new MqttServer(function (c) {
+    console.log('Connection acknowledged');
+
+    var self = Date.now();
+    connections[self] = (c);
+    c.on('end', function() {
+      console.log('Client disconnected. ')
+      delete connections[self];
+    })
+
+    c.on('connect', function (packet) {
+      var rc = 'returnCode'
+      var connack = {}
+      if (serverClient.options && serverClient.options.protocolVersion === 5) {
+        rc = 'reasonCode'
+        if (packet.clientId === 'invalid') {
+          connack[rc] = 128
+        } else {
+          connack[rc] = 0
+        }
+      } else {
+        if (packet.clientId === 'invalid') {
+          connack[rc] = 2
+        } else {
+          connack[rc] = 0
+        }
+      }
+      if (packet.properties && packet.properties.authenticationMethod) {
+        return false
+      } else {
+        serverClient.connack(connack)
+      }
+    })
+    serverClient.on('publish', function (packet) {
+      setImmediate(function () {
+        switch (packet.qos) {
+        case 0:
+          break
+        case 1:
+          serverClient.puback(packet)
+          break
+        case 2:
+          serverClient.pubrec(packet)
+          break
+        }
+      })
+    })
+
+    serverClient.on('subscribe', function (packet) {
+      serverClient.suback({
+        messageId: packet.messageId,
+        granted: packet.subscriptions.map(function (e) {
+          return e.qos
+        })
+      })
+    })
+
+    serverClient.on('unsubscribe', function (packet) {
+      packet.granted = packet.unsubscriptions.map(function () { return 0 })
+      serverClient.unsuback(packet)
+    })
+
+    serverClient.on('pingreq', function () {
+      serverClient.pingresp()
+    })
+  });
+
+  server.listen(socket);
+  return server;
+}
+
+// check for failed cleanup
+console.log('Checking for leftover socket.');
+fs.stat(SOCKETFILE, function (err, stats) {
+    if (err) {
+        // start server
+        console.log('No leftover socket found.');
+        server = createServer(SOCKETFILE); return;
+    }
+    // remove file then start server
+    console.log('Removing leftover socket.')
+    fs.unlink(SOCKETFILE, function(err){
+        if(err){
+            // This should never happen.
+            console.error(err); process.exit(0);
+        }
+        server = createServer(SOCKETFILE); return;
+    });
+});
+
+// close all connections when the user does CTRL-C
+function cleanup(){
+    if(!SHUTDOWN){ SHUTDOWN = true;
+        console.log('\n',"Terminating.",'\n');
+        if(Object.keys(connections).length){
+            let clients = Object.keys(connections);
+            while(clients.length){
+                let client = clients.pop();
+                connections[client].write('__disconnect');
+                connections[client].end();
+            }
+        }
+        server.close();
+        process.exit(0);
+    }
+}
+process.on('SIGINT', cleanup);
+

--- a/lib/connect/file.js
+++ b/lib/connect/file.js
@@ -1,7 +1,12 @@
 'use strict'
 var net = require('net')
+var debug = require('debug')('mqttjs:file')
 
 function buildBuilder (client, opts) {
+  let pathname
+
+  pathname = opts.pathname
+  debug('pathname %s', opts.pathname)
   return net.createConnection(opts.pathname)
 }
 

--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -117,7 +117,8 @@ function connect (brokerUrl, opts) {
       'wx',
       'wxs',
       'ali',
-      'alis'
+      'alis',
+      'file'
     ].filter(function (key, index) {
       if (isSecure && index % 2 === 0) {
         // Skip insecure protocols when requesting a secure one.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mqtt",
   "description": "A library for the MQTT protocol",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "contributors": [
     "Adam Rudd <adamvrr@gmail.com>",
     "Matteo Collina <matteo.collina@gmail.com> (https://github.com/mcollina)",

--- a/test/server.js
+++ b/test/server.js
@@ -6,6 +6,9 @@ var Connection = require('mqtt-connection')
 
 /**
  * MqttServer
+ * All we are doing here is updating the connection event handler to take
+ * the connection object (a net.Socket), and create a MQTT specific connection over
+ * that net.Socket. Then once
  *
  * @param {Function} listener - fired on client connection
  */


### PR DESCRIPTION
Related to: #1040 
This PR is still in the works, but carrys over from @ralight's PR for Unix Domain Sockets support for MQTT.js. I see there is lots of discussion around MQTT.js in Mosquitto that @ralight has participated in, and the resolution was something along the lines of, there is an actionable and useful security gain for having unix domain socket support for a service like mosquitto, so they are looking to add it. 

From the MQTT.js perspective, this should be a minimal change. This PR is not complete quite yet, I think I have added some of the changes to make it work, but I want to add a unix domain sockets sample and also add the tests to support it. 

For the tests, it should be very simple, just adding on a new flavor of the existing MQTT-Connection based server, except in this case listening on a unix domain port. There should be a check that the tests are running on a POSIX OS (i.e. not Windows) since obviously the tests will fail without the support of unix domain sockets on the OS. 

