### PR TITLE
correct browser detection

### DIFF
--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -8,7 +8,8 @@ var debug = require('debug')('mqttjs')
 
 var protocols = {}
 
-if (process.title !== 'browser') {
+// eslint-disable-next-line camelcase
+if ((typeof process !== 'undefined' && process.title !== 'browser') || typeof __webpack_require__ === 'function') {
   protocols.mqtt = require('./tcp')
   protocols.tcp = require('./tcp')
   protocols.ssl = require('./tls')

--- a/lib/connect/ws.js
+++ b/lib/connect/ws.js
@@ -11,8 +11,8 @@ var WSS_OPTIONS = [
   'pfx',
   'passphrase'
 ]
-var IS_BROWSER = process.title === 'browser'
-
+// eslint-disable-next-line camelcase
+var IS_BROWSER = (typeof process !== 'undefined' && process.title === 'browser') || typeof __webpack_require__ === 'function'
 function buildUrl (opts, client) {
   var url = opts.protocol + '://' + opts.hostname + ':' + opts.port + opts.path
   if (typeof (opts.transformWsUrl) === 'function') {


### PR DESCRIPTION
currently webpack based projects couldn't import mqtt.js because incorrect browser detection.
It's not a problem for react, where node-shims enabled, but a pain for angular (where enabling node-shims isn't supported officially)
To fix that issue we need to check if `process` exists (it will be not available in browser)
Also due to shims in webpack we need to check are we in process of bundling, or not.