### PR TITLE
Fix the typings for the connect function to have the proper overloads

### DIFF
--- a/types/lib/connect/index.d.ts
+++ b/types/lib/connect/index.d.ts
@@ -1,10 +1,25 @@
-import { IClientOptions, MqttClient } from '../client'
+import { IClientOptions, MqttClient } from "../client";
 /**
  * connect - connect to an MQTT broker.
  *
- * @param {String} [brokerUrl] - url of the broker, optional
+ * @param {String} brokerUrl - url of the broker
+ */
+declare function connect(brokerUrl: string): MqttClient;
+
+/**
+ * connect - connect to an MQTT broker.
+ *
  * @param {Object} opts - see MqttClient#constructor
  */
-declare function connect (brokerUrl?: string | any, opts?: IClientOptions): MqttClient
-export { connect }
-export { MqttClient }
+declare function connect(opts: IClientOptions): MqttClient;
+
+/**
+ * connect - connect to an MQTT broker.
+ *
+ * @param {String} brokerUrl - url of the broker
+ * @param {Object} opts - see MqttClient#constructor
+ */
+declare function connect(brokerUrl: string, opts: IClientOptions): MqttClient;
+
+export { connect };
+export { MqttClient };


### PR DESCRIPTION
This makes it so that it makes it more readily apparent that you can omit the URL string, and provide the options as the first parameter instead.
This change purely effects the typing in order to make it better represent the underlying code, so it shouldn't cause any breaking changes.