### PR TITLE
feat: export validation code for stand alone use in other projects

### DIFF
--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -2,6 +2,7 @@
 
 const MqttClient = require('../client')
 const Store = require('../store')
+const validations = require('../validations')
 const url = require('url')
 const xtend = require('xtend')
 const debug = require('debug')('mqttjs')
@@ -163,3 +164,4 @@ module.exports = connect
 module.exports.connect = connect
 module.exports.MqttClient = MqttClient
 module.exports.Store = Store
+module.exports.validations = validations

--- a/lib/validations.js
+++ b/lib/validations.js
@@ -1,17 +1,13 @@
 'use strict'
 
 /**
- * Validate a topic to see if it's valid or not.
- * A topic is valid if it follow below rules:
- * - Rule #1: If any part of the topic is not `+` or `#`, then it must not contain `+` and '#'
- * - Rule #2: Part `#` must be located at the end of the mailbox
+ * Validate the parts of a topic to see if it's valid or not.
  *
- * @param {String} topic - A topic
+ * @see {validateTopic}
+ * @param {String[]} parts
  * @returns {Boolean} If the topic is valid, returns true. Otherwise, returns false.
  */
-function validateTopic (topic) {
-  const parts = topic.split('/')
-
+function validateTopicParts (parts) {
   for (let i = 0; i < parts.length; i++) {
     if (parts[i] === '+') {
       continue
@@ -31,8 +27,21 @@ function validateTopic (topic) {
 }
 
 /**
+ * Validate a topic to see if it's valid or not.
+ * A topic is valid if it follow below rules:
+ * - Rule #1: If any part of the topic is not `+` or `#`, then it must not contain `+` and '#'
+ * - Rule #2: Part `#` must be located at the end of the mailbox
+ *
+ * @param {String} topic - A topic
+ * @returns {Boolean} If the topic is valid, returns true. Otherwise, returns false.
+ */
+function validateTopic (topic) {
+  return validateTopicParts(topic.split('/'))
+}
+
+/**
  * Validate an array of topics to see if any of them is valid or not
-  * @param {Array} topics - Array of topics
+ * @param {Array} topics - Array of topics
  * @returns {String} If the topics is valid, returns null. Otherwise, returns the invalid one
  */
 function validateTopics (topics) {
@@ -48,5 +57,7 @@ function validateTopics (topics) {
 }
 
 module.exports = {
+  validateTopicParts: validateTopicParts,
+  validateTopic: validateTopic,
   validateTopics: validateTopics
 }

--- a/mqtt.js
+++ b/mqtt.js
@@ -5,6 +5,7 @@
  * See LICENSE for more information
  */
 
+const validations = require('./lib/validations')
 const MqttClient = require('./lib/client')
 const connect = require('./lib/connect')
 const Store = require('./lib/store')
@@ -19,3 +20,4 @@ module.exports.Client = MqttClient
 module.exports.Store = Store
 module.exports.DefaultMessageIdProvider = DefaultMessageIdProvider
 module.exports.UniqueMessageIdProvider = UniqueMessageIdProvider
+module.exports.validations = validations

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,4 @@
+export * from './lib/validations'
 export * from './lib/client'
 export * from './lib/connect'
 export * from './lib/store'

--- a/types/lib/validations.d.ts
+++ b/types/lib/validations.d.ts
@@ -1,0 +1,28 @@
+declare export namespace validations {
+    /**
+     * Validate the parts of a topic to see if it's valid or not.
+     * 
+     * @see {validateTopic}
+     * @param {string[]} parts 
+     * @returns {boolean} If the topic is valid, returns true. Otherwise, returns false.
+     */
+    function validateTopicParts(parts: string[]) : boolean
+
+    /**
+     * Validate a topic to see if it's valid or not.
+     * A topic is valid if it follow below rules:
+     * - Rule #1: If any part of the topic is not `+` or `#`, then it must not contain `+` and '#'
+     * - Rule #2: Part `#` must be located at the end of the mailbox
+     *
+     * @param {string} topic - A topic
+     * @returns {boolean} If the topic is valid, returns true. Otherwise, returns false.
+     */
+    function validateTopic(topic: string) : boolean
+
+    /**
+     * Validate an array of topics to see if any of them is valid or not
+     * @param {string[]} topics - Array of topics
+     * @returns {'empty_topic_list' | string | null} If the topics is valid, returns null. Otherwise, returns the invalid one
+     */
+    function validateTopics(topics: string[]) : 'empty_topic_list' | string | null
+}


### PR DESCRIPTION
I have exposed the topic validation functions (alongside with their types) in order to allow third parties to benefit of their use without having to use the client itself.