### PR TITLE
fix: consistency, used `this` instead of `that`

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -330,7 +330,7 @@ function MqttClient (streamBuilder, options) {
 
   // Send queued packets
   this.on('connect', function () {
-    const queue = this.queue
+    const queue = that.queue
 
     function deliver () {
       const entry = queue.shift()
@@ -372,10 +372,10 @@ function MqttClient (streamBuilder, options) {
 
   this.on('close', function () {
     debug('close :: connected set to `false`')
-    this.connected = false
+    that.connected = false
 
     debug('close :: clearing connackTimer')
-    clearTimeout(this.connackTimer)
+    clearTimeout(that.connackTimer)
 
     debug('close :: clearing ping timer')
     if (that.pingTimer !== null) {
@@ -383,12 +383,12 @@ function MqttClient (streamBuilder, options) {
       that.pingTimer = null
     }
 
-    if (this.topicAliasRecv) {
-      this.topicAliasRecv.clear()
+    if (that.topicAliasRecv) {
+      that.topicAliasRecv.clear()
     }
 
     debug('close :: calling _setupReconnect')
-    this._setupReconnect()
+    that._setupReconnect()
   })
   EventEmitter.call(this)
 


### PR DESCRIPTION
By looking at the code I found that in some anonimous functions both `this` and `that` were used. Giving that this happens on events listeners both works but it would be better to only use one for consistency