### PR TITLE
fix: fix payloadFormatIndicator to boolean type

### DIFF
--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -94,7 +94,7 @@ export interface IClientOptions extends ISecureClientOptions {
     * */
     properties?: {
       willDelayInterval?: number,
-      payloadFormatIndicator?: number,
+      payloadFormatIndicator?: boolean,
       messageExpiryInterval?: number,
       contentType?: string,
       responseTopic?: string,


### PR DESCRIPTION
The `payloadFormatIndicator` in the README defines the boolean type https://github.com/mqttjs/MQTT.js/#mqttclientstreambuilder-options