### PR TITLE
fix(typescript): Use correct version of @types/ws

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,15 +74,15 @@
     "number-allocator": "^1.0.7",
     "pump": "^3.0.0",
     "readable-stream": "^3.6.0",
-    "rfdc": "^1.3.0",
     "reinterval": "^1.1.0",
+    "rfdc": "^1.3.0",
     "split2": "^3.1.0",
-    "ws": "^7.5.0",
+    "ws": "^7.5.5",
     "xtend": "^4.0.2"
   },
   "devDependencies": {
     "@types/node": "^10.0.0",
-    "@types/ws": "^8.2.0",
+    "@types/ws": "^7.4.7",
     "aedes": "^0.42.5",
     "airtap": "^3.0.0",
     "browserify": "^16.5.0",


### PR DESCRIPTION
Version 8 is a stub, because in v8 types are integrated in the main package.