### PR TITLE
Add support for ALPN TLS extension

### DIFF
--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -131,6 +131,10 @@ export interface ISecureClientOptions {
    */
   ca?: string | string[] | Buffer | Buffer[]
   rejectUnauthorized?: boolean
+  /**
+   * optional alpn's
+   */
+  ALPNProtocols?: string[] | Buffer[] | Uint8Array[] | Buffer | Uint8Array;
 }
 export interface IClientPublishOptions {
   /**

--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -134,7 +134,7 @@ export interface ISecureClientOptions {
   /**
    * optional alpn's
    */
-  ALPNProtocols?: string[] | Buffer[] | Uint8Array[] | Buffer | Uint8Array;
+  ALPNProtocols?: string[] | Buffer[] | Uint8Array[] | Buffer | Uint8Array
 }
 export interface IClientPublishOptions {
   /**


### PR DESCRIPTION
This Pull Request adds support for ALPN.  
With this change it is now possible to use AWS MQTT Broker on Port 443 with Custom Authorization.  
More information at: https://docs.aws.amazon.com/iot/latest/developerguide/protocols.html  

This change is not AWS specific, there's more use cases behind the support of this feature.  

For more references have a look at the NodeJS types repository: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/tls.d.ts#L446

Example:  
```
mqtt.connect("AWS_ACCOUNT_ID-ats.iot.eu-west-1.amazonaws.com", {
  ...
  port: 443,
  ALPNProtocols = ['mqtt']
  ...
})
```