### PR TITLE
chore!: drop support for node 12-14

### DIFF
--- a/.github/workflows/mqttjs-test.yml
+++ b/.github/workflows/mqttjs-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
       fail-fast: false
 
     steps:

--- a/.github/workflows/release-it.yml
+++ b/.github/workflows/release-it.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: [ubuntu-latest]
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
     steps:
       - name: Checkout master
         uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "typescript": "^4.5.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@airtap/browserify-istanbul": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "mqtt.js"
   ],
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=16.0.0"
   },
   "browser": {
     "./mqtt.js": "./lib/connect/index.js",


### PR DESCRIPTION
BREAKING CHANGE: Dropped support for NodeJS 12-14