### PR TITLE
fix: error events in a browser environment are emitted without any parameters

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -18,8 +18,14 @@ const xtend = require('xtend')
 const debug = require('debug')('mqttjs:client')
 const nextTick = process ? process.nextTick : function (callback) { setTimeout(callback, 0) }
 const setImmediate = global.setImmediate || function (callback) {
+  // Copy function arguments
+  const args = new Array(arguments.length - 1)
+  for (let i = 0; i < args.length; i++) {
+    args[i] = arguments[i + 1]
+  }
+
   // works in node v0.8
-  nextTick(callback)
+  nextTick(function () { callback.apply(undefined, args) })
 }
 const defaultConnectOptions = {
   keepalive: 60,


### PR DESCRIPTION
In a browser, where the `setImmediate` and `nextTick` polyfills are needed, the Errors being passed such as [this scenario](https://github.com/mqttjs/MQTT.js/blob/3451564363cf0933355ab6d66e73c80fa13379e8/lib/client.js#L726) are ignored.

Issue was originally raised [here](https://github.com/mqttjs/MQTT.js/issues/1474).