### PR TITLE
Add missing 'duplexify' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "commist": "^1.0.0",
     "concat-stream": "^2.0.0",
     "debug": "^4.1.1",
+    "duplexify": "^4.1.1",
     "help-me": "^1.0.1",
     "inherits": "^2.0.3",
     "minimist": "^1.2.5",


### PR DESCRIPTION
'duplexify' is used by MQTT.js but not present in package.json

###### References
- https://github.com/mqttjs/MQTT.js/blob/37b12cb9/lib/connect/ali.js#L4
- https://github.com/mqttjs/MQTT.js/blob/37b12cb9/lib/connect/wx.js#L4
- https://github.com/mqttjs/MQTT.js/blob/37b12cb9/lib/connect/ws.js#L5
- https://github.com/mqttjs/MQTT.js/issues/1215