### PR TITLE
Replace url parse by url class

### DIFF
--- a/examples/wss/client_with_proxy.js
+++ b/examples/wss/client_with_proxy.js
@@ -2,7 +2,6 @@
 
 var mqtt = require('mqtt')
 var HttpsProxyAgent = require('https-proxy-agent')
-var url = require('url')
 /*
 host: host of the endpoint you want to connect e.g. my.mqqt.host.com
 path: path to you endpoint e.g. '/foo/bar/mqtt'
@@ -13,8 +12,8 @@ proxy: your proxy e.g. proxy.foo.bar.com
 port: http proxy port e.g. 8080
 */
 var proxy = process.env.http_proxy || 'http://<proxy>:<port>'
-var parsed = url.parse(endpoint)
-var proxyOpts = url.parse(proxy)
+var parsed = new URL(endpoint)
+var proxyOpts = new URL(proxy)
 // true for wss
 proxyOpts.secureEndpoint = parsed.protocol ? parsed.protocol === 'wss:' : true
 var agent = new HttpsProxyAgent(proxyOpts)

--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -2,8 +2,6 @@
 
 var MqttClient = require('../client')
 var Store = require('../store')
-var url = require('url')
-var xtend = require('xtend')
 var debug = require('debug')('mqttjs')
 
 var protocols = {}
@@ -60,23 +58,32 @@ function connect (brokerUrl, opts) {
   opts = opts || {}
 
   if (brokerUrl) {
-    var parsed = url.parse(brokerUrl, true)
-    if (parsed.port != null) {
-      parsed.port = Number(parsed.port)
-    }
-
-    opts = xtend(parsed, opts)
-
     if (opts.protocol === null) {
       throw new Error('Missing protocol')
     }
+    var parsed = new URL(brokerUrl)
+    // the URL object is a bit special, so copy individual
+    // items to the opts object
+    opts.hostname = parsed.hostname
+    opts.host = parsed.host
+    opts.protocol = parsed.protocol
+    opts.port = Number(parsed.port) || null
+    opts.username = parsed.username
+    opts.password = parsed.password
+    opts.searchParams = parsed.searchParams
     opts.protocol = opts.protocol.replace(/:$/, '')
   }
 
   // merge in the auth options if supplied
+  // legacy support for url.parse objects (now deprecated in node.js)
   parseAuthOptions(opts)
 
   // support clientId passed in the query string of the url
+  if (opts.searchParams && typeof opts.searchParams.get('clientId') === 'string') {
+    opts.clientId = opts.searchParams.get('clientId')
+  }
+
+  // legacy support for url.parse objects (now deprecated in node.js)
   if (opts.query && typeof opts.query.clientId === 'string') {
     opts.clientId = opts.query.clientId
   }

--- a/lib/connect/ws.js
+++ b/lib/connect/ws.js
@@ -3,7 +3,7 @@
 const WS = require('ws')
 const debug = require('debug')('mqttjs:ws')
 const duplexify = require('duplexify')
-const urlModule = require('url')
+const Buffer = require('safe-buffer').Buffer
 const Transform = require('readable-stream').Transform
 
 let WSS_OPTIONS = [
@@ -69,7 +69,7 @@ function setDefaultBrowserOpts (opts) {
     if (typeof (document) === 'undefined') {
       throw new Error('Could not determine host. Specify host manually.')
     }
-    const parsed = urlModule.parse(document.URL)
+    const parsed = new URL(document.URL)
     options.hostname = parsed.hostname
 
     if (!options.port) {

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -1,9 +1,8 @@
 'use strict'
 
 var mqtt = require('../../lib/connect')
-var _URL = require('url')
 var xtend = require('xtend')
-var parsed = _URL.parse(document.URL)
+var parsed = new URL(document.URL)
 var isHttps = parsed.protocol === 'https:'
 var port = parsed.port || (isHttps ? 443 : 80)
 var host = parsed.hostname

--- a/test/mqtt.js
+++ b/test/mqtt.js
@@ -18,7 +18,7 @@ describe('mqtt', function () {
       (function () {
         var c = mqtt.connect('foo.bar.com')
         c.end()
-      }).should.throw('Missing protocol')
+      }).should.throw('Invalid URL: foo.bar.com')
     })
 
     it('should throw an error when called with no protocol specified - with options', function () {


### PR DESCRIPTION
This fixes https://github.com/mqttjs/MQTT.js/issues/1130 by replacing url.parse by the URL class as advised by the [Node documentation](https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost) on the subject:
```quote
Use of the legacy url.parse() method is discouraged. Users should use the WHATWG URL API. Because the url.parse() method 
uses a lenient, non-standard algorithm for parsing URL strings, security issues can be introduced. Specifically, issues with host 
name spoofing and incorrect handling of usernames and passwords have been identified.
```

Kind regards,
Hans