### PR TITLE
fix #1235

### DIFF
--- a/lib/connect/ws.js
+++ b/lib/connect/ws.js
@@ -117,6 +117,7 @@ function streamBuilder (client, opts) {
   let socket = createWebSocket(client, url, options)
   let webSocketStream = WS.createWebSocketStream(socket, options.wsOptions)
   webSocketStream.url = url
+  socket.on('close', () => { webSocketStream.end() })
   return webSocketStream
 }
 

--- a/lib/connect/ws.js
+++ b/lib/connect/ws.js
@@ -117,7 +117,7 @@ function streamBuilder (client, opts) {
   let socket = createWebSocket(client, url, options)
   let webSocketStream = WS.createWebSocketStream(socket, options.wsOptions)
   webSocketStream.url = url
-  socket.on('close', () => { webSocketStream.end() })
+  socket.on('close', () => { webSocketStream.destroy() })
   return webSocketStream
 }
 


### PR DESCRIPTION

fix #1235

Call the end() of the WebSocket stream when the Websocket close event emit.