### PR TITLE
fix: fix v4 wechat miniprogram connect error 修复v4版本无法在微信小程序中使用的bug

### DIFF
--- a/lib/connect/wx.js
+++ b/lib/connect/wx.js
@@ -10,9 +10,12 @@ let socketTask, proxy, stream
 function buildProxy () {
   const proxy = new Transform()
   proxy._write = function (chunk, encoding, next) {
+    // wechat socket send ArrayBuffer, we need convert Buffer to ArrayBuffer
+    // see https://developers.weixin.qq.com/miniprogram/dev/api/network/websocket/SocketTask.send.html
+    // see https://www.npmjs.com/package/buffer#convert-buffer-to-arraybuffer
     // we need slice, since the buffer underlying is not guaranteed to exactly represents the chunk typearray we want send
     socketTask.send({
-      data: chunk.byteLength == chunk.buffer.byteLength ? chunk.buffer : chunk.buffer.slice(0, chunk.byteLength),
+      data: (chunk.byteOffset == 0 && chunk.byteLength == chunk.buffer.byteLength) ? chunk.buffer : chunk.buffer.slice(chunk.byteOffset, chunk.byteOffset+chunk.byteLength),
       success: function () {
         next()
       },

--- a/lib/connect/wx.js
+++ b/lib/connect/wx.js
@@ -10,8 +10,9 @@ let socketTask, proxy, stream
 function buildProxy () {
   const proxy = new Transform()
   proxy._write = function (chunk, encoding, next) {
+    // we need slice, since the buffer underlying is not guaranteed to exactly represents the chunk typearray we want send
     socketTask.send({
-      data: chunk.buffer,
+      data: chunk.byteLength == chunk.buffer.byteLength ? chunk.buffer : chunk.buffer.slice(0, chunk.byteLength),
       success: function () {
         next()
       },

--- a/lib/connect/wx.js
+++ b/lib/connect/wx.js
@@ -107,6 +107,7 @@ function buildStream (client, opts) {
 
   proxy = buildProxy()
   stream = duplexify.obj()
+  /*
   stream._destroy = function (err, cb) {
     socketTask.close({
       success: function () {
@@ -128,6 +129,7 @@ function buildStream (client, opts) {
       })
     }, 0)
   }.bind(stream)
+  */
 
   bindEventHandler()
 


### PR DESCRIPTION
wechat is exactly run like an browser environment, since we may use subarray to build a typedarray, the  buffer underlying is not  exactly represents the chunk typedarray we want send.

as the image below, we want send one Byte, but we send 4bytes

<img width="593" alt="image" src="https://user-images.githubusercontent.com/3275714/178086270-06d0ea3a-9e17-44a0-b396-5347dacc43a0.png">
<img width="722" alt="image" src="https://user-images.githubusercontent.com/3275714/178086274-add40572-0990-4326-838d-841061918fe5.png">

the reason is in MQTT-packet, we use subarray

 https://github.com/mqttjs/mqtt-packet/blob/7f7c2ed8bcb4b2c582851d120a94e0b4a731f661/numbers.js#L44

and we send the underlying buff

https://github.com/mqttjs/MQTT.js/blob/8b0fa591fbe6575ff855ede104f4d35472546167/lib/connect/wx.js#L12-L17




