### PR TITLE
fix: buffer is not defined in browser

### DIFF
--- a/lib/connect/ali.js
+++ b/lib/connect/ali.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const Transform = require('readable-stream').Transform
 const duplexify = require('duplexify')
 

--- a/lib/connect/ws.js
+++ b/lib/connect/ws.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const WS = require('ws')
 const debug = require('debug')('mqttjs:ws')
 const duplexify = require('duplexify')

--- a/lib/connect/wx.js
+++ b/lib/connect/wx.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const Transform = require('readable-stream').Transform
 const duplexify = require('duplexify')
 

--- a/types/lib/connect/index.d.ts
+++ b/types/lib/connect/index.d.ts
@@ -1,17 +1,11 @@
-import { IClientOptions, MqttClient } from "../client";
-/**
- * connect - connect to an MQTT broker.
- *
- * @param {String} brokerUrl - url of the broker
- */
-declare function connect(brokerUrl: string): MqttClient;
+import { IClientOptions, MqttClient } from '../client'
 
 /**
  * connect - connect to an MQTT broker.
  *
  * @param {Object} opts - see MqttClient#constructor
  */
-declare function connect(opts: IClientOptions): MqttClient;
+declare function connect (opts: IClientOptions): MqttClient
 
 /**
  * connect - connect to an MQTT broker.
@@ -19,7 +13,7 @@ declare function connect(opts: IClientOptions): MqttClient;
  * @param {String} brokerUrl - url of the broker
  * @param {Object} opts - see MqttClient#constructor
  */
-declare function connect(brokerUrl: string, opts: IClientOptions): MqttClient;
+declare function connect (brokerUrl: string, opts?: IClientOptions): MqttClient
 
-export { connect };
-export { MqttClient };
+export { connect }
+export { MqttClient }


### PR DESCRIPTION
fix issue https://github.com/mqttjs/MQTT.js/issues/1412
The Node.js doc recommends to explicitly import or require 'buffer':
> While the Buffer class is available within the global scope, it is still recommended to explicitly reference it via an import or require statement.
https://nodejs.org/api/buffer.html

Similar as https://github.com/mqttjs/mqtt-packet/pull/128