### PR TITLE
Add missing `debug` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "base64-js": "^1.3.0",
     "commist": "^1.0.0",
     "concat-stream": "^1.6.2",
+    "debug": "^4.1.1",
     "end-of-stream": "^1.4.1",
     "es6-map": "^0.1.5",
     "help-me": "^1.0.1",


### PR DESCRIPTION
The `debug` package is missing from dependencies resulting in an error being thrown:

```
internal/modules/cjs/loader.js:965
  throw err;
  ^

Error: Cannot find module 'debug'
Require stack:
- /app/node_modules/mqtt/lib/client.js
- /app/node_modules/mqtt/mqtt.js
```