### PR TITLE
Don't send empty username and password

### DIFF
--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -73,8 +73,8 @@ function connect (brokerUrl, opts) {
     opts.pathname = parsed.pathname
     opts.port = Number(parsed.port) || null
     opts.protocol = parsed.protocol
-    opts.username = opts.username || parsed.username
-    opts.password = opts.password || parsed.password
+    opts.username = opts.username || parsed.username || null
+    opts.password = opts.password || parsed.password || null
     opts.search = parsed.search
     opts.searchParams = parsed.searchParams
     opts.path = parsed.pathname + parsed.search


### PR DESCRIPTION
Since 70a247c changed how we generate options, we now end up sending an empty username and password when they are not set, instead of sending _no_ username and password. This ends up confusing some MQTT servers, which don't properly detect an empty username/password as an anonymous login.

This can be seen most clearly in the connect flags:

### b5b3814 (one commit before 70a247c)
```
Connect Flags: 0x02, QoS Level: At most once delivery (Fire and Forget), Clean Session Flag
    0... .... = User Name Flag: Not set
    .0.. .... = Password Flag: Not set
    ..0. .... = Will Retain: Not set
    ...0 0... = QoS Level: At most once delivery (Fire and Forget) (0)
    .... .0.. = Will Flag: Not set
    .... ..1. = Clean Session Flag: Set
    .... ...0 = (Reserved): Not set
```

### 70a247c
```
Connect Flags: 0xc2, User Name Flag, Password Flag, QoS Level: At most once delivery (Fire and Forget), Clean Session Flag
    1... .... = User Name Flag: Set
    .1.. .... = Password Flag: Set
    ..0. .... = Will Retain: Not set
    ...0 0... = QoS Level: At most once delivery (Fire and Forget) (0)
    .... .0.. = Will Flag: Not set
    .... ..1. = Clean Session Flag: Set
    .... ...0 = (Reserved): Not set
```

Setting the options to null when they're false-y seems to fix this.