### PR TITLE
Skip TLS SNI if host is IP address

### DIFF
--- a/lib/connect/tls.js
+++ b/lib/connect/tls.js
@@ -1,12 +1,16 @@
 'use strict'
 var tls = require('tls')
+var net = require('net')
 var debug = require('debug')('mqttjs:tls')
 
 function buildBuilder (mqttClient, opts) {
   var connection
   opts.port = opts.port || 8883
   opts.host = opts.hostname || opts.host || 'localhost'
-  opts.servername = opts.host
+
+  if(net.isIP(opts.host) === 0){
+    opts.servername = opts.host
+  }
 
   opts.rejectUnauthorized = opts.rejectUnauthorized !== false
 


### PR DESCRIPTION
This avoids showing a warning when the broker address is just an IP
[DEP0123] DeprecationWarning: Setting the TLS ServerName to an IP address is not permitted by RFC 6066. This will be ignored in a future version.
Same fix as node-postgres has used https://github.com/brianc/node-postgres/pull/1890/commits/d3c8ebac78347ee3bd21f3734cd05ae9acf5762a