### PR TITLE
fix(type): add properties type for IClientSubscribeOptions

### DIFF
--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -179,7 +179,14 @@ export interface IClientSubscribeOptions {
   /*
   * Retain Handling option
   * */
-  rh?: number
+  rh?: number,
+  /*
+  *  MQTT 5.0 properies object of subscribe
+  * */
+  properties?: {
+    subscriptionIdentifier?: number,
+    userProperties?: UserProperties
+  }
 }
 export interface IClientReconnectOptions {
   /**


### PR DESCRIPTION
Hi, devs! @YoDaMa When I set the MQTT 5.0 properties on subscribe function, I found no properties type defined.

![image](https://user-images.githubusercontent.com/21299158/145968842-7b4f41ad-7266-4973-b892-4aac5fbeaab9.png)

Hopefully, this PR will fix this type of error.

Because when I checked the documentation, it supports this configuration.

![image](https://user-images.githubusercontent.com/21299158/145969390-8bd7204b-0c9b-4f15-9bb6-34d5674f4a09.png)

