### PR TITLE
fix multi protocol test mechanism.

### DIFF
--- a/test/client.js
+++ b/test/client.js
@@ -18,7 +18,7 @@ var debug = require('debug')('TEST:client')
 
 describe('MqttClient', function () {
   var client
-  var server = serverBuilder()
+  var server = serverBuilder('mqtt')
   var config = {protocol: 'mqtt', port: ports.PORT}
   server.listen(ports.PORT)
 
@@ -277,7 +277,7 @@ describe('MqttClient', function () {
     it('should not keep requeueing the first message when offline', function (done) {
       this.timeout(2500)
 
-      var server2 = serverBuilder().listen(ports.PORTAND45)
+      var server2 = serverBuilder('mqtt').listen(ports.PORTAND45)
       client = mqtt.connect({
         port: ports.PORTAND45,
         host: 'localhost',

--- a/test/client_mqtt5.js
+++ b/test/client_mqtt5.js
@@ -8,7 +8,7 @@ var serverBuilder = require('./server_helpers_for_client_tests').serverBuilder
 var ports = require('./helpers/port_list')
 
 describe('MQTT 5.0', function () {
-  var server = serverBuilder().listen(ports.PORTAND115)
+  var server = serverBuilder('mqtt').listen(ports.PORTAND115)
   var config = { protocol: 'mqtt', port: ports.PORTAND115, protocolVersion: 5, properties: { maximumPacketSize: 200 } }
 
   abstractClientTests(server, config)

--- a/test/server_helpers_for_client_tests.js
+++ b/test/server_helpers_for_client_tests.js
@@ -1,16 +1,26 @@
 'use strict'
 
 var MqttServer = require('./server').MqttServer
-var MqttServerNoWait = require('./server').MqttServerNoWait
+var MqttSecureServer = require('./server').MqttSecureServer
 var debug = require('debug')('TEST:server_helpers')
+
+var path = require('path')
+var fs = require('fs')
+var KEY = path.join(__dirname, 'helpers', 'tls-key.pem')
+var CERT = path.join(__dirname, 'helpers', 'tls-cert.pem')
+
+var http = require('http')
+var WebSocket = require('ws')
+var MQTTConnection = require('mqtt-connection')
 
 /**
  * This will build the client for the server to use during testing, and set up the
  * server side client based on mqtt-connection for handling MQTT messages.
- * @param {boolean} fastFlag
+ * @param {String} protocol - 'mqtt', 'mqtts' or 'ws'
+ * @param {Function} handler - event handler
  */
-function serverBuilder (fastFlag) {
-  var handler = function (serverClient) {
+function serverBuilder (protocol, handler) {
+  var defaultHandler = function (serverClient) {
     serverClient.on('auth', function (packet) {
       var rc = 'reasonCode'
       var connack = {}
@@ -90,10 +100,39 @@ function serverBuilder (fastFlag) {
       debug('disconnected from server')
     })
   }
-  if (fastFlag) {
-    return new MqttServerNoWait(handler)
-  } else {
-    return new MqttServer(handler)
+
+  if (!handler) {
+    handler = defaultHandler
+  }
+
+  switch (protocol) {
+    case 'mqtt':
+      return new MqttServer(handler)
+    case 'mqtts':
+      return new MqttSecureServer({
+        key: fs.readFileSync(KEY),
+        cert: fs.readFileSync(CERT)
+      },
+      handler)
+    case 'ws':
+      var attachWebsocketServer = function (server) {
+        var webSocketServer = new WebSocket.Server({server: server, perMessageDeflate: false})
+
+        webSocketServer.on('connection', function (ws) {
+          var stream = WebSocket.createWebSocketStream(ws)
+          var connection = new MQTTConnection(stream)
+          connection.protocol = ws.protocol
+          server.emit('client', connection)
+          stream.on('error', function () {})
+          connection.on('error', function () {})
+          connection.on('close', function () {})
+        })
+      }
+
+      var httpServer = http.createServer()
+      attachWebsocketServer(httpServer)
+      httpServer.on('client', handler)
+      return httpServer
   }
 }
 


### PR DESCRIPTION
I found an issue in test case where the wrong connection protocol was applied.

The test cases of abstract_client.js are designed for using multiple protocols (mqtt, mqtts, and ws).
However some of test cases used mqtt explicitly. So the test cases use only mqtt protocol three times instead of the combination of mqtt, mqtts, and ws.
It should be tested by mqtt, mqtts, and ws.

Send a PR with the following modifications.

### Updated test/server_helpers_for_client_tests.js

- Added code to create a broker for Secure(TLS)
- Added code to create a broker for WebSockets
- Moved MqttServerNoWait to test/ websocket_client.js

### Updated test/abstract_client.js

Fixed client creation.

__Before__
```js
        client = mqtt.connect({
```

__After__
```js
        client = connect({
```

Fixed broker creation. 
__Before__
```js
      var server2 = new MqttServer(function (serverClient) {
```

__After__
```js
      var server2 = serverBuilder(config.protocol, function (serverClient) {
```

### Updated test/websocket_client.js

I fixed the following test because it didn't go through the correct path.

```should reconnect to multiple host-ports-protocol combinations if servers is passed```

