### PR TITLE
Removed collections.js dependency from number-allocator.

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "inherits": "^2.0.3",
     "minimist": "^1.2.5",
     "mqtt-packet": "^6.8.0",
-    "number-allocator": "^1.0.8",
+    "number-allocator": "^1.0.9",
     "pump": "^3.0.0",
     "readable-stream": "^3.6.0",
     "reinterval": "^1.1.0",


### PR DESCRIPTION
Since number-allocator https://www.npmjs.com/package/number-allocator
1.0.9, js-sdsl https://www.npmjs.com/package/js-sdsl is used insteaad of
collections https://www.npmjs.com/package/collections.

collections modify intrinsic type such as Array, it has unexpected side
effect for users. So I removed the dependency of collections.

It is a partial fix for #1392.

Replacement for LRU map is still needed to remove collections dependency.