### PR TITLE
fix #1157

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1450,7 +1450,7 @@ MqttClient.prototype._resubscribe = function (connack) {
   debug('_resubscribe')
   var _resubscribeTopicsKeys = Object.keys(this._resubscribeTopics)
   if (!this._firstConnection &&
-      (this.options.clean || (this.options.protocolVersion === 5 && !connack.sessionPresent)) &&
+      (this.options.clean || (this.options.protocolVersion >= 4 && !connack.sessionPresent)) &&
       _resubscribeTopicsKeys.length > 0) {
     if (this.options.resubscribe) {
       if (this.options.protocolVersion === 5) {


### PR DESCRIPTION
`connack.sessionPresent` check should also check MQTT 3.1.1, because it also have `sessionPresent` property.
http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718035