### PR TITLE
fix: problem with publish callback invoked twice

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1593,7 +1593,7 @@ class MqttClient extends EventEmitter {
     const messageId = packet.messageId
     const type = packet.cmd
     let response = null
-    const cb = this.outgoing[messageId] ? this.outgoing[messageId].cb : null
+    let cb = this.outgoing[messageId] ? this.outgoing[messageId].cb : null
     const that = this
     let err
 
@@ -1626,6 +1626,7 @@ class MqttClient extends EventEmitter {
           err = new Error('Publish error: ' + errors[pubackRC])
           err.code = pubackRC
           cb(err, packet)
+          // prevent invoking callback twice when deleting message from store #1511
           cb = null
         }
         delete this.outgoing[messageId]
@@ -1646,6 +1647,12 @@ class MqttClient extends EventEmitter {
           err = new Error('Publish error: ' + errors[pubrecRC])
           err.code = pubrecRC
           cb(err, packet)
+          // prevent invoking callback twice when deleting message from store #1511
+          cb = null
+          delete this.outgoing[messageId]
+          this.outgoingStore.del(packet, cb)
+          this.messageIdProvider.deallocate(messageId)
+          this._invokeStoreProcessingQueue()
         } else {
           this._sendPacket(response)
         }

--- a/lib/client.js
+++ b/lib/client.js
@@ -1626,6 +1626,7 @@ class MqttClient extends EventEmitter {
           err = new Error('Publish error: ' + errors[pubackRC])
           err.code = pubackRC
           cb(err, packet)
+          cb = null
         }
         delete this.outgoing[messageId]
         this.outgoingStore.del(packet, cb)

--- a/lib/client.js
+++ b/lib/client.js
@@ -1047,11 +1047,12 @@ class MqttClient extends EventEmitter {
    * @example client.removeOutgoingMessage(client.getLastAllocated());
    */
   removeOutgoingMessage (messageId) {
-    const cb = this.outgoing[messageId] ? this.outgoing[messageId].cb : null
-    delete this.outgoing[messageId]
-    this.outgoingStore.del({ messageId }, function () {
-      cb(new Error('Message removed'))
-    })
+    if (this.outgoing[messageId]) {
+      const cb = this.outgoing[messageId].cb
+      this._removeOutgoingAndStoreMessage(messageId, function () {
+        cb(new Error('Message removed'))
+      })
+    }
     return this
   }
 
@@ -1593,7 +1594,7 @@ class MqttClient extends EventEmitter {
     const messageId = packet.messageId
     const type = packet.cmd
     let response = null
-    let cb = this.outgoing[messageId] ? this.outgoing[messageId].cb : null
+    const cb = this.outgoing[messageId] ? this.outgoing[messageId].cb : null
     const that = this
     let err
 
@@ -1625,14 +1626,13 @@ class MqttClient extends EventEmitter {
         if (pubackRC && pubackRC > 0 && pubackRC !== 16) {
           err = new Error('Publish error: ' + errors[pubackRC])
           err.code = pubackRC
-          cb(err, packet)
-          // prevent invoking callback twice when deleting message from store #1511
-          cb = null
+          this._removeOutgoingAndStoreMessage(messageId, function () {
+            cb(err, packet)
+          })
+        } else {
+          this._removeOutgoingAndStoreMessage(messageId, cb)
         }
-        delete this.outgoing[messageId]
-        this.outgoingStore.del(packet, cb)
-        this.messageIdProvider.deallocate(messageId)
-        this._invokeStoreProcessingQueue()
+
         break
       }
       case 'pubrec': {
@@ -1646,13 +1646,9 @@ class MqttClient extends EventEmitter {
         if (pubrecRC && pubrecRC > 0 && pubrecRC !== 16) {
           err = new Error('Publish error: ' + errors[pubrecRC])
           err.code = pubrecRC
-          cb(err, packet)
-          // prevent invoking callback twice when deleting message from store #1511
-          cb = null
-          delete this.outgoing[messageId]
-          this.outgoingStore.del(packet, cb)
-          this.messageIdProvider.deallocate(messageId)
-          this._invokeStoreProcessingQueue()
+          this._removeOutgoingAndStoreMessage(messageId, function () {
+            cb(err, packet)
+          })
         } else {
           this._sendPacket(response)
         }
@@ -1896,7 +1892,9 @@ class MqttClient extends EventEmitter {
   }
 
   _invokeStoreProcessingQueue () {
-    if (this._storeProcessingQueue.length > 0) {
+    // If _storeProcessing is true, the message is resending.
+    // During resend, processing is skipped to prevent new messages from interrupting. #1635
+    if (!this._storeProcessing && this._storeProcessingQueue.length > 0) {
       const f = this._storeProcessingQueue[0]
       if (f && f.invoke()) {
         this._storeProcessingQueue.shift()
@@ -1916,6 +1914,22 @@ class MqttClient extends EventEmitter {
       if (f.callback) f.callback(new Error('Connection closed'))
     }
     this._storeProcessingQueue.splice(0)
+  }
+
+  /**
+   * _removeOutgoingAndStoreMessage
+   * @param {Number} messageId - messageId to remove message
+   * @param {Function} cb - called when the message removed
+   * @api private
+   */
+  _removeOutgoingAndStoreMessage (messageId, cb) {
+    const self = this
+    delete this.outgoing[messageId]
+    self.outgoingStore.del({ messageId }, function (err, packet) {
+      cb(err, packet)
+      self.messageIdProvider.deallocate(messageId)
+      self._invokeStoreProcessingQueue()
+    })
   }
 }
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -86,7 +86,7 @@ class Store {
     packet = this._inflights.get(packet.messageId)
     if (packet) {
       this._inflights.delete(packet.messageId)
-      if (cb) cb(null, packet)
+      cb(null, packet)
     } else if (cb) {
       cb(new Error('missing packet'))
     }

--- a/lib/store.js
+++ b/lib/store.js
@@ -86,7 +86,7 @@ class Store {
     packet = this._inflights.get(packet.messageId)
     if (packet) {
       this._inflights.delete(packet.messageId)
-      cb(null, packet)
+      if (cb) cb(null, packet)
     } else if (cb) {
       cb(new Error('missing packet'))
     }

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -1076,7 +1076,7 @@ module.exports = function (server, config) {
       })
     })
 
-    it.only('should fire a callback (qos 2) on error', function (done) {
+    it('should fire a callback (qos 2) on error', function (done) {
       // 145 = Packet Identifier in use
       const pubrecReasonCode = 145
       const pubOpts = { qos: 2 }

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -1014,6 +1014,57 @@ module.exports = function (server, config) {
       })
     })
 
+    it('should fire a callback (qos 1) on error', function (done) {
+      // 145 = Packet Identifier in use
+      const pubackReasonCode = 145
+      const pubOpts = { qos: 1 }
+      let client = null
+
+      const server2 = serverBuilder(config.protocol, function (serverClient) {
+        serverClient.on('connect', function () {
+          const connack = version === 5 ? { reasonCode: 0 } : { returnCode: 0 }
+          serverClient.connack(connack)
+        })
+        serverClient.on('publish', function (packet) {
+          if (packet.qos === 1) {
+            if (version === 5) {
+              serverClient.puback({
+                messageId: packet.messageId,
+                reasonCode: pubackReasonCode
+              })
+            } else {
+              serverClient.puback({ messageId: packet.messageId })
+            }
+          }
+        })
+      })
+
+      server2.listen(ports.PORTAND72, function () {
+        client = connect({
+          port: ports.PORTAND72,
+          host: 'localhost',
+          clean: true,
+          clientId: 'cid1',
+          reconnectPeriod: 0
+        })
+
+        client.once('connect', function () {
+          client.publish('a', 'b', pubOpts, function (err) {
+            if (version === 5) {
+              assert.strictEqual(err.code, pubackReasonCode)
+            } else {
+              assert.ifError(err)
+            }
+            setImmediate(function () {
+              client.end(() => {
+                server2.close(done())
+              })
+            })
+          })
+        })
+      })
+    })
+
     it('should fire a callback (qos 2)', function (done) {
       const client = connect()
       const opts = { qos: 2 }
@@ -1021,6 +1072,61 @@ module.exports = function (server, config) {
       client.once('connect', function () {
         client.publish('a', 'b', opts, function () {
           client.end((err) => done(err))
+        })
+      })
+    })
+
+    it.only('should fire a callback (qos 2) on error', function (done) {
+      // 145 = Packet Identifier in use
+      const pubrecReasonCode = 145
+      const pubOpts = { qos: 2 }
+      let client = null
+
+      const server2 = serverBuilder(config.protocol, function (serverClient) {
+        serverClient.on('connect', function () {
+          const connack = version === 5 ? { reasonCode: 0 } : { returnCode: 0 }
+          serverClient.connack(connack)
+        })
+        serverClient.on('publish', function (packet) {
+          if (packet.qos === 2) {
+            if (version === 5) {
+              serverClient.pubrec({
+                messageId: packet.messageId,
+                reasonCode: pubrecReasonCode
+              })
+            } else {
+              serverClient.pubrec({ messageId: packet.messageId })
+            }
+          }
+        })
+        serverClient.on('pubrel', function (packet) {
+          if (!serverClient.writable) return false
+          serverClient.pubcomp(packet)
+        })
+      })
+
+      server2.listen(ports.PORTAND103, function () {
+        client = connect({
+          port: ports.PORTAND103,
+          host: 'localhost',
+          clean: true,
+          clientId: 'cid1',
+          reconnectPeriod: 0
+        })
+
+        client.once('connect', function () {
+          client.publish('a', 'b', pubOpts, function (err) {
+            if (version === 5) {
+              assert.strictEqual(err.code, pubrecReasonCode)
+            } else {
+              assert.ifError(err)
+            }
+            setImmediate(function () {
+              client.end(true, () => {
+                server2.close(done())
+              })
+            })
+          })
         })
       })
     })


### PR DESCRIPTION
User callback is executed twice if the received PUBACK indicates failure (by reason code). 
Related issue: #1511

The following modification prevents the callback from invoked twice.

- If ``resonCode`` in PUBACK to failure, set the cb variable to NULL after the callback is invoked.
- When deleting a message from the store, do not invoke the callback if cb is null 
