### PR TITLE
Rework examples to be a bit more specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ in JavaScript for node.js and the browser.
 * [Command Line Tools](#cli)
 * [API](#api)
 * [Browser](#browser)
-* [Weapp and Ali support](#weapp-alipay)
 * [About QoS](#qos)
 * [TypeScript](#typescript)
+* [Weapp and Ali support](#weapp-alipay)
 * [Contributing](#contributing)
 * [License](#license)
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@
 MQTT.js is a client library for the [MQTT](http://mqtt.org/) protocol, written
 in JavaScript for node.js and the browser.
 
+## Table of Contents
 * [__MQTT.js vNext__](#vnext)
 * [Upgrade notes](#notes)
 * [Installation](#install)
 * [Example](#example)
+* [Import Styles](#example)
 * [Command Line Tools](#cli)
 * [API](#api)
 * [Browser](#browser)
-* [Weapp](#weapp)
+* [Weapp and Ali support](#weapp-alipay)
 * [About QoS](#qos)
 * [TypeScript](#typescript)
 * [Contributing](#contributing)

--- a/README.md
+++ b/README.md
@@ -115,6 +115,25 @@ If you do not want to install a separate broker, you can try using the
 
 to use MQTT.js in the browser see the [browserify](#browserify) section
 
+<a name="import_styles"></a>
+## Import styles
+### CommonJS (Require)
+```js
+var mqtt = require('mqtt')  // require mqtt
+var client = mqtt.connect('est.mosquitto.org')  // create a client
+```
+### ES6 Modules (Import)
+#### Aliased wildcard import
+```js
+import * as mqtt from "mqtt"  // import everything inside the mqtt module and give it the namespace "mqtt"
+let client = mqtt.connect('mqtt://test.mosquitto.org') // create a client
+```
+#### Importing individual components
+```js
+import { connect } from "mqtt"  // import connect from mqtt
+let client = connect('mqtt://test.mosquitto.org') // create a client
+```
+
 <a name="promises"></a>
 ## Promise support
 
@@ -275,7 +294,7 @@ Connects to the broker specified by the given url and options and
 returns a [Client](#client).
 
 The URL can be on the following protocols: 'mqtt', 'mqtts', 'tcp',
-'tls', 'ws', 'wss'. The URL can also be an object as returned by
+'tls', 'ws', 'wss', 'wxs', 'alis'. The URL can also be an object as returned by
 [`URL.parse()`](http://nodejs.org/api/url.html#url_url_parse_urlstr_parsequerystring_slashesdenotehost),
 in that case the two objects are merged, i.e. you can pass a single
 object with both the URL and the connect options.
@@ -651,42 +670,6 @@ The MQTT.js bundle is available through http://unpkg.com, specifically
 at https://unpkg.com/mqtt/dist/mqtt.min.js.
 See http://unpkg.com for the full documentation on version ranges.
 
-<a name="weapp"></a>
-## WeChat Mini Program
-Support [WeChat Mini Program](https://mp.weixin.qq.com/). See [Doc](https://mp.weixin.qq.com/debug/wxadoc/dev/api/network-socket.html).
-<a name="example"></a>
-
-## Example(js)
-
-```js
-var mqtt = require('mqtt')
-var client = mqtt.connect('wxs://test.mosquitto.org')
-```
-
-## Example(ts)
-
-```ts
-import { connect } from 'mqtt';
-const client = connect('wxs://test.mosquitto.org');
-```
-
-## Ali Mini Program
-Surport [Ali Mini Program](https://open.alipay.com/channel/miniIndex.htm). See [Doc](https://docs.alipay.com/mini/developer/getting-started).
-<a name="example"></a>
-
-## Example(js)
-
-```js
-var mqtt = require('mqtt')
-var client = mqtt.connect('alis://test.mosquitto.org')
-```
-
-## Example(ts)
-
-```ts
-import { connect } from 'mqtt';
-const client  = connect('alis://test.mosquitto.org');
-```
 
 <a name="browserify"></a>
 ### Browserify
@@ -806,6 +789,31 @@ Before you can begin using these TypeScript definitions with your project, you n
  * Set tsconfig.json: `{"compilerOptions" : {"moduleResolution" : "node"}, ...}`
  * Includes the TypeScript definitions for node. You can use npm to install this by typing the following into a terminal window:
    `npm install --save-dev @types/node`
+   
+### Typescript example
+```
+import * as mqtt from "mqtt"
+let client : mqtt.MqttClient = mqtt.connect('mqtt://test.mosquitto.org')
+```
+
+<a name="weapp-alipay"></a>
+## WeChat and Ali Mini Program support
+### WeChat Mini Program
+Supports [WeChat Mini Program](https://mp.weixin.qq.com/). Use the `wxs` protocol. See [the WeChat docs](https://mp.weixin.qq.com/debug/wxadoc/dev/api/network-socket.html).
+
+```js
+var mqtt = require('mqtt')
+var client = mqtt.connect('wxs://test.mosquitto.org')
+```
+
+### Ali Mini Program
+Supports [Ali Mini Program](https://open.alipay.com/channel/miniIndex.htm). Use the `alis` protocol. See [the Alipay docs](https://docs.alipay.com/mini/developer/getting-started).
+<a name="example"></a>
+
+```js
+var mqtt = require('mqtt')
+var client = mqtt.connect('alis://test.mosquitto.org')
+```
 
 <a name="contributing"></a>
 ## Contributing
@@ -826,6 +834,7 @@ MQTT.js is only possible due to the excellent work of the following contributors
 <tr><th align="left">Maxime Agor</th><td><a href="https://github.com/4rzael">GitHub/4rzael</a></td><td><a href="http://twitter.com/4rzael">Twitter/@4rzael</a></td></tr>
 <tr><th align="left">Siarhei Buntsevich</th><td><a href="https://github.com/scarry1992">GitHub/scarry1992</a></td></tr>
 </tbody></table>
+
 
 <a name="license"></a>
 ## License


### PR DESCRIPTION
Firstly: I love this module, it's really helpful and I use it all the time.

I was using this module with TypeScript for the first time today and found the docs a bit confusing. I made these changes because I would have liked to have had this information up front and labelled more clearly:
* How to import the contents of MQTT.js in more than one import style
* A TypeScript example showing off one of the types in MQTT.js

I also added the WeChat and AliPay protocols to the list of the supported protocols because I thought it was a bit weird that they were listed in their own section but not there, and restructured the section to only contain one example of the specific usage to make it clearer what's different there.

Thank you! 😄 