### PR TITLE
do not use process.nextTick without check that it exists

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -12,9 +12,10 @@ var reInterval = require('reinterval')
 var validations = require('./validations')
 var xtend = require('xtend')
 var debug = require('debug')('mqttjs:client')
+var nextTick = process ? process.nextTick : function (callback) { setTimeout(callback, 0) }
 var setImmediate = global.setImmediate || function (callback) {
   // works in node v0.8
-  process.nextTick(callback)
+  nextTick(callback)
 }
 var defaultConnectOptions = {
   keepalive: 60,
@@ -303,7 +304,7 @@ MqttClient.prototype._setupStream = function () {
 
   function nextTickWork () {
     if (packets.length) {
-      process.nextTick(work)
+      nextTick(work)
     } else {
       var done = completeParse
       completeParse = null
@@ -837,8 +838,8 @@ MqttClient.prototype.end = function (force, opts, cb) {
     debug('end :: (%s) :: finish :: calling _cleanUp with force %s', that.options.clientId, force)
     that._cleanUp(force, () => {
       debug('end :: finish :: calling process.nextTick on closeStores')
-      // var boundProcess = process.nextTick.bind(null, closeStores)
-      process.nextTick(closeStores.bind(that))
+      // var boundProcess = nextTick.bind(null, closeStores)
+      nextTick(closeStores.bind(that))
     }, opts)
   }
 

--- a/lib/connect/wx.js
+++ b/lib/connect/wx.js
@@ -117,13 +117,13 @@ function buildStream (client, opts) {
     stream.destroy = destroyRef
 
     var self = this
-    process.nextTick(function () {
+    setTimeout(function () {
       socketTask.close({
         fail: function () {
           self._destroy(new Error())
         }
       })
-    })
+    }, 0)
   }.bind(stream)
 
   bindEventHandler()

--- a/lib/store.js
+++ b/lib/store.js
@@ -88,9 +88,9 @@ Store.prototype.createStream = function () {
 
     destroyed = true
 
-    process.nextTick(function () {
+    setTimeout(function () {
       self.emit('close')
-    })
+    }, 0)
   }
 
   return stream


### PR DESCRIPTION
if we do not add shims to browser `process.nextTick` does not exist, because of missing `process`.
In v8 eventloop sequence is:

```javascript
process.nextTick(callback) // runs first, after current Tick
setTimeout(callback, 0) // runs after nextTick
setImmediate(callback) // runs after all (https://github.com/nodejs/node-v0.x-archive/issues/25788#issuecomment-128869483)
```

That's why where is possible (in destructors) process.nextTick substituted with setTimeout.
Where it's significant - substitution will be done if process.nextTick is missing.