### PR TITLE
fix: topicAliasMaximum under must be under Connect properties

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -270,7 +270,7 @@ function MqttClient (streamBuilder, options) {
   debug('MqttClient :: options.keepalive', options.keepalive)
   debug('MqttClient :: options.reconnectPeriod', options.reconnectPeriod)
   debug('MqttClient :: options.rejectUnauthorized', options.rejectUnauthorized)
-  debug('MqttClient :: options.topicAliasMaximum', options.topicAliasMaximum)
+  debug('MqttClient :: options.properties.topicAliasMaximum', options.properties.topicAliasMaximum)
 
   this.options.clientId = (typeof options.clientId === 'string') ? options.clientId : defaultId()
 
@@ -320,11 +320,11 @@ function MqttClient (streamBuilder, options) {
   // True if connection is first time.
   this._firstConnection = true
 
-  if (options.topicAliasMaximum > 0) {
-    if (options.topicAliasMaximum > 0xffff) {
-      debug('MqttClient :: options.topicAliasMaximum is out of range')
+  if (options.properties && options.properties.topicAliasMaximum > 0) {
+    if (options.properties.topicAliasMaximum > 0xffff) {
+      debug('MqttClient :: options.properties.topicAliasMaximum is out of range')
     } else {
-      this.topicAliasRecv = new TopicAliasRecv(options.topicAliasMaximum)
+      this.topicAliasRecv = new TopicAliasRecv(options.properties.topicAliasMaximum)
     }
   }
 


### PR DESCRIPTION
It looks the `topicAliasMaximum` is under the wrong object.
This seems to be affecting https://github.com/emqx/MQTTX