### PR TITLE
fix: `_storeProcessing` staying true after outStore got emptied

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1806,7 +1806,6 @@ MqttClient.prototype._onConnect = function (packet) {
       if (!outStore) {
         return
       }
-      that._storeProcessing = true
 
       const packet = outStore.read(1)
 
@@ -1817,6 +1816,8 @@ MqttClient.prototype._onConnect = function (packet) {
         outStore.once('readable', storeDeliver)
         return
       }
+
+      that._storeProcessing = true
 
       // Skip already processed store packets
       if (that._packetIdsDuringStoreProcessing[packet.messageId]) {


### PR DESCRIPTION
This PR makes sure that new messages get published after a local store that accumulated some messages while the broker was offline, reconnects. In storeDeliver, this._storeProcessing got set to true before the check if there are actually stored packets left to send. So if there aren't any, this._storeProcessing will still be true on the next publish(), resulting in packets accumulating in this._storeProcessingQueue, but their invokes are never called, because Readable Event 'end' has already happened for the emptied Store and no new messages will be put into the Store as well. 

Fixes #1116 

