### PR TITLE
feat: react-native support

### DIFF
--- a/lib/connect/react-native.js
+++ b/lib/connect/react-native.js
@@ -1,0 +1,20 @@
+'use strict'
+
+// React Native might not have a process object, so we need to polyfill it
+if (typeof process === 'undefined') {
+  // eslint-disable-next-line no-global-assign
+  process = {}
+};
+
+// We need set the value of process.title, which mqtt.js uses to determine if it's running inside a browser
+// like environment and thus knows it doesn't have access to NodeJS core modules like net, tls
+process.title = 'browser'
+
+// Legitimate polyfill for process.nextTick, necessary for Duplexify, which is used by mqtt-packet
+process.nextTick = setImmediate
+
+// Polyfill for Buffer, which is present in NodeJS core, but not in the React Native environment
+global.Buffer = global.Buffer || require('safe-buffer').Buffer
+
+// Entry point for a browser like environment
+module.exports = require('./index')

--- a/package.json
+++ b/package.json
@@ -60,6 +60,12 @@
     "tls": false,
     "net": false
   },
+  "react-native": {
+    "./mqtt.js": "./lib/connect/react-native.js",
+    "fs": false,
+    "tls": false,
+    "net": false
+  },
   "dependencies": {
     "commist": "^1.0.0",
     "concat-stream": "^2.0.0",
@@ -75,6 +81,7 @@
     "readable-stream": "^4.1.0",
     "reinterval": "^1.1.0",
     "rfdc": "^1.3.0",
+    "safe-buffer": "^5.2.1",
     "split2": "^3.1.0",
     "ws": "^7.5.5",
     "xtend": "^4.0.2"


### PR DESCRIPTION
Add support for React Native by leveraging the `react-native` entrypoint (metro bundler makes use of it), extending the browser behaviour and polyfilling anything that still broke

This does introduce a [tiny](https://bundlephobia.com/package/safe-buffer@5.2.1) package `safe-buffer` to dependencies, which NodeJS doesn't need.

Resolves https://github.com/mqttjs/MQTT.js/issues/1264, https://github.com/mqttjs/MQTT.js/issues/573