### PR TITLE
fix(types): topic alias controls and password

### DIFF
--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -50,7 +50,7 @@ export interface IClientOptions extends ISecureClientOptions {
   /**
    * the password required by your broker, if any
    */
-  password?: string
+  password?: Buffer | string
   /**
    * a Store for the incoming packets
    */
@@ -60,6 +60,10 @@ export interface IClientOptions extends ISecureClientOptions {
    */
   outgoingStore?: Store
   queueQoSZero?: boolean
+
+  autoUseTopicAlias?: boolean
+  autoAssignTopicAlias?: boolean
+
   reschedulePings?: boolean
   servers?: Array<{
     host: string


### PR DESCRIPTION
* Adds typescript entries for the two top-level topic alias controls in client config: autoUseTopicAlias and autoAssignTopicAlias
* Modifies password entry to properly reflect the fact that password is, by specification, binary data (https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901072).  Leave string in for backwards compatibility.