### PR TITLE
fix(types): missing null declaration for error in subscription callback

### DIFF
--- a/types/lib/client.d.ts
+++ b/types/lib/client.d.ts
@@ -68,7 +68,7 @@ export interface ISubscriptionMap {
 
 export declare type OnConnectCallback = (packet: IConnackPacket) => void
 export declare type OnDisconnectCallback = (packet: IDisconnectPacket) => void
-export declare type ClientSubscribeCallback = (err: Error, granted: ISubscriptionGrant[]) => void
+export declare type ClientSubscribeCallback = (err: Error | null, granted: ISubscriptionGrant[]) => void
 export declare type OnMessageCallback = (topic: string, payload: Buffer, packet: IPublishPacket) => void
 export declare type OnPacketCallback = (packet: Packet) => void
 export declare type OnCloseCallback = () => void


### PR DESCRIPTION
The callback that can be passed to client.subscribe can be invoked with null as observed in link below, https://github.com/mqttjs/MQTT.js/blob/b3ce3da84147c86eb176759f53fa929e96de7969/lib/client.js#L784

The type of the callback does not reflect this and assumes an error is always present. This patch fixes this.