### PR TITLE
Fix memory leak in subscription "message-id to topic" mapping

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1637,6 +1637,7 @@ MqttClient.prototype._handleAck = function (packet) {
           }
         }
       }
+      delete this.messageIdToTopic[messageId]
       this._invokeStoreProcessingQueue()
       cb(null, packet)
       break


### PR DESCRIPTION
We've been using this library extensively in a project that makes a *lot* of subscriptions and have noticed that it's been leaking memory (which is causing NodeJS to crash with "JavaScript heap out of memory"). 

We've pinpointed this to the MQTT.js library's "message id to subscription" mapping:

A message ID is assigned and stored in `messageIdToTopic` whenever a new subscription is started and resubscription is enabled (which is the default).  The message-id to topic mapping is never cleared and keeps accumulating over time, which creates a memory leak that can not be resolved by the caller. 

This mapping seems to have been introduced as a way to prevent resubscriptions of topics that have failed to subscribe on their first attempt, as introduced in as part of https://github.com/mqttjs/MQTT.js/pull/665 in https://github.com/mqttjs/MQTT.js/commit/f6d12f04c1c689c028961d396f79324b60d6cf8d

There's, unless I'm overlooking something, no reason to keep this mapping in place once an acknowledgement is received. With that assumption, I've created a few tests to reproduce the issue and have created a simple fix that clears the mapping when `SUBACK` is received. 

We've been running a patched version of the library and have noticed a significant reduce in memory usage and can confirm that, for us, the memory leak has been resolved. Would love to get this included upstream though. If there's something that we missed, I'd love to know too!