### PR TITLE
fix: update alis for fix alimin program app

### DIFF
--- a/lib/connect/ali.js
+++ b/lib/connect/ali.js
@@ -14,7 +14,8 @@ function buildProxy () {
   var proxy = new Transform()
   proxy._write = function (chunk, encoding, next) {
     my.sendSocketMessage({
-      data: chunk.buffer,
+      data: chunk.toString('base64'),
+      isBuffer: 1,
       success: function () {
         next()
       },
@@ -116,7 +117,9 @@ function buildStream (client, opts) {
   my = opts.my
   my.connectSocket({
     url: url,
-    protocols: websocketSubProtocol
+    headers : {
+      "Sec-WebSocket-Protocol" : "mqtt"
+    }
   })
 
   proxy = buildProxy()


### PR DESCRIPTION
I am from Alibaba Cloud IoT Business Unit. I provide jssdk for developers to connect to the Alibaba Cloud IoT platform (https://github.com/aliyun/alibabacloud-iot-device-sdk). I recently found that the users of Alibaba Applet cannot work normally The reason for using it is that mqttjs uses Alipay APIs that are not standardized (this problem is located with Yunfeng, a classmate of Alipay applet container development), so the correct modification is proposed as follows:

Correct mqttjs error when using Alipay applet mqtt connection
1: my.connectSocket incoming protocol will be intercepted, you need to increase the headers parameter
2: sendSocketMessage data needs to be a base64 string, and isBuffer: 1 is required

issue : https://github.com/mqttjs/MQTT.js/pull/1057