### PR TITLE
fix(types): subscribe definition

### DIFF
--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -196,6 +196,15 @@ export interface IClientSubscribeOptions {
     userProperties?: UserProperties
   }
 }
+export interface IClientSubscribeProperties {
+  /*
+  *  MQTT 5.0 properies object of subscribe
+  * */
+  properties?: {
+    subscriptionIdentifier?: number,
+    userProperties?: UserProperties
+  }
+}
 export interface IClientReconnectOptions {
   /**
    * a Store for the incoming packets

--- a/types/lib/client.d.ts
+++ b/types/lib/client.d.ts
@@ -5,6 +5,7 @@ import {
   IClientOptions,
   IClientPublishOptions,
   IClientSubscribeOptions,
+  IClientSubscribeProperties,
   IClientReconnectOptions
 } from './client-options'
 import { Store } from './store'
@@ -164,7 +165,11 @@ export declare class MqttClient extends events.EventEmitter {
    */
   public subscribe (topic:
                      string
-                     | string[], opts: IClientSubscribeOptions, callback?: ClientSubscribeCallback): this
+                     | string[]
+                     | ISubscriptionMap,
+                    opts:
+                     IClientSubscribeOptions
+                     | IClientSubscribeProperties, callback?: ClientSubscribeCallback): this
   public subscribe (topic:
                      string
                      | string[]


### PR DESCRIPTION
TypeScript definition of subscribe() has two functions.
https://github.com/mqttjs/MQTT.js/blob/aa49aaf9856fe9f433005e850b490a96505add19/types/lib/client.d.ts#L165-L167
The type of the  first parameter is string or string[].
The second parameter is opts. opts could have properties. e.g.)SubscriptionIdentifier

https://github.com/mqttjs/MQTT.js/blob/aa49aaf9856fe9f433005e850b490a96505add19/types/lib/client.d.ts#L168-L171
The type of the first parameter is string, string[], or ISubscriptionMap.
ISubscriptionMap is defined as follows:
https://github.com/mqttjs/MQTT.js/blob/aa49aaf9856fe9f433005e850b490a96505add19/types/lib/client.d.ts#L57-L67

MQTT spec defines properties are in common for all subscription entries on one subscription.
So ISubscriptionMap doesn't have properties.

When ISubscriptionMap is passed as the first argument, then the following code is processed:
https://github.com/mqttjs/MQTT.js/blob/aa49aaf9856fe9f433005e850b490a96505add19/lib/client.js#L760-L780

qos, nl, rap, and rh are extraced from ISubscriptionMap, but propertiy such as SubscriptionIdentifier are gotten from opts. Because properties are in common for subscribe entries.

However, the TypeScript definition doesn't have a combination of ISubscriptionMap and opts (for properties).
So this PR add it to the following definition:
https://github.com/mqttjs/MQTT.js/blob/aa49aaf9856fe9f433005e850b490a96505add19/types/lib/client.d.ts#L165-L167

The type of opts is IClientSubscribeOptions that is defined as follows:
https://github.com/mqttjs/MQTT.js/blob/aa49aaf9856fe9f433005e850b490a96505add19/types/lib/client-options.d.ts#L170-L194

When opts is used with ISubscriptionMap, only properties field is required. So I added IClientSubscribeProperties.
