### PR TITLE
fix: messageeId

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -343,7 +343,7 @@ function MqttClient (streamBuilder, options) {
       var send = true
       if (packet.messageId && packet.messageId !== 0) {
         if (!that.messageIdProvider.register(packet.messageId)) {
-          packet.messageeId = that.messageIdProvider.allocate()
+          packet.messageId = that.messageIdProvider.allocate()
           if (packet.messageId === null) {
             send = false
           }


### PR DESCRIPTION
typo causes send to never be falsy