### PR TITLE
refactor: move handlers to lib/handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ The arguments are:
   - `resubscribe` : if connection is broken and reconnects,
     subscribed topics are automatically subscribed again (default `true`)
   - `messageIdProvider`: custom messageId provider. when `new UniqueMessageIdProvider()` is set, then non conflict messageId is provided.
+  - `log`: custom log function. Default uses [debug](https://www.npmjs.com/package/debug) package.
 
 In case mqtts (mqtt over tls) is required, the `options` object is
 passed through to

--- a/lib/client.js
+++ b/lib/client.js
@@ -958,7 +958,7 @@ class MqttClient extends EventEmitter {
    * @api private
    */
   _cleanUp(forced, done) {
-    const opts = arguments[2]
+    const opts = arguments[2] || {}
     if (done) {
       this.log('_cleanUp :: done callback provided for on stream close')
       this.stream.on('close', done)
@@ -976,10 +976,18 @@ class MqttClient extends EventEmitter {
       this.log('_cleanUp :: (%s) :: call _sendPacket with disconnect packet', this.options.clientId)
       this._sendPacket(
         packet,
-        setImmediate.bind(
-          null,
-          this.stream.end.bind(this.stream)
-        )
+        () => {
+          this.log('_cleanUp :: (%s) :: destroying stream', this.options.clientId)
+          setImmediate(
+            () => {
+              this.stream.end(() => {
+                this.log('_cleanUp :: (%s) :: stream destroyed', this.options.clientId)
+                // once stream is closed the 'close' event will fire and that will
+                // emit client `close` event and call `done` callback if done is provided
+              })
+            }
+          )
+        }
       )
     }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,7 +6,6 @@
 const EventEmitter = require('events').EventEmitter
 const Store = require('./store')
 const TopicAliasRecv = require('./topic-alias-recv')
-const TopicAliasSend = require('./topic-alias-send')
 const mqttPacket = require('mqtt-packet')
 const DefaultMessageIdProvider = require('./default-message-id-provider')
 const Writable = require('readable-stream').Writable

--- a/lib/client.js
+++ b/lib/client.js
@@ -14,6 +14,8 @@ const reInterval = require('reinterval')
 const clone = require('rfdc/default')
 const validations = require('./validations')
 const debug = require('debug')('mqttjs:client')
+const handlePacket = require('./handlers')
+
 const nextTick = process ? process.nextTick : function (callback) { setTimeout(callback, 0) }
 const setImmediate = global.setImmediate || function (...args) {
   const callback = args.shift()
@@ -104,9 +106,9 @@ function applyTopicAlias (client, packet) {
         if (alias) {
           if (topic.length !== 0) {
             // register topic alias
-            debug('applyTopicAlias :: register topic: %s - alias: %d', topic, alias)
+            this.log('applyTopicAlias :: register topic: %s - alias: %d', topic, alias)
             if (!client.topicAliasSend.put(topic, alias)) {
-              debug('applyTopicAlias :: error out of range. topic: %s - alias: %d', topic, alias)
+              this.log('applyTopicAlias :: error out of range. topic: %s - alias: %d', topic, alias)
               return new Error('Sending Topic Alias out of range')
             }
           }
@@ -117,25 +119,25 @@ function applyTopicAlias (client, packet) {
               if (alias) {
                 packet.topic = ''
                 packet.properties = { ...(packet.properties), topicAlias: alias }
-                debug('applyTopicAlias :: auto assign(use) topic: %s - alias: %d', topic, alias)
+                this.log('applyTopicAlias :: auto assign(use) topic: %s - alias: %d', topic, alias)
               } else {
                 alias = client.topicAliasSend.getLruAlias()
                 client.topicAliasSend.put(topic, alias)
                 packet.properties = { ...(packet.properties), topicAlias: alias }
-                debug('applyTopicAlias :: auto assign topic: %s - alias: %d', topic, alias)
+                this.log('applyTopicAlias :: auto assign topic: %s - alias: %d', topic, alias)
               }
             } else if (client.options.autoUseTopicAlias) {
               alias = client.topicAliasSend.getAliasByTopic(topic)
               if (alias) {
                 packet.topic = ''
                 packet.properties = { ...(packet.properties), topicAlias: alias }
-                debug('applyTopicAlias :: auto use topic: %s - alias: %d', topic, alias)
+                this.log('applyTopicAlias :: auto use topic: %s - alias: %d', topic, alias)
               }
             }
           }
         }
       } else if (alias) {
-        debug('applyTopicAlias :: error out of range. topic: %s - alias: %d', topic, alias)
+        this.log('applyTopicAlias :: error out of range. topic: %s - alias: %d', topic, alias)
         return new Error('Sending Topic Alias out of range')
       }
     }
@@ -168,26 +170,26 @@ function removeTopicAliasAndRecoverTopicName (client, packet) {
 }
 
 function sendPacket (client, packet, cb) {
-  debug('sendPacket :: packet: %O', packet)
-  debug('sendPacket :: emitting `packetsend`')
+  this.log('sendPacket :: packet: %O', packet)
+  this.log('sendPacket :: emitting `packetsend`')
 
   client.emit('packetsend', packet)
 
-  debug('sendPacket :: writing to stream')
+  this.log('sendPacket :: writing to stream')
   const result = mqttPacket.writeToStream(packet, client.stream, client.options)
-  debug('sendPacket :: writeToStream result %s', result)
+  this.log('sendPacket :: writeToStream result %s', result)
   if (!result && cb && cb !== nop) {
-    debug('sendPacket :: handle events on `drain` once through callback.')
+    this.log('sendPacket :: handle events on `drain` once through callback.')
     client.stream.once('drain', cb)
   } else if (cb) {
-    debug('sendPacket :: invoking cb')
+    this.log('sendPacket :: invoking cb')
     cb()
   }
 }
 
 function flush (queue) {
   if (queue) {
-    debug('flush: queue exists? %b', !!(queue))
+    this.log('flush: queue exists? %b', !!(queue))
     Object.keys(queue).forEach(function (messageId) {
       if (typeof queue[messageId].cb === 'function') {
         queue[messageId].cb(new Error('Connection closed'))
@@ -201,7 +203,7 @@ function flush (queue) {
 
 function flushVolatile (queue) {
   if (queue) {
-    debug('flushVolatile :: deleting volatile messages from the queue and setting their callbacks as error function')
+    this.log('flushVolatile :: deleting volatile messages from the queue and setting their callbacks as error function')
     Object.keys(queue).forEach(function (messageId) {
       if (queue[messageId].volatile && typeof queue[messageId].cb === 'function') {
         queue[messageId].cb(new Error('Connection closed'))
@@ -212,7 +214,7 @@ function flushVolatile (queue) {
 }
 
 function storeAndSend (client, packet, cb, cbStorePut) {
-  debug('storeAndSend :: store packet with cmd %s to outgoingStore', packet.cmd)
+  this.log('storeAndSend :: store packet with cmd %s to outgoingStore', packet.cmd)
   let storePacket = packet
   let err
   if (storePacket.cmd === 'publish') {
@@ -235,7 +237,7 @@ function storeAndSend (client, packet, cb, cbStorePut) {
 }
 
 function nop (error) {
-  debug('nop ::', error)
+  this.log('nop ::', error)
 }
 
 /**
@@ -263,17 +265,19 @@ class MqttClient extends EventEmitter {
       }
     }
 
-    debug('MqttClient :: options.protocol', options.protocol)
-    debug('MqttClient :: options.protocolVersion', options.protocolVersion)
-    debug('MqttClient :: options.username', options.username)
-    debug('MqttClient :: options.keepalive', options.keepalive)
-    debug('MqttClient :: options.reconnectPeriod', options.reconnectPeriod)
-    debug('MqttClient :: options.rejectUnauthorized', options.rejectUnauthorized)
-    debug('MqttClient :: options.properties.topicAliasMaximum', options.properties ? options.properties.topicAliasMaximum : undefined)
+    this.log = this.options.log || debug
+
+    this.log('MqttClient :: options.protocol', options.protocol)
+    this.log('MqttClient :: options.protocolVersion', options.protocolVersion)
+    this.log('MqttClient :: options.username', options.username)
+    this.log('MqttClient :: options.keepalive', options.keepalive)
+    this.log('MqttClient :: options.reconnectPeriod', options.reconnectPeriod)
+    this.log('MqttClient :: options.rejectUnauthorized', options.rejectUnauthorized)
+    this.log('MqttClient :: options.properties.topicAliasMaximum', options.properties ? options.properties.topicAliasMaximum : undefined)
 
     this.options.clientId = (typeof options.clientId === 'string') ? options.clientId : defaultId()
 
-    debug('MqttClient :: clientId', this.options.clientId)
+    this.log('MqttClient :: clientId', this.options.clientId)
 
     this.options.customHandleAcks = (options.protocolVersion === 5 && options.customHandleAcks) ? options.customHandleAcks : function () { arguments[3](0) }
 
@@ -326,7 +330,7 @@ class MqttClient extends EventEmitter {
 
     if (options.properties && options.properties.topicAliasMaximum > 0) {
       if (options.properties.topicAliasMaximum > 0xffff) {
-        debug('MqttClient :: options.properties.topicAliasMaximum is out of range')
+        this.log('MqttClient :: options.properties.topicAliasMaximum is out of range')
       } else {
         this.topicAliasRecv = new TopicAliasRecv(options.properties.topicAliasMaximum)
       }
@@ -338,7 +342,7 @@ class MqttClient extends EventEmitter {
 
       function deliver () {
         const entry = queue.shift()
-        debug('deliver :: entry %o', entry)
+        this.log('deliver :: entry %o', entry)
         let packet = null
 
         if (!entry) {
@@ -347,7 +351,7 @@ class MqttClient extends EventEmitter {
         }
 
         packet = entry.packet
-        debug('deliver :: call _sendPacket for %o', packet)
+        this.log('deliver :: call _sendPacket for %o', packet)
         let send = true
         if (packet.messageId && packet.messageId !== 0) {
           if (!that.messageIdProvider.register(packet.messageId)) {
@@ -365,23 +369,23 @@ class MqttClient extends EventEmitter {
             }
           )
         } else {
-          debug('messageId: %d has already used. The message is skipped and removed.', packet.messageId)
+          this.log('messageId: %d has already used. The message is skipped and removed.', packet.messageId)
           deliver()
         }
       }
 
-      debug('connect :: sending queued packets')
+      this.log('connect :: sending queued packets')
       deliver()
     })
 
     this.on('close', function () {
-      debug('close :: connected set to `false`')
+      this.log('close :: connected set to `false`')
       that.connected = false
 
-      debug('close :: clearing connackTimer')
+      this.log('close :: clearing connackTimer')
       clearTimeout(that.connackTimer)
 
-      debug('close :: clearing ping timer')
+      this.log('close :: clearing ping timer')
       if (that.pingTimer !== null) {
         that.pingTimer.clear()
         that.pingTimer = null
@@ -391,12 +395,12 @@ class MqttClient extends EventEmitter {
         that.topicAliasRecv.clear()
       }
 
-      debug('close :: calling _setupReconnect')
+      this.log('close :: calling _setupReconnect')
       that._setupReconnect()
     })
     EventEmitter.call(this)
 
-    debug('MqttClient :: setting up stream')
+    this.log('MqttClient :: setting up stream')
     this._setupStream()
   }
 
@@ -412,14 +416,14 @@ class MqttClient extends EventEmitter {
     let completeParse = null
     const packets = []
 
-    debug('_setupStream :: calling method to clear reconnect')
+    this.log('_setupStream :: calling method to clear reconnect')
     this._clearReconnect()
 
-    debug('_setupStream :: using streamBuilder provided to client to create stream')
+    this.log('_setupStream :: using streamBuilder provided to client to create stream')
     this.stream = this.streamBuilder(this)
 
     parser.on('packet', function (packet) {
-      debug('parser :: on packet push to packets array.')
+      this.log('parser :: on packet push to packets array.')
       packets.push(packet)
     })
 
@@ -434,40 +438,40 @@ class MqttClient extends EventEmitter {
     }
 
     function work () {
-      debug('work :: getting next packet in queue')
+      this.log('work :: getting next packet in queue')
       const packet = packets.shift()
 
       if (packet) {
-        debug('work :: packet pulled from queue')
-        that._handlePacket(packet, nextTickWork)
+        this.log('work :: packet pulled from queue')
+        handlePacket(this, packet, nextTickWork)
       } else {
-        debug('work :: no packets in queue')
+        this.log('work :: no packets in queue')
         const done = completeParse
         completeParse = null
-        debug('work :: done flag is %s', !!(done))
+        this.log('work :: done flag is %s', !!(done))
         if (done) done()
       }
     }
 
     writable._write = function (buf, enc, done) {
       completeParse = done
-      debug('writable stream :: parsing buffer')
+      this.log('writable stream :: parsing buffer')
       parser.parse(buf)
       work()
     }
 
     function streamErrorHandler (error) {
-      debug('streamErrorHandler :: error', error.message)
+      this.log('streamErrorHandler :: error', error.message)
       if (socketErrors.includes(error.code)) {
         // handle error
-        debug('streamErrorHandler :: emitting error')
+        this.log('streamErrorHandler :: emitting error')
         that.emit('error', error)
       } else {
         nop(error)
       }
     }
 
-    debug('_setupStream :: pipe stream to writable stream')
+    this.log('_setupStream :: pipe stream to writable stream')
     this.stream.pipe(writable)
 
     // Suppress connection errors
@@ -475,14 +479,14 @@ class MqttClient extends EventEmitter {
 
     // Echo stream close
     this.stream.on('close', function () {
-      debug('(%s)stream :: on close', that.options.clientId)
+      this.log('(%s)stream :: on close', that.options.clientId)
       flushVolatile(that.outgoing)
-      debug('stream: emit close to MqttClient')
+      this.log('stream: emit close to MqttClient')
       that.emit('close')
     })
 
     // Send a connect packet
-    debug('_setupStream: sending packet `connect`')
+    this.log('_setupStream: sending packet `connect`')
     const connectPacket = Object.create(this.options)
     connectPacket.cmd = 'connect'
     if (this.topicAliasRecv) {
@@ -517,59 +521,9 @@ class MqttClient extends EventEmitter {
 
     clearTimeout(this.connackTimer)
     this.connackTimer = setTimeout(function () {
-      debug('!!connectTimeout hit!! Calling _cleanUp with force `true`')
+      this.log('!!connectTimeout hit!! Calling _cleanUp with force `true`')
       that._cleanUp(true)
     }, this.options.connectTimeout)
-  }
-
-  _handlePacket (packet, done) {
-    const options = this.options
-
-    if (options.protocolVersion === 5 && options.properties && options.properties.maximumPacketSize && options.properties.maximumPacketSize < packet.length) {
-      this.emit('error', new Error('exceeding packets size ' + packet.cmd))
-      this.end({ reasonCode: 149, properties: { reasonString: 'Maximum packet size was exceeded' } })
-      return this
-    }
-    debug('_handlePacket :: emitting packetreceive')
-    this.emit('packetreceive', packet)
-
-    switch (packet.cmd) {
-      case 'publish':
-        this._handlePublish(packet, done)
-        break
-      case 'puback':
-      case 'pubrec':
-      case 'pubcomp':
-      case 'suback':
-      case 'unsuback':
-        this._handleAck(packet)
-        done()
-        break
-      case 'pubrel':
-        this._handlePubrel(packet, done)
-        break
-      case 'connack':
-        this._handleConnack(packet)
-        done()
-        break
-      case 'auth':
-        this._handleAuth(packet)
-        done()
-        break
-      case 'pingresp':
-        this._handlePingresp(packet)
-        done()
-        break
-      case 'disconnect':
-        this._handleDisconnect(packet)
-        done()
-        break
-      default:
-        // do nothing
-        // maybe we should do an error handling
-        // or just log it
-        break
-    }
   }
 
   _checkDisconnecting (callback) {
@@ -604,7 +558,7 @@ class MqttClient extends EventEmitter {
    * @example client.publish('topic', 'message', console.log);
    */
   publish (topic, message, opts, callback) {
-    debug('publish :: message `%s` to topic `%s`', message, topic)
+    this.log('publish :: message `%s` to topic `%s`', message, topic)
     const options = this.options
 
     // .publish(topic, payload, cb);
@@ -627,7 +581,7 @@ class MqttClient extends EventEmitter {
       if (opts.qos === 1 || opts.qos === 2) {
         messageId = that._nextId()
         if (messageId === null) {
-          debug('No messageId left')
+          this.log('No messageId left')
           return false
         }
       }
@@ -645,7 +599,7 @@ class MqttClient extends EventEmitter {
         packet.properties = opts.properties
       }
 
-      debug('publish :: qos', opts.qos)
+      this.log('publish :: qos', opts.qos)
       switch (opts.qos) {
         case 1:
         case 2:
@@ -654,11 +608,11 @@ class MqttClient extends EventEmitter {
             volatile: false,
             cb: callback || nop
           }
-          debug('MqttClient:publish: packet cmd: %s', packet.cmd)
+          this.log('MqttClient:publish: packet cmd: %s', packet.cmd)
           that._sendPacket(packet, undefined, opts.cbStorePut)
           break
         default:
-          debug('MqttClient:publish: packet cmd: %s', packet.cmd)
+          this.log('MqttClient:publish: packet cmd: %s', packet.cmd)
           that._sendPacket(packet, callback, opts.cbStorePut)
           break
       }
@@ -724,7 +678,7 @@ class MqttClient extends EventEmitter {
     }
 
     if (this._checkDisconnecting(callback)) {
-      debug('subscribe: discconecting true')
+      this.log('subscribe: discconecting true')
       return this
     }
 
@@ -740,7 +694,7 @@ class MqttClient extends EventEmitter {
 
     if (Array.isArray(obj)) {
       obj.forEach(function (topic) {
-        debug('subscribe: array topic %s', topic)
+        this.log('subscribe: array topic %s', topic)
         if (!Object.prototype.hasOwnProperty.call(that._resubscribeTopics, topic) ||
           that._resubscribeTopics[topic].qos < opts.qos ||
           resubscribe) {
@@ -754,7 +708,7 @@ class MqttClient extends EventEmitter {
             currentOpts.rh = opts.rh
             currentOpts.properties = opts.properties
           }
-          debug('subscribe: pushing topic `%s` and qos `%s` to subs list', currentOpts.topic, currentOpts.qos)
+          this.log('subscribe: pushing topic `%s` and qos `%s` to subs list', currentOpts.topic, currentOpts.qos)
           subs.push(currentOpts)
         }
       })
@@ -762,7 +716,7 @@ class MqttClient extends EventEmitter {
       Object
         .keys(obj)
         .forEach(function (k) {
-          debug('subscribe: object topic %s', k)
+          this.log('subscribe: object topic %s', k)
           if (!Object.prototype.hasOwnProperty.call(that._resubscribeTopics, k) ||
             that._resubscribeTopics[k].qos < obj[k].qos ||
             resubscribe) {
@@ -776,7 +730,7 @@ class MqttClient extends EventEmitter {
               currentOpts.rh = obj[k].rh
               currentOpts.properties = opts.properties
             }
-            debug('subscribe: pushing `%s` to subs list', currentOpts)
+            this.log('subscribe: pushing `%s` to subs list', currentOpts)
             subs.push(currentOpts)
           }
         })
@@ -790,7 +744,7 @@ class MqttClient extends EventEmitter {
     const subscribeProc = function () {
       const messageId = that._nextId()
       if (messageId === null) {
-        debug('No messageId left')
+        this.log('No messageId left')
         return false
       }
 
@@ -809,7 +763,7 @@ class MqttClient extends EventEmitter {
 
       // subscriptions to resubscribe to in case of disconnect
       if (that.options.resubscribe) {
-        debug('subscribe :: resubscribe true')
+        this.log('subscribe :: resubscribe true')
         const topics = []
         subs.forEach(function (sub) {
           if (that.options.reconnectPeriod > 0) {
@@ -840,7 +794,7 @@ class MqttClient extends EventEmitter {
           callback(err, subs)
         }
       }
-      debug('subscribe :: call _sendPacket')
+      this.log('subscribe :: call _sendPacket')
       that._sendPacket(packet)
       return true
     }
@@ -900,7 +854,7 @@ class MqttClient extends EventEmitter {
     const unsubscribeProc = function () {
       const messageId = that._nextId()
       if (messageId === null) {
-        debug('No messageId left')
+        this.log('No messageId left')
         return false
       }
       const packet = {
@@ -930,7 +884,7 @@ class MqttClient extends EventEmitter {
         cb: callback
       }
 
-      debug('unsubscribe: call _sendPacket')
+      this.log('unsubscribe: call _sendPacket')
       that._sendPacket(packet)
 
       return true
@@ -961,7 +915,7 @@ class MqttClient extends EventEmitter {
   end (force, opts, cb) {
     const that = this
 
-    debug('end :: (%s)', this.options.clientId)
+    this.log('end :: (%s)', this.options.clientId)
 
     if (force == null || typeof force !== 'boolean') {
       cb = opts || nop
@@ -981,19 +935,19 @@ class MqttClient extends EventEmitter {
       opts = null
     }
 
-    debug('end :: cb? %s', !!cb)
+    this.log('end :: cb? %s', !!cb)
     cb = cb || nop
 
     function closeStores () {
-      debug('end :: closeStores: closing incoming and outgoing stores')
+      this.log('end :: closeStores: closing incoming and outgoing stores')
       that.disconnected = true
       that.incomingStore.close(function (e1) {
         that.outgoingStore.close(function (e2) {
-          debug('end :: closeStores: emitting end')
+          this.log('end :: closeStores: emitting end')
           that.emit('end')
           if (cb) {
             const err = e1 || e2
-            debug('end :: closeStores: invoking callback with args')
+            this.log('end :: closeStores: invoking callback with args')
             cb(err)
           }
         })
@@ -1007,9 +961,9 @@ class MqttClient extends EventEmitter {
       // defer closesStores of an I/O cycle,
       // just to make sure things are
       // ok for websockets
-      debug('end :: (%s) :: finish :: calling _cleanUp with force %s', that.options.clientId, force)
+      this.log('end :: (%s) :: finish :: calling _cleanUp with force %s', that.options.clientId, force)
       that._cleanUp(force, () => {
-        debug('end :: finish :: calling process.nextTick on closeStores')
+        this.log('end :: finish :: calling process.nextTick on closeStores')
         // const boundProcess = nextTick.bind(null, closeStores)
         nextTick(closeStores.bind(that))
       }, opts)
@@ -1026,10 +980,10 @@ class MqttClient extends EventEmitter {
 
     if (!force && Object.keys(this.outgoing).length > 0) {
       // wait 10ms, just to be sure we received all of it
-      debug('end :: (%s) :: calling finish in 10ms once outgoing is empty', that.options.clientId)
+      this.log('end :: (%s) :: calling finish in 10ms once outgoing is empty', that.options.clientId)
       this.once('outgoingEmpty', setTimeout.bind(null, finish, 10))
     } else {
-      debug('end :: (%s) :: immediately calling finish', that.options.clientId)
+      this.log('end :: (%s) :: immediately calling finish', that.options.clientId)
       finish()
     }
 
@@ -1068,7 +1022,7 @@ class MqttClient extends EventEmitter {
    * @api public
    */
   reconnect (opts) {
-    debug('client reconnect')
+    this.log('client reconnect')
     const that = this
     const f = function () {
       if (opts) {
@@ -1099,13 +1053,13 @@ class MqttClient extends EventEmitter {
    * @api privateish
    */
   _reconnect () {
-    debug('_reconnect: emitting reconnect to client')
+    this.log('_reconnect: emitting reconnect to client')
     this.emit('reconnect')
     if (this.connected) {
       this.end(() => { this._setupStream() })
-      debug('client already connected. disconnecting first.')
+      this.log('client already connected. disconnecting first.')
     } else {
-      debug('_reconnect: calling _setupStream')
+      this.log('_reconnect: calling _setupStream')
       this._setupStream()
     }
   }
@@ -1118,18 +1072,18 @@ class MqttClient extends EventEmitter {
 
     if (!that.disconnecting && !that.reconnectTimer && (that.options.reconnectPeriod > 0)) {
       if (!this.reconnecting) {
-        debug('_setupReconnect :: emit `offline` state')
+        this.log('_setupReconnect :: emit `offline` state')
         this.emit('offline')
-        debug('_setupReconnect :: set `reconnecting` to `true`')
+        this.log('_setupReconnect :: set `reconnecting` to `true`')
         this.reconnecting = true
       }
-      debug('_setupReconnect :: setting reconnectTimer for %d ms', that.options.reconnectPeriod)
+      this.log('_setupReconnect :: setting reconnectTimer for %d ms', that.options.reconnectPeriod)
       that.reconnectTimer = setInterval(function () {
-        debug('reconnectTimer :: reconnect triggered!')
+        this.log('reconnectTimer :: reconnect triggered!')
         that._reconnect()
       }, that.options.reconnectPeriod)
     } else {
-      debug('_setupReconnect :: doing nothing...')
+      this.log('_setupReconnect :: doing nothing...')
     }
   }
 
@@ -1137,7 +1091,7 @@ class MqttClient extends EventEmitter {
    * _clearReconnect - clear the reconnect timer
    */
   _clearReconnect () {
-    debug('_clearReconnect : clearing reconnect timer')
+    this.log('_clearReconnect : clearing reconnect timer')
     if (this.reconnectTimer) {
       clearInterval(this.reconnectTimer)
       this.reconnectTimer = null
@@ -1151,20 +1105,20 @@ class MqttClient extends EventEmitter {
   _cleanUp (forced, done) {
     const opts = arguments[2]
     if (done) {
-      debug('_cleanUp :: done callback provided for on stream close')
+      this.log('_cleanUp :: done callback provided for on stream close')
       this.stream.on('close', done)
     }
 
-    debug('_cleanUp :: forced? %s', forced)
+    this.log('_cleanUp :: forced? %s', forced)
     if (forced) {
       if ((this.options.reconnectPeriod === 0) && this.options.clean) {
         flush(this.outgoing)
       }
-      debug('_cleanUp :: (%s) :: destroying stream', this.options.clientId)
+      this.log('_cleanUp :: (%s) :: destroying stream', this.options.clientId)
       this.stream.destroy()
     } else {
       const packet = { cmd: 'disconnect', ...opts }
-      debug('_cleanUp :: (%s) :: call _sendPacket with disconnect packet', this.options.clientId)
+      this.log('_cleanUp :: (%s) :: call _sendPacket with disconnect packet', this.options.clientId)
       this._sendPacket(
         packet,
         setImmediate.bind(
@@ -1175,19 +1129,19 @@ class MqttClient extends EventEmitter {
     }
 
     if (!this.disconnecting) {
-      debug('_cleanUp :: client not disconnecting. Clearing and resetting reconnect.')
+      this.log('_cleanUp :: client not disconnecting. Clearing and resetting reconnect.')
       this._clearReconnect()
       this._setupReconnect()
     }
 
     if (this.pingTimer !== null) {
-      debug('_cleanUp :: clearing pingTimer')
+      this.log('_cleanUp :: clearing pingTimer')
       this.pingTimer.clear()
       this.pingTimer = null
     }
 
     if (done && !this.connected) {
-      debug('_cleanUp :: (%s) :: removing stream `done` callback `close` listener', this.options.clientId)
+      this.log('_cleanUp :: (%s) :: removing stream `done` callback `close` listener', this.options.clientId)
       this.stream.removeListener('close', done)
       done()
     }
@@ -1202,7 +1156,7 @@ class MqttClient extends EventEmitter {
    * @api private
    */
   _sendPacket (packet, cb, cbStorePut, noStore) {
-    debug('_sendPacket :: (%s) ::  start', this.options.clientId)
+    this.log('_sendPacket :: (%s) ::  start', this.options.clientId)
     cbStorePut = cbStorePut || nop
     cb = cb || nop
 
@@ -1220,7 +1174,7 @@ class MqttClient extends EventEmitter {
         return
       }
 
-      debug('_sendPacket :: client not connected. Storing packet offline.')
+      this.log('_sendPacket :: client not connected. Storing packet offline.')
       this._storePacket(packet, cb, cbStorePut)
       return
     }
@@ -1265,7 +1219,7 @@ class MqttClient extends EventEmitter {
         sendPacket(this, packet, cb)
         break
     }
-    debug('_sendPacket :: (%s) ::  end', this.options.clientId)
+    this.log('_sendPacket :: (%s) ::  end', this.options.clientId)
   }
 
   /**
@@ -1276,8 +1230,8 @@ class MqttClient extends EventEmitter {
    * @api private
    */
   _storePacket (packet, cb, cbStorePut) {
-    debug('_storePacket :: packet: %o', packet)
-    debug('_storePacket :: cb? %s', !!cb)
+    this.log('_storePacket :: packet: %o', packet)
+    this.log('_storePacket :: cb? %s', !!cb)
     cbStorePut = cbStorePut || nop
 
     let storePacket = packet
@@ -1313,7 +1267,7 @@ class MqttClient extends EventEmitter {
    * @api private
    */
   _setupPingTimer () {
-    debug('_setupPingTimer :: keepalive %d (seconds)', this.options.keepalive)
+    this.log('_setupPingTimer :: keepalive %d (seconds)', this.options.keepalive)
     const that = this
 
     if (!this.pingTimer && this.options.keepalive) {
@@ -1341,100 +1295,16 @@ class MqttClient extends EventEmitter {
    * @api private
    */
   _checkPing () {
-    debug('_checkPing :: checking ping...')
+    this.log('_checkPing :: checking ping...')
     if (this.pingResp) {
-      debug('_checkPing :: ping response received. Clearing flag and sending `pingreq`')
+      this.log('_checkPing :: ping response received. Clearing flag and sending `pingreq`')
       this.pingResp = false
       this._sendPacket({ cmd: 'pingreq' })
     } else {
       // do a forced cleanup since socket will be in bad shape
-      debug('_checkPing :: calling _cleanUp with force true')
+      this.log('_checkPing :: calling _cleanUp with force true')
       this._cleanUp(true)
     }
-  }
-
-  /**
-   * _handlePingresp - handle a pingresp
-   *
-   * @api private
-   */
-  _handlePingresp () {
-    this.pingResp = true
-  }
-
-  /**
-   * _handleConnack
-   *
-   * @param {Object} packet
-   * @api private
-   */
-  _handleConnack (packet) {
-    debug('_handleConnack')
-    const options = this.options
-    const version = options.protocolVersion
-    const rc = version === 5 ? packet.reasonCode : packet.returnCode
-
-    clearTimeout(this.connackTimer)
-    delete this.topicAliasSend
-
-    if (packet.properties) {
-      if (packet.properties.topicAliasMaximum) {
-        if (packet.properties.topicAliasMaximum > 0xffff) {
-          this.emit('error', new Error('topicAliasMaximum from broker is out of range'))
-          return
-        }
-        if (packet.properties.topicAliasMaximum > 0) {
-          this.topicAliasSend = new TopicAliasSend(packet.properties.topicAliasMaximum)
-        }
-      }
-      if (packet.properties.serverKeepAlive && options.keepalive) {
-        options.keepalive = packet.properties.serverKeepAlive
-        this._shiftPingInterval()
-      }
-      if (packet.properties.maximumPacketSize) {
-        if (!options.properties) { options.properties = {} }
-        options.properties.maximumPacketSize = packet.properties.maximumPacketSize
-      }
-    }
-
-    if (rc === 0) {
-      this.reconnecting = false
-      this._onConnect(packet)
-    } else if (rc > 0) {
-      const err = new Error('Connection refused: ' + errors[rc])
-      err.code = rc
-      this.emit('error', err)
-    }
-  }
-
-  _handleAuth (packet) {
-    const options = this.options
-    const version = options.protocolVersion
-    const rc = version === 5 ? packet.reasonCode : packet.returnCode
-
-    if (version !== 5) {
-      const err = new Error('Protocol error: Auth packets are only supported in MQTT 5. Your version:' + version)
-      err.code = rc
-      this.emit('error', err)
-      return
-    }
-
-    const that = this
-    this.handleAuth(packet, function (err, packet) {
-      if (err) {
-        that.emit('error', err)
-        return
-      }
-
-      if (rc === 24) {
-        that.reconnecting = false
-        that._sendPacket(packet)
-      } else {
-        const error = new Error('Connection refused: ' + errors[rc])
-        err.code = rc
-        that.emit('error', error)
-      }
-    })
   }
 
   /**
@@ -1447,131 +1317,6 @@ class MqttClient extends EventEmitter {
   }
 
   /**
-   * _handlePublish
-   *
-   * @param {Object} packet
-   * @api private
-   */
-  /*
-  those late 2 case should be rewrite to comply with coding style:
-
-  case 1:
-  case 0:
-    // do not wait sending a puback
-    // no callback passed
-    if (1 === qos) {
-      this._sendPacket({
-        cmd: 'puback',
-        messageId: messageId
-      });
-    }
-    // emit the message event for both qos 1 and 0
-    this.emit('message', topic, message, packet);
-    this.handleMessage(packet, done);
-    break;
-  default:
-    // do nothing but every switch mus have a default
-    // log or throw an error about unknown qos
-    break;
-
-  for now i just suppressed the warnings
-  */
-  _handlePublish (packet, done) {
-    debug('_handlePublish: packet %o', packet)
-    done = typeof done !== 'undefined' ? done : nop
-    let topic = packet.topic.toString()
-    const message = packet.payload
-    const qos = packet.qos
-    const messageId = packet.messageId
-    const that = this
-    const options = this.options
-    const validReasonCodes = [0, 16, 128, 131, 135, 144, 145, 151, 153]
-    if (this.options.protocolVersion === 5) {
-      let alias
-      if (packet.properties) {
-        alias = packet.properties.topicAlias
-      }
-      if (typeof alias !== 'undefined') {
-        if (topic.length === 0) {
-          if (alias > 0 && alias <= 0xffff) {
-            const gotTopic = this.topicAliasRecv.getTopicByAlias(alias)
-            if (gotTopic) {
-              topic = gotTopic
-              debug('_handlePublish :: topic complemented by alias. topic: %s - alias: %d', topic, alias)
-            } else {
-              debug('_handlePublish :: unregistered topic alias. alias: %d', alias)
-              this.emit('error', new Error('Received unregistered Topic Alias'))
-              return
-            }
-          } else {
-            debug('_handlePublish :: topic alias out of range. alias: %d', alias)
-            this.emit('error', new Error('Received Topic Alias is out of range'))
-            return
-          }
-        } else {
-          if (this.topicAliasRecv.put(topic, alias)) {
-            debug('_handlePublish :: registered topic: %s - alias: %d', topic, alias)
-          } else {
-            debug('_handlePublish :: topic alias out of range. alias: %d', alias)
-            this.emit('error', new Error('Received Topic Alias is out of range'))
-            return
-          }
-        }
-      }
-    }
-    debug('_handlePublish: qos %d', qos)
-    switch (qos) {
-      case 2: {
-        options.customHandleAcks(topic, message, packet, function (error, code) {
-          if (!(error instanceof Error)) {
-            code = error
-            error = null
-          }
-          if (error) { return that.emit('error', error) }
-          if (validReasonCodes.indexOf(code) === -1) { return that.emit('error', new Error('Wrong reason code for pubrec')) }
-          if (code) {
-            that._sendPacket({ cmd: 'pubrec', messageId, reasonCode: code }, done)
-          } else {
-            that.incomingStore.put(packet, function () {
-              that._sendPacket({ cmd: 'pubrec', messageId }, done)
-            })
-          }
-        })
-        break
-      }
-      case 1: {
-        // emit the message event
-        options.customHandleAcks(topic, message, packet, function (error, code) {
-          if (!(error instanceof Error)) {
-            code = error
-            error = null
-          }
-          if (error) { return that.emit('error', error) }
-          if (validReasonCodes.indexOf(code) === -1) { return that.emit('error', new Error('Wrong reason code for puback')) }
-          if (!code) { that.emit('message', topic, message, packet) }
-          that.handleMessage(packet, function (err) {
-            if (err) {
-              return done && done(err)
-            }
-            that._sendPacket({ cmd: 'puback', messageId, reasonCode: code }, done)
-          })
-        })
-        break
-      }
-      case 0:
-        // emit the message event
-        this.emit('message', topic, message, packet)
-        this.handleMessage(packet, done)
-        break
-      default:
-        // do nothing
-        debug('_handlePublish: unknown QoS. Doing nothing.')
-        // log or throw an error about unknown qos
-        break
-    }
-  }
-
-  /**
    * Handle messages with backpressure support, one at a time.
    * Override at will.
    *
@@ -1581,153 +1326,6 @@ class MqttClient extends EventEmitter {
    */
   handleMessage (packet, callback) {
     callback()
-  }
-
-  /**
-   * _handleAck
-   *
-   * @param {Object} packet
-   * @api private
-   */
-  _handleAck (packet) {
-    /* eslint no-fallthrough: "off" */
-    const messageId = packet.messageId
-    const type = packet.cmd
-    let response = null
-    const cb = this.outgoing[messageId] ? this.outgoing[messageId].cb : null
-    const that = this
-    let err
-
-    // Checking `!cb` happens to work, but it's not technically "correct".
-    //
-    // Why? This code assumes that "no callback" is the same as that "we're not
-    // waiting for responses" (puback, pubrec, pubcomp, suback, or unsuback).
-    //
-    // It would be better to check `if (!this.outgoing[messageId])` here, but
-    // there's no reason to change it and risk (another) regression.
-    //
-    // The only reason this code works is becaues code in MqttClient.publish,
-    // MqttClinet.subscribe, and MqttClient.unsubscribe ensures that we will
-    // have a callback even if the user doesn't pass one in.)
-    if (!cb) {
-      debug('_handleAck :: Server sent an ack in error. Ignoring.')
-      // Server sent an ack in error, ignore it.
-      return
-    }
-
-    // Process
-    debug('_handleAck :: packet type', type)
-    switch (type) {
-      case 'pubcomp':
-      // same thing as puback for QoS 2
-      case 'puback': {
-        const pubackRC = packet.reasonCode
-        // Callback - we're done
-        if (pubackRC && pubackRC > 0 && pubackRC !== 16) {
-          err = new Error('Publish error: ' + errors[pubackRC])
-          err.code = pubackRC
-          this._removeOutgoingAndStoreMessage(messageId, function () {
-            cb(err, packet)
-          })
-        } else {
-          this._removeOutgoingAndStoreMessage(messageId, cb)
-        }
-
-        break
-      }
-      case 'pubrec': {
-        response = {
-          cmd: 'pubrel',
-          qos: 2,
-          messageId
-        }
-        const pubrecRC = packet.reasonCode
-
-        if (pubrecRC && pubrecRC > 0 && pubrecRC !== 16) {
-          err = new Error('Publish error: ' + errors[pubrecRC])
-          err.code = pubrecRC
-          this._removeOutgoingAndStoreMessage(messageId, function () {
-            cb(err, packet)
-          })
-        } else {
-          this._sendPacket(response)
-        }
-        break
-      }
-      case 'suback': {
-        delete this.outgoing[messageId]
-        this.messageIdProvider.deallocate(messageId)
-        for (let grantedI = 0; grantedI < packet.granted.length; grantedI++) {
-          if ((packet.granted[grantedI] & 0x80) !== 0) {
-            // suback with Failure status
-            const topics = this.messageIdToTopic[messageId]
-            if (topics) {
-              topics.forEach(function (topic) {
-                delete that._resubscribeTopics[topic]
-              })
-            }
-          }
-        }
-        delete this.messageIdToTopic[messageId]
-        this._invokeStoreProcessingQueue()
-        cb(null, packet)
-        break
-      }
-      case 'unsuback': {
-        delete this.outgoing[messageId]
-        this.messageIdProvider.deallocate(messageId)
-        this._invokeStoreProcessingQueue()
-        cb(null)
-        break
-      }
-      default:
-        that.emit('error', new Error('unrecognized packet type'))
-    }
-
-    if (this.disconnecting &&
-      Object.keys(this.outgoing).length === 0) {
-      this.emit('outgoingEmpty')
-    }
-  }
-
-  /**
-   * _handlePubrel
-   *
-   * @param {Object} packet
-   * @api private
-   */
-  _handlePubrel (packet, callback) {
-    debug('handling pubrel packet')
-    callback = typeof callback !== 'undefined' ? callback : nop
-    const messageId = packet.messageId
-    const that = this
-
-    const comp = { cmd: 'pubcomp', messageId }
-
-    that.incomingStore.get(packet, function (err, pub) {
-      if (!err) {
-        that.emit('message', pub.topic, pub.payload, pub)
-        that.handleMessage(pub, function (err) {
-          if (err) {
-            return callback(err)
-          }
-          that.incomingStore.del(pub, nop)
-          that._sendPacket(comp, callback)
-        })
-      } else {
-        that._sendPacket(comp, callback)
-      }
-    })
-  }
-
-  /**
-   * _handleDisconnect
-   *
-   * @param {Object} packet
-   * @api private
-   */
-  _handleDisconnect (packet) {
-    this.emit('disconnect', packet)
   }
 
   /**
@@ -1751,14 +1349,14 @@ class MqttClient extends EventEmitter {
    * @api private
    */
   _resubscribe () {
-    debug('_resubscribe')
+    this.log('_resubscribe')
     const _resubscribeTopicsKeys = Object.keys(this._resubscribeTopics)
     if (!this._firstConnection &&
       (this.options.clean || (this.options.protocolVersion === 5 && !this.connackPacket.sessionPresent)) &&
       _resubscribeTopicsKeys.length > 0) {
       if (this.options.resubscribe) {
         if (this.options.protocolVersion === 5) {
-          debug('_resubscribe: protocolVersion 5')
+          this.log('_resubscribe: protocolVersion 5')
           for (let topicI = 0; topicI < _resubscribeTopicsKeys.length; topicI++) {
             const resubscribeTopic = {}
             resubscribeTopic[_resubscribeTopicsKeys[topicI]] = this._resubscribeTopics[_resubscribeTopicsKeys[topicI]]
@@ -1861,7 +1459,7 @@ class MqttClient extends EventEmitter {
           if (that.messageIdProvider.register(packet.messageId)) {
             that._sendPacket(packet, undefined, undefined, true)
           } else {
-            debug('messageId: %d has already used.', packet.messageId)
+            this.log('messageId: %d has already used.', packet.messageId)
           }
         } else if (outStore.destroy) {
           outStore.destroy()

--- a/lib/client.js
+++ b/lib/client.js
@@ -42,106 +42,8 @@ const socketErrors = [
   'ETIMEDOUT'
 ]
 
-// Other Socket Errors: EADDRINUSE, ECONNRESET, ENOTFOUND, ETIMEDOUT.
-
-const errors = {
-  0: '',
-  1: 'Unacceptable protocol version',
-  2: 'Identifier rejected',
-  3: 'Server unavailable',
-  4: 'Bad username or password',
-  5: 'Not authorized',
-  16: 'No matching subscribers',
-  17: 'No subscription existed',
-  128: 'Unspecified error',
-  129: 'Malformed Packet',
-  130: 'Protocol Error',
-  131: 'Implementation specific error',
-  132: 'Unsupported Protocol Version',
-  133: 'Client Identifier not valid',
-  134: 'Bad User Name or Password',
-  135: 'Not authorized',
-  136: 'Server unavailable',
-  137: 'Server busy',
-  138: 'Banned',
-  139: 'Server shutting down',
-  140: 'Bad authentication method',
-  141: 'Keep Alive timeout',
-  142: 'Session taken over',
-  143: 'Topic Filter invalid',
-  144: 'Topic Name invalid',
-  145: 'Packet identifier in use',
-  146: 'Packet Identifier not found',
-  147: 'Receive Maximum exceeded',
-  148: 'Topic Alias invalid',
-  149: 'Packet too large',
-  150: 'Message rate too high',
-  151: 'Quota exceeded',
-  152: 'Administrative action',
-  153: 'Payload format invalid',
-  154: 'Retain not supported',
-  155: 'QoS not supported',
-  156: 'Use another server',
-  157: 'Server moved',
-  158: 'Shared Subscriptions not supported',
-  159: 'Connection rate exceeded',
-  160: 'Maximum connect time',
-  161: 'Subscription Identifiers not supported',
-  162: 'Wildcard Subscriptions not supported'
-}
-
 function defaultId () {
   return 'mqttjs_' + Math.random().toString(16).substr(2, 8)
-}
-
-function applyTopicAlias (client, packet) {
-  if (client.options.protocolVersion === 5) {
-    if (packet.cmd === 'publish') {
-      let alias
-      if (packet.properties) {
-        alias = packet.properties.topicAlias
-      }
-      const topic = packet.topic.toString()
-      if (client.topicAliasSend) {
-        if (alias) {
-          if (topic.length !== 0) {
-            // register topic alias
-            this.log('applyTopicAlias :: register topic: %s - alias: %d', topic, alias)
-            if (!client.topicAliasSend.put(topic, alias)) {
-              this.log('applyTopicAlias :: error out of range. topic: %s - alias: %d', topic, alias)
-              return new Error('Sending Topic Alias out of range')
-            }
-          }
-        } else {
-          if (topic.length !== 0) {
-            if (client.options.autoAssignTopicAlias) {
-              alias = client.topicAliasSend.getAliasByTopic(topic)
-              if (alias) {
-                packet.topic = ''
-                packet.properties = { ...(packet.properties), topicAlias: alias }
-                this.log('applyTopicAlias :: auto assign(use) topic: %s - alias: %d', topic, alias)
-              } else {
-                alias = client.topicAliasSend.getLruAlias()
-                client.topicAliasSend.put(topic, alias)
-                packet.properties = { ...(packet.properties), topicAlias: alias }
-                this.log('applyTopicAlias :: auto assign topic: %s - alias: %d', topic, alias)
-              }
-            } else if (client.options.autoUseTopicAlias) {
-              alias = client.topicAliasSend.getAliasByTopic(topic)
-              if (alias) {
-                packet.topic = ''
-                packet.properties = { ...(packet.properties), topicAlias: alias }
-                this.log('applyTopicAlias :: auto use topic: %s - alias: %d', topic, alias)
-              }
-            }
-          }
-        }
-      } else if (alias) {
-        this.log('applyTopicAlias :: error out of range. topic: %s - alias: %d', topic, alias)
-        return new Error('Sending Topic Alias out of range')
-      }
-    }
-  }
 }
 
 function removeTopicAliasAndRecoverTopicName (client, packet) {
@@ -170,26 +72,26 @@ function removeTopicAliasAndRecoverTopicName (client, packet) {
 }
 
 function sendPacket (client, packet, cb) {
-  this.log('sendPacket :: packet: %O', packet)
-  this.log('sendPacket :: emitting `packetsend`')
+  client.log('sendPacket :: packet: %O', packet)
+  client.log('sendPacket :: emitting `packetsend`')
 
   client.emit('packetsend', packet)
 
-  this.log('sendPacket :: writing to stream')
+  client.log('sendPacket :: writing to stream')
   const result = mqttPacket.writeToStream(packet, client.stream, client.options)
-  this.log('sendPacket :: writeToStream result %s', result)
-  if (!result && cb && cb !== nop) {
-    this.log('sendPacket :: handle events on `drain` once through callback.')
+  client.log('sendPacket :: writeToStream result %s', result)
+  if (!result && cb && cb !== client.nop) {
+    client.log('sendPacket :: handle events on `drain` once through callback.')
     client.stream.once('drain', cb)
   } else if (cb) {
-    this.log('sendPacket :: invoking cb')
+    client.log('sendPacket :: invoking cb')
     cb()
   }
 }
 
-function flush (queue) {
+function flush (client, queue) {
   if (queue) {
-    this.log('flush: queue exists? %b', !!(queue))
+    client.log('flush: queue exists? %b', !!(queue))
     Object.keys(queue).forEach(function (messageId) {
       if (typeof queue[messageId].cb === 'function') {
         queue[messageId].cb(new Error('Connection closed'))
@@ -201,9 +103,9 @@ function flush (queue) {
   }
 }
 
-function flushVolatile (queue) {
+function flushVolatile (client, queue) {
   if (queue) {
-    this.log('flushVolatile :: deleting volatile messages from the queue and setting their callbacks as error function')
+    client.log('flushVolatile :: deleting volatile messages from the queue and setting their callbacks as error function')
     Object.keys(queue).forEach(function (messageId) {
       if (queue[messageId].volatile && typeof queue[messageId].cb === 'function') {
         queue[messageId].cb(new Error('Connection closed'))
@@ -213,32 +115,6 @@ function flushVolatile (queue) {
   }
 }
 
-function storeAndSend (client, packet, cb, cbStorePut) {
-  this.log('storeAndSend :: store packet with cmd %s to outgoingStore', packet.cmd)
-  let storePacket = packet
-  let err
-  if (storePacket.cmd === 'publish') {
-    // The original packet is for sending.
-    // The cloned storePacket is for storing to resend on reconnect.
-    // Topic Alias must not be used after disconnected.
-    storePacket = clone(packet)
-    err = removeTopicAliasAndRecoverTopicName(client, storePacket)
-    if (err) {
-      return cb && cb(err)
-    }
-  }
-  client.outgoingStore.put(storePacket, function storedPacket (err) {
-    if (err) {
-      return cb && cb(err)
-    }
-    cbStorePut()
-    sendPacket(client, packet, cb)
-  })
-}
-
-function nop (error) {
-  this.log('nop ::', error)
-}
 
 /**
  * MqttClient constructor
@@ -266,6 +142,7 @@ class MqttClient extends EventEmitter {
     }
 
     this.log = this.options.log || debug
+    this.nop = this._nop.bind(this)
 
     this.log('MqttClient :: options.protocol', options.protocol)
     this.log('MqttClient :: options.protocolVersion', options.protocolVersion)
@@ -342,7 +219,7 @@ class MqttClient extends EventEmitter {
 
       function deliver () {
         const entry = queue.shift()
-        this.log('deliver :: entry %o', entry)
+        that.log('deliver :: entry %o', entry)
         let packet = null
 
         if (!entry) {
@@ -351,7 +228,7 @@ class MqttClient extends EventEmitter {
         }
 
         packet = entry.packet
-        this.log('deliver :: call _sendPacket for %o', packet)
+        that.log('deliver :: call _sendPacket for %o', packet)
         let send = true
         if (packet.messageId && packet.messageId !== 0) {
           if (!that.messageIdProvider.register(packet.messageId)) {
@@ -369,23 +246,23 @@ class MqttClient extends EventEmitter {
             }
           )
         } else {
-          this.log('messageId: %d has already used. The message is skipped and removed.', packet.messageId)
+          that.log('messageId: %d has already used. The message is skipped and removed.', packet.messageId)
           deliver()
         }
       }
 
-      this.log('connect :: sending queued packets')
+      that.log('connect :: sending queued packets')
       deliver()
     })
 
     this.on('close', function () {
-      this.log('close :: connected set to `false`')
+      that.log('close :: connected set to `false`')
       that.connected = false
 
-      this.log('close :: clearing connackTimer')
+      that.log('close :: clearing connackTimer')
       clearTimeout(that.connackTimer)
 
-      this.log('close :: clearing ping timer')
+      that.log('close :: clearing ping timer')
       if (that.pingTimer !== null) {
         that.pingTimer.clear()
         that.pingTimer = null
@@ -395,10 +272,9 @@ class MqttClient extends EventEmitter {
         that.topicAliasRecv.clear()
       }
 
-      this.log('close :: calling _setupReconnect')
+      that.log('close :: calling _setupReconnect')
       that._setupReconnect()
     })
-    EventEmitter.call(this)
 
     this.log('MqttClient :: setting up stream')
     this._setupStream()
@@ -423,7 +299,7 @@ class MqttClient extends EventEmitter {
     this.stream = this.streamBuilder(this)
 
     parser.on('packet', function (packet) {
-      this.log('parser :: on packet push to packets array.')
+      that.log('parser :: on packet push to packets array.')
       packets.push(packet)
     })
 
@@ -438,36 +314,36 @@ class MqttClient extends EventEmitter {
     }
 
     function work () {
-      this.log('work :: getting next packet in queue')
+      that.log('work :: getting next packet in queue')
       const packet = packets.shift()
 
       if (packet) {
-        this.log('work :: packet pulled from queue')
-        handlePacket(this, packet, nextTickWork)
+        that.log('work :: packet pulled from queue')
+        handlePacket(that, packet, nextTickWork)
       } else {
-        this.log('work :: no packets in queue')
+        that.log('work :: no packets in queue')
         const done = completeParse
         completeParse = null
-        this.log('work :: done flag is %s', !!(done))
+        that.log('work :: done flag is %s', !!(done))
         if (done) done()
       }
     }
 
     writable._write = function (buf, enc, done) {
       completeParse = done
-      this.log('writable stream :: parsing buffer')
+      that.log('writable stream :: parsing buffer')
       parser.parse(buf)
       work()
     }
 
     function streamErrorHandler (error) {
-      this.log('streamErrorHandler :: error', error.message)
+      that.log('streamErrorHandler :: error', error.message)
       if (socketErrors.includes(error.code)) {
         // handle error
-        this.log('streamErrorHandler :: emitting error')
+        that.log('streamErrorHandler :: emitting error')
         that.emit('error', error)
       } else {
-        nop(error)
+        that.nop(error)
       }
     }
 
@@ -479,9 +355,9 @@ class MqttClient extends EventEmitter {
 
     // Echo stream close
     this.stream.on('close', function () {
-      this.log('(%s)stream :: on close', that.options.clientId)
-      flushVolatile(that.outgoing)
-      this.log('stream: emit close to MqttClient')
+      that.log('(%s)stream :: on close', that.options.clientId)
+      flushVolatile(that, that.outgoing)
+      that.log('stream: emit close to MqttClient')
       that.emit('close')
     })
 
@@ -521,14 +397,14 @@ class MqttClient extends EventEmitter {
 
     clearTimeout(this.connackTimer)
     this.connackTimer = setTimeout(function () {
-      this.log('!!connectTimeout hit!! Calling _cleanUp with force `true`')
+      that.log('!!connectTimeout hit!! Calling _cleanUp with force `true`')
       that._cleanUp(true)
     }, this.options.connectTimeout)
   }
 
   _checkDisconnecting (callback) {
     if (this.disconnecting) {
-      if (callback && callback !== nop) {
+      if (callback && callback !== this.nop) {
         callback(new Error('client disconnecting'))
       } else {
         this.emit('error', new Error('client disconnecting'))
@@ -581,7 +457,7 @@ class MqttClient extends EventEmitter {
       if (opts.qos === 1 || opts.qos === 2) {
         messageId = that._nextId()
         if (messageId === null) {
-          this.log('No messageId left')
+          that.log('No messageId left')
           return false
         }
       }
@@ -599,20 +475,20 @@ class MqttClient extends EventEmitter {
         packet.properties = opts.properties
       }
 
-      this.log('publish :: qos', opts.qos)
+      that.log('publish :: qos', opts.qos)
       switch (opts.qos) {
         case 1:
         case 2:
           // Add to callbacks
           that.outgoing[packet.messageId] = {
             volatile: false,
-            cb: callback || nop
+            cb: callback || that.nop
           }
-          this.log('MqttClient:publish: packet cmd: %s', packet.cmd)
+          that.log('MqttClient:publish: packet cmd: %s', packet.cmd)
           that._sendPacket(packet, undefined, opts.cbStorePut)
           break
         default:
-          this.log('MqttClient:publish: packet cmd: %s', packet.cmd)
+          that.log('MqttClient:publish: packet cmd: %s', packet.cmd)
           that._sendPacket(packet, callback, opts.cbStorePut)
           break
       }
@@ -656,7 +532,7 @@ class MqttClient extends EventEmitter {
     const subs = []
     let obj = args.shift()
     const resubscribe = obj.resubscribe
-    let callback = args.pop() || nop
+    let callback = args.pop() || this.nop
     let opts = args.pop()
     const version = this.options.protocolVersion
 
@@ -668,7 +544,7 @@ class MqttClient extends EventEmitter {
 
     if (typeof callback !== 'function') {
       opts = callback
-      callback = nop
+      callback = this.nop
     }
 
     const invalidTopic = validations.validateTopics(obj)
@@ -694,7 +570,7 @@ class MqttClient extends EventEmitter {
 
     if (Array.isArray(obj)) {
       obj.forEach(function (topic) {
-        this.log('subscribe: array topic %s', topic)
+        that.log('subscribe: array topic %s', topic)
         if (!Object.prototype.hasOwnProperty.call(that._resubscribeTopics, topic) ||
           that._resubscribeTopics[topic].qos < opts.qos ||
           resubscribe) {
@@ -708,7 +584,7 @@ class MqttClient extends EventEmitter {
             currentOpts.rh = opts.rh
             currentOpts.properties = opts.properties
           }
-          this.log('subscribe: pushing topic `%s` and qos `%s` to subs list', currentOpts.topic, currentOpts.qos)
+          that.log('subscribe: pushing topic `%s` and qos `%s` to subs list', currentOpts.topic, currentOpts.qos)
           subs.push(currentOpts)
         }
       })
@@ -716,7 +592,7 @@ class MqttClient extends EventEmitter {
       Object
         .keys(obj)
         .forEach(function (k) {
-          this.log('subscribe: object topic %s', k)
+          that.log('subscribe: object topic %s', k)
           if (!Object.prototype.hasOwnProperty.call(that._resubscribeTopics, k) ||
             that._resubscribeTopics[k].qos < obj[k].qos ||
             resubscribe) {
@@ -730,7 +606,7 @@ class MqttClient extends EventEmitter {
               currentOpts.rh = obj[k].rh
               currentOpts.properties = opts.properties
             }
-            this.log('subscribe: pushing `%s` to subs list', currentOpts)
+            that.log('subscribe: pushing `%s` to subs list', currentOpts)
             subs.push(currentOpts)
           }
         })
@@ -744,7 +620,7 @@ class MqttClient extends EventEmitter {
     const subscribeProc = function () {
       const messageId = that._nextId()
       if (messageId === null) {
-        this.log('No messageId left')
+        that.log('No messageId left')
         return false
       }
 
@@ -763,7 +639,7 @@ class MqttClient extends EventEmitter {
 
       // subscriptions to resubscribe to in case of disconnect
       if (that.options.resubscribe) {
-        this.log('subscribe :: resubscribe true')
+        that.log('subscribe :: resubscribe true')
         const topics = []
         subs.forEach(function (sub) {
           if (that.options.reconnectPeriod > 0) {
@@ -794,7 +670,7 @@ class MqttClient extends EventEmitter {
           callback(err, subs)
         }
       }
-      this.log('subscribe :: call _sendPacket')
+      that.log('subscribe :: call _sendPacket')
       that._sendPacket(packet)
       return true
     }
@@ -830,7 +706,7 @@ class MqttClient extends EventEmitter {
       args[i] = arguments[i]
     }
     let topic = args.shift()
-    let callback = args.pop() || nop
+    let callback = args.pop() || this.nop
     let opts = args.pop()
     if (typeof topic === 'string') {
       topic = [topic]
@@ -838,7 +714,7 @@ class MqttClient extends EventEmitter {
 
     if (typeof callback !== 'function') {
       opts = callback
-      callback = nop
+      callback = this.nop
     }
 
     const invalidTopic = validations.validateTopics(topic)
@@ -854,7 +730,7 @@ class MqttClient extends EventEmitter {
     const unsubscribeProc = function () {
       const messageId = that._nextId()
       if (messageId === null) {
-        this.log('No messageId left')
+        that.log('No messageId left')
         return false
       }
       const packet = {
@@ -884,7 +760,7 @@ class MqttClient extends EventEmitter {
         cb: callback
       }
 
-      this.log('unsubscribe: call _sendPacket')
+      that.log('unsubscribe: call _sendPacket')
       that._sendPacket(packet)
 
       return true
@@ -918,14 +794,14 @@ class MqttClient extends EventEmitter {
     this.log('end :: (%s)', this.options.clientId)
 
     if (force == null || typeof force !== 'boolean') {
-      cb = opts || nop
+      cb = opts || this.nop
       opts = force
       force = false
       if (typeof opts !== 'object') {
         cb = opts
         opts = null
         if (typeof cb !== 'function') {
-          cb = nop
+          cb = this.nop
         }
       }
     }
@@ -936,18 +812,18 @@ class MqttClient extends EventEmitter {
     }
 
     this.log('end :: cb? %s', !!cb)
-    cb = cb || nop
+    cb = cb || this.nop
 
     function closeStores () {
-      this.log('end :: closeStores: closing incoming and outgoing stores')
+      that.log('end :: closeStores: closing incoming and outgoing stores')
       that.disconnected = true
       that.incomingStore.close(function (e1) {
         that.outgoingStore.close(function (e2) {
-          this.log('end :: closeStores: emitting end')
+          that.log('end :: closeStores: emitting end')
           that.emit('end')
           if (cb) {
             const err = e1 || e2
-            this.log('end :: closeStores: invoking callback with args')
+            that.log('end :: closeStores: invoking callback with args')
             cb(err)
           }
         })
@@ -961,9 +837,9 @@ class MqttClient extends EventEmitter {
       // defer closesStores of an I/O cycle,
       // just to make sure things are
       // ok for websockets
-      this.log('end :: (%s) :: finish :: calling _cleanUp with force %s', that.options.clientId, force)
+      that.log('end :: (%s) :: finish :: calling _cleanUp with force %s', that.options.clientId, force)
       that._cleanUp(force, () => {
-        this.log('end :: finish :: calling process.nextTick on closeStores')
+        that.log('end :: finish :: calling process.nextTick on closeStores')
         // const boundProcess = nextTick.bind(null, closeStores)
         nextTick(closeStores.bind(that))
       }, opts)
@@ -1079,7 +955,7 @@ class MqttClient extends EventEmitter {
       }
       this.log('_setupReconnect :: setting reconnectTimer for %d ms', that.options.reconnectPeriod)
       that.reconnectTimer = setInterval(function () {
-        this.log('reconnectTimer :: reconnect triggered!')
+        that.log('reconnectTimer :: reconnect triggered!')
         that._reconnect()
       }, that.options.reconnectPeriod)
     } else {
@@ -1112,7 +988,7 @@ class MqttClient extends EventEmitter {
     this.log('_cleanUp :: forced? %s', forced)
     if (forced) {
       if ((this.options.reconnectPeriod === 0) && this.options.clean) {
-        flush(this.outgoing)
+        flush(this, this.outgoing)
       }
       this.log('_cleanUp :: (%s) :: destroying stream', this.options.clientId)
       this.stream.destroy()
@@ -1147,6 +1023,84 @@ class MqttClient extends EventEmitter {
     }
   }
 
+  _storeAndSend (packet, cb, cbStorePut) {
+    this.log('storeAndSend :: store packet with cmd %s to outgoingStore', packet.cmd)
+    let storePacket = packet
+    let err
+    if (storePacket.cmd === 'publish') {
+      // The original packet is for sending.
+      // The cloned storePacket is for storing to resend on reconnect.
+      // Topic Alias must not be used after disconnected.
+      storePacket = clone(packet)
+      err = removeTopicAliasAndRecoverTopicName(this, storePacket)
+      if (err) {
+        return cb && cb(err)
+      }
+    }
+    const that = this
+    this.outgoingStore.put(storePacket, function storedPacket (err) {
+      if (err) {
+        return cb && cb(err)
+      }
+      cbStorePut()
+      sendPacket(that, packet, cb)
+    })
+  }
+
+  _applyTopicAlias (packet) {
+    if (this.options.protocolVersion === 5) {
+      if (packet.cmd === 'publish') {
+        let alias
+        if (packet.properties) {
+          alias = packet.properties.topicAlias
+        }
+        const topic = packet.topic.toString()
+        if (this.topicAliasSend) {
+          if (alias) {
+            if (topic.length !== 0) {
+              // register topic alias
+              this.log('applyTopicAlias :: register topic: %s - alias: %d', topic, alias)
+              if (!this.topicAliasSend.put(topic, alias)) {
+                this.log('applyTopicAlias :: error out of range. topic: %s - alias: %d', topic, alias)
+                return new Error('Sending Topic Alias out of range')
+              }
+            }
+          } else {
+            if (topic.length !== 0) {
+              if (this.options.autoAssignTopicAlias) {
+                alias = this.topicAliasSend.getAliasByTopic(topic)
+                if (alias) {
+                  packet.topic = ''
+                  packet.properties = { ...(packet.properties), topicAlias: alias }
+                  this.log('applyTopicAlias :: auto assign(use) topic: %s - alias: %d', topic, alias)
+                } else {
+                  alias = this.topicAliasSend.getLruAlias()
+                  this.topicAliasSend.put(topic, alias)
+                  packet.properties = { ...(packet.properties), topicAlias: alias }
+                  this.log('applyTopicAlias :: auto assign topic: %s - alias: %d', topic, alias)
+                }
+              } else if (this.options.autoUseTopicAlias) {
+                alias = this.topicAliasSend.getAliasByTopic(topic)
+                if (alias) {
+                  packet.topic = ''
+                  packet.properties = { ...(packet.properties), topicAlias: alias }
+                  this.log('applyTopicAlias :: auto use topic: %s - alias: %d', topic, alias)
+                }
+              }
+            }
+          }
+        } else if (alias) {
+          this.log('applyTopicAlias :: error out of range. topic: %s - alias: %d', topic, alias)
+          return new Error('Sending Topic Alias out of range')
+        }
+      }
+    }
+  }
+
+  _nop(err) {
+    this.log('nop ::', err)
+  }
+
   /**
    * _sendPacket - send or queue a packet
    * @param {Object} packet - packet options
@@ -1157,10 +1111,10 @@ class MqttClient extends EventEmitter {
    */
   _sendPacket (packet, cb, cbStorePut, noStore) {
     this.log('_sendPacket :: (%s) ::  start', this.options.clientId)
-    cbStorePut = cbStorePut || nop
-    cb = cb || nop
+    cbStorePut = cbStorePut || this.nop
+    cb = cb || this.nop
 
-    const err = applyTopicAlias(this, packet)
+    const err = this._applyTopicAlias(packet)
     if (err) {
       cb(err)
       return
@@ -1196,7 +1150,7 @@ class MqttClient extends EventEmitter {
       case 'publish':
         break
       case 'pubrel':
-        storeAndSend(this, packet, cb, cbStorePut)
+        this._storeAndSend(packet, cb, cbStorePut)
         return
       default:
         sendPacket(this, packet, cb)
@@ -1206,7 +1160,7 @@ class MqttClient extends EventEmitter {
     switch (packet.qos) {
       case 2:
       case 1:
-        storeAndSend(this, packet, cb, cbStorePut)
+        this._storeAndSend(packet, cb, cbStorePut)
         break
       /**
        * no need of case here since it will be caught by default
@@ -1232,7 +1186,7 @@ class MqttClient extends EventEmitter {
   _storePacket (packet, cb, cbStorePut) {
     this.log('_storePacket :: packet: %o', packet)
     this.log('_storePacket :: cb? %s', !!cb)
-    cbStorePut = cbStorePut || nop
+    cbStorePut = cbStorePut || this.nop
 
     let storePacket = packet
     if (storePacket.cmd === 'publish') {
@@ -1459,7 +1413,7 @@ class MqttClient extends EventEmitter {
           if (that.messageIdProvider.register(packet.messageId)) {
             that._sendPacket(packet, undefined, undefined, true)
           } else {
-            this.log('messageId: %d has already used.', packet.messageId)
+            that.log('messageId: %d has already used.', packet.messageId)
           }
         } else if (outStore.destroy) {
           outStore.destroy()

--- a/lib/client.js
+++ b/lib/client.js
@@ -41,11 +41,11 @@ const socketErrors = [
   'ETIMEDOUT'
 ]
 
-function defaultId () {
+function defaultId() {
   return 'mqttjs_' + Math.random().toString(16).substr(2, 8)
 }
 
-function removeTopicAliasAndRecoverTopicName (client, packet) {
+function removeTopicAliasAndRecoverTopicName(client, packet) {
   let alias
   if (packet.properties) {
     alias = packet.properties.topicAlias
@@ -70,7 +70,7 @@ function removeTopicAliasAndRecoverTopicName (client, packet) {
   }
 }
 
-function sendPacket (client, packet, cb) {
+function sendPacket(client, packet, cb) {
   client.log('sendPacket :: packet: %O', packet)
   client.log('sendPacket :: emitting `packetsend`')
 
@@ -88,7 +88,7 @@ function sendPacket (client, packet, cb) {
   }
 }
 
-function flush (client, queue) {
+function flush(client, queue) {
   if (queue) {
     client.log('flush: queue exists? %b', !!(queue))
     Object.keys(queue).forEach(function (messageId) {
@@ -102,7 +102,7 @@ function flush (client, queue) {
   }
 }
 
-function flushVolatile (client, queue) {
+function flushVolatile(client, queue) {
   if (queue) {
     client.log('flushVolatile :: deleting volatile messages from the queue and setting their callbacks as error function')
     Object.keys(queue).forEach(function (messageId) {
@@ -123,7 +123,7 @@ function flushVolatile (client, queue) {
  * (see Connection#connect)
  */
 class MqttClient extends EventEmitter {
-  constructor (streamBuilder, options) {
+  constructor(streamBuilder, options) {
     super()
 
     let k
@@ -216,7 +216,7 @@ class MqttClient extends EventEmitter {
     this.on('connect', function () {
       const queue = that.queue
 
-      function deliver () {
+      function deliver() {
         const entry = queue.shift()
         that.log('deliver :: entry %o', entry)
         let packet = null
@@ -284,7 +284,7 @@ class MqttClient extends EventEmitter {
    *
    * @api private
    */
-  _setupStream () {
+  _setupStream() {
     const that = this
     const writable = new Writable()
     const parser = mqttPacket.parser(this.options)
@@ -302,7 +302,7 @@ class MqttClient extends EventEmitter {
       packets.push(packet)
     })
 
-    function nextTickWork () {
+    function nextTickWork() {
       if (packets.length) {
         nextTick(work)
       } else {
@@ -312,7 +312,7 @@ class MqttClient extends EventEmitter {
       }
     }
 
-    function work () {
+    function work() {
       that.log('work :: getting next packet in queue')
       const packet = packets.shift()
 
@@ -335,7 +335,7 @@ class MqttClient extends EventEmitter {
       work()
     }
 
-    function streamErrorHandler (error) {
+    function streamErrorHandler(error) {
       that.log('streamErrorHandler :: error', error.message)
       if (socketErrors.includes(error.code)) {
         // handle error
@@ -401,7 +401,7 @@ class MqttClient extends EventEmitter {
     }, this.options.connectTimeout)
   }
 
-  _checkDisconnecting (callback) {
+  _checkDisconnecting(callback) {
     if (this.disconnecting) {
       if (callback && callback !== this.nop) {
         callback(new Error('client disconnecting'))
@@ -432,7 +432,7 @@ class MqttClient extends EventEmitter {
    *     client.publish('topic', 'message', {qos: 1, retain: true, dup: true});
    * @example client.publish('topic', 'message', console.log);
    */
-  publish (topic, message, opts, callback) {
+  publish(topic, message, opts, callback) {
     this.log('publish :: message `%s` to topic `%s`', message, topic)
     const options = this.options
 
@@ -522,7 +522,7 @@ class MqttClient extends EventEmitter {
    * @example client.subscribe({'topic': {qos: 0}, 'topic2': {qos: 1}}, console.log);
    * @example client.subscribe('topic', console.log);
    */
-  subscribe () {
+  subscribe() {
     const that = this
     const args = new Array(arguments.length)
     for (let i = 0; i < arguments.length; i++) {
@@ -567,47 +567,41 @@ class MqttClient extends EventEmitter {
     }
     opts = { ...defaultOpts, ...opts }
 
+    function parseSub(topic, subOptions) {
+      // subOptions is defined only when providing a subs map, use opts otherwise
+      subOptions = subOptions || opts
+      if (!Object.prototype.hasOwnProperty.call(that._resubscribeTopics, topic) ||
+        that._resubscribeTopics[topic].qos < subOptions.qos ||
+        resubscribe) {
+        const currentOpts = {
+          topic,
+          qos: subOptions.qos
+        }
+        if (version === 5) {
+          currentOpts.nl = subOptions.nl
+          currentOpts.rap = subOptions.rap
+          currentOpts.rh = subOptions.rh
+          // use opts.properties
+          currentOpts.properties = opts.properties
+        }
+        that.log('subscribe: pushing topic `%s` and qos `%s` to subs list', currentOpts.topic, currentOpts.qos)
+        subs.push(currentOpts)
+      }
+    }
+
     if (Array.isArray(obj)) {
+      // array of topics
       obj.forEach(function (topic) {
         that.log('subscribe: array topic %s', topic)
-        if (!Object.prototype.hasOwnProperty.call(that._resubscribeTopics, topic) ||
-          that._resubscribeTopics[topic].qos < opts.qos ||
-          resubscribe) {
-          const currentOpts = {
-            topic,
-            qos: opts.qos
-          }
-          if (version === 5) {
-            currentOpts.nl = opts.nl
-            currentOpts.rap = opts.rap
-            currentOpts.rh = opts.rh
-            currentOpts.properties = opts.properties
-          }
-          that.log('subscribe: pushing topic `%s` and qos `%s` to subs list', currentOpts.topic, currentOpts.qos)
-          subs.push(currentOpts)
-        }
+        parseSub(topic)
       })
     } else {
+      // object topic --> subOptions (no properties)
       Object
         .keys(obj)
-        .forEach(function (k) {
-          that.log('subscribe: object topic %s', k)
-          if (!Object.prototype.hasOwnProperty.call(that._resubscribeTopics, k) ||
-            that._resubscribeTopics[k].qos < obj[k].qos ||
-            resubscribe) {
-            const currentOpts = {
-              topic: k,
-              qos: obj[k].qos
-            }
-            if (version === 5) {
-              currentOpts.nl = obj[k].nl
-              currentOpts.rap = obj[k].rap
-              currentOpts.rh = obj[k].rh
-              currentOpts.properties = opts.properties
-            }
-            that.log('subscribe: pushing `%s` to subs list', currentOpts)
-            subs.push(currentOpts)
-          }
+        .forEach(function (topic) {
+          that.log('subscribe: object topic %s, %o', topic, obj[topic])
+          parseSub(topic, obj[topic])
         })
     }
 
@@ -698,7 +692,7 @@ class MqttClient extends EventEmitter {
    * @example client.unsubscribe('topic');
    * @example client.unsubscribe('topic', console.log);
    */
-  unsubscribe () {
+  unsubscribe() {
     const that = this
     const args = new Array(arguments.length)
     for (let i = 0; i < arguments.length; i++) {
@@ -787,7 +781,7 @@ class MqttClient extends EventEmitter {
    *
    * @api public
    */
-  end (force, opts, cb) {
+  end(force, opts, cb) {
     const that = this
 
     this.log('end :: (%s)', this.options.clientId)
@@ -813,7 +807,7 @@ class MqttClient extends EventEmitter {
     this.log('end :: cb? %s', !!cb)
     cb = cb || this.nop
 
-    function closeStores () {
+    function closeStores() {
       that.log('end :: closeStores: closing incoming and outgoing stores')
       that.disconnected = true
       that.incomingStore.close(function (e1) {
@@ -832,7 +826,7 @@ class MqttClient extends EventEmitter {
       }
     }
 
-    function finish () {
+    function finish() {
       // defer closesStores of an I/O cycle,
       // just to make sure things are
       // ok for websockets
@@ -875,7 +869,7 @@ class MqttClient extends EventEmitter {
    *
    * @example client.removeOutgoingMessage(client.getLastAllocated());
    */
-  removeOutgoingMessage (messageId) {
+  removeOutgoingMessage(messageId) {
     if (this.outgoing[messageId]) {
       const cb = this.outgoing[messageId].cb
       this._removeOutgoingAndStoreMessage(messageId, function () {
@@ -896,7 +890,7 @@ class MqttClient extends EventEmitter {
    *
    * @api public
    */
-  reconnect (opts) {
+  reconnect(opts) {
     this.log('client reconnect')
     const that = this
     const f = function () {
@@ -927,7 +921,7 @@ class MqttClient extends EventEmitter {
    * _reconnect - implement reconnection
    * @api privateish
    */
-  _reconnect () {
+  _reconnect() {
     this.log('_reconnect: emitting reconnect to client')
     this.emit('reconnect')
     if (this.connected) {
@@ -942,7 +936,7 @@ class MqttClient extends EventEmitter {
   /**
    * _setupReconnect - setup reconnect timer
    */
-  _setupReconnect () {
+  _setupReconnect() {
     const that = this
 
     if (!that.disconnecting && !that.reconnectTimer && (that.options.reconnectPeriod > 0)) {
@@ -965,7 +959,7 @@ class MqttClient extends EventEmitter {
   /**
    * _clearReconnect - clear the reconnect timer
    */
-  _clearReconnect () {
+  _clearReconnect() {
     this.log('_clearReconnect : clearing reconnect timer')
     if (this.reconnectTimer) {
       clearInterval(this.reconnectTimer)
@@ -977,7 +971,7 @@ class MqttClient extends EventEmitter {
    * _cleanUp - clean up on connection end
    * @api private
    */
-  _cleanUp (forced, done) {
+  _cleanUp(forced, done) {
     const opts = arguments[2]
     if (done) {
       this.log('_cleanUp :: done callback provided for on stream close')
@@ -1022,7 +1016,7 @@ class MqttClient extends EventEmitter {
     }
   }
 
-  _storeAndSend (packet, cb, cbStorePut) {
+  _storeAndSend(packet, cb, cbStorePut) {
     this.log('storeAndSend :: store packet with cmd %s to outgoingStore', packet.cmd)
     let storePacket = packet
     let err
@@ -1037,7 +1031,7 @@ class MqttClient extends EventEmitter {
       }
     }
     const that = this
-    this.outgoingStore.put(storePacket, function storedPacket (err) {
+    this.outgoingStore.put(storePacket, function storedPacket(err) {
       if (err) {
         return cb && cb(err)
       }
@@ -1046,7 +1040,7 @@ class MqttClient extends EventEmitter {
     })
   }
 
-  _applyTopicAlias (packet) {
+  _applyTopicAlias(packet) {
     if (this.options.protocolVersion === 5) {
       if (packet.cmd === 'publish') {
         let alias
@@ -1108,7 +1102,7 @@ class MqttClient extends EventEmitter {
    * @param {Boolean} noStore - send without put to the store
    * @api private
    */
-  _sendPacket (packet, cb, cbStorePut, noStore) {
+  _sendPacket(packet, cb, cbStorePut, noStore) {
     this.log('_sendPacket :: (%s) ::  start', this.options.clientId)
     cbStorePut = cbStorePut || this.nop
     cb = cb || this.nop
@@ -1182,7 +1176,7 @@ class MqttClient extends EventEmitter {
    * @param {Function} cbStorePut - called when message is put into outgoingStore
    * @api private
    */
-  _storePacket (packet, cb, cbStorePut) {
+  _storePacket(packet, cb, cbStorePut) {
     this.log('_storePacket :: packet: %o', packet)
     this.log('_storePacket :: cb? %s', !!cb)
     cbStorePut = cbStorePut || this.nop
@@ -1219,7 +1213,7 @@ class MqttClient extends EventEmitter {
    *
    * @api private
    */
-  _setupPingTimer () {
+  _setupPingTimer() {
     this.log('_setupPingTimer :: keepalive %d (seconds)', this.options.keepalive)
     const that = this
 
@@ -1236,7 +1230,7 @@ class MqttClient extends EventEmitter {
    *
    * @api private
    */
-  _shiftPingInterval () {
+  _shiftPingInterval() {
     if (this.pingTimer && this.options.keepalive && this.options.reschedulePings) {
       this.pingTimer.reschedule(this.options.keepalive * 1000)
     }
@@ -1247,7 +1241,7 @@ class MqttClient extends EventEmitter {
    *
    * @api private
    */
-  _checkPing () {
+  _checkPing() {
     this.log('_checkPing :: checking ping...')
     if (this.pingResp) {
       this.log('_checkPing :: ping response received. Clearing flag and sending `pingreq`')
@@ -1265,7 +1259,7 @@ class MqttClient extends EventEmitter {
    * @return the auth packet to be returned to the broker
    * @api public
    */
-  handleAuth (packet, callback) {
+  handleAuth(packet, callback) {
     callback()
   }
 
@@ -1277,7 +1271,7 @@ class MqttClient extends EventEmitter {
    * @param Function callback call when finished
    * @api public
    */
-  handleMessage (packet, callback) {
+  handleMessage(packet, callback) {
     callback()
   }
 
@@ -1285,7 +1279,7 @@ class MqttClient extends EventEmitter {
    * _nextId
    * @return unsigned int
    */
-  _nextId () {
+  _nextId() {
     return this.messageIdProvider.allocate()
   }
 
@@ -1293,7 +1287,7 @@ class MqttClient extends EventEmitter {
    * getLastMessageId
    * @return unsigned int
    */
-  getLastMessageId () {
+  getLastMessageId() {
     return this.messageIdProvider.getLastAllocated()
   }
 
@@ -1301,7 +1295,7 @@ class MqttClient extends EventEmitter {
    * _resubscribe
    * @api private
    */
-  _resubscribe () {
+  _resubscribe() {
     this.log('_resubscribe')
     const _resubscribeTopicsKeys = Object.keys(this._resubscribeTopics)
     if (!this._firstConnection &&
@@ -1333,7 +1327,7 @@ class MqttClient extends EventEmitter {
    *
    * @api private
    */
-  _onConnect (packet) {
+  _onConnect(packet) {
     if (this.disconnected) {
       this.emit('connect', packet)
       return
@@ -1347,10 +1341,10 @@ class MqttClient extends EventEmitter {
 
     this.connected = true
 
-    function startStreamProcess () {
+    function startStreamProcess() {
       let outStore = that.outgoingStore.createStream()
 
-      function clearStoreProcessing () {
+      function clearStoreProcessing() {
         that._storeProcessing = false
         that._packetIdsDuringStoreProcessing = {}
       }
@@ -1363,14 +1357,14 @@ class MqttClient extends EventEmitter {
         that.emit('error', err)
       })
 
-      function remove () {
+      function remove() {
         outStore.destroy()
         outStore = null
         that._flushStoreProcessingQueue()
         clearStoreProcessing()
       }
 
-      function storeDeliver () {
+      function storeDeliver() {
         // edge case, we wrapped this twice
         if (!outStore) {
           return
@@ -1442,7 +1436,7 @@ class MqttClient extends EventEmitter {
     startStreamProcess()
   }
 
-  _invokeStoreProcessingQueue () {
+  _invokeStoreProcessingQueue() {
     // If _storeProcessing is true, the message is resending.
     // During resend, processing is skipped to prevent new messages from interrupting. #1635
     if (!this._storeProcessing && this._storeProcessingQueue.length > 0) {
@@ -1455,11 +1449,11 @@ class MqttClient extends EventEmitter {
     return false
   }
 
-  _invokeAllStoreProcessingQueue () {
+  _invokeAllStoreProcessingQueue() {
     while (this._invokeStoreProcessingQueue()) { /* empty */ }
   }
 
-  _flushStoreProcessingQueue () {
+  _flushStoreProcessingQueue() {
     for (const f of this._storeProcessingQueue) {
       if (f.cbStorePut) f.cbStorePut(new Error('Connection closed'))
       if (f.callback) f.callback(new Error('Connection closed'))
@@ -1473,7 +1467,7 @@ class MqttClient extends EventEmitter {
    * @param {Function} cb - called when the message removed
    * @api private
    */
-  _removeOutgoingAndStoreMessage (messageId, cb) {
+  _removeOutgoingAndStoreMessage(messageId, cb) {
     const self = this
     delete this.outgoing[messageId]
     self.outgoingStore.del({ messageId }, function (err, packet) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -41,79 +41,6 @@ const socketErrors = [
   'ETIMEDOUT'
 ]
 
-function defaultId() {
-  return 'mqttjs_' + Math.random().toString(16).substr(2, 8)
-}
-
-function removeTopicAliasAndRecoverTopicName(client, packet) {
-  let alias
-  if (packet.properties) {
-    alias = packet.properties.topicAlias
-  }
-
-  let topic = packet.topic.toString()
-  if (topic.length === 0) {
-    // restore topic from alias
-    if (typeof alias === 'undefined') {
-      return new Error('Unregistered Topic Alias')
-    } else {
-      topic = client.topicAliasSend.getTopicByAlias(alias)
-      if (typeof topic === 'undefined') {
-        return new Error('Unregistered Topic Alias')
-      } else {
-        packet.topic = topic
-      }
-    }
-  }
-  if (alias) {
-    delete packet.properties.topicAlias
-  }
-}
-
-function sendPacket(client, packet, cb) {
-  client.log('sendPacket :: packet: %O', packet)
-  client.log('sendPacket :: emitting `packetsend`')
-
-  client.emit('packetsend', packet)
-
-  client.log('sendPacket :: writing to stream')
-  const result = mqttPacket.writeToStream(packet, client.stream, client.options)
-  client.log('sendPacket :: writeToStream result %s', result)
-  if (!result && cb && cb !== client.nop) {
-    client.log('sendPacket :: handle events on `drain` once through callback.')
-    client.stream.once('drain', cb)
-  } else if (cb) {
-    client.log('sendPacket :: invoking cb')
-    cb()
-  }
-}
-
-function flush(client, queue) {
-  if (queue) {
-    client.log('flush: queue exists? %b', !!(queue))
-    Object.keys(queue).forEach(function (messageId) {
-      if (typeof queue[messageId].cb === 'function') {
-        queue[messageId].cb(new Error('Connection closed'))
-        // This is suspicious.  Why do we only delete this if we have a callbck?
-        // If this is by-design, then adding no as callback would cause this to get deleted unintentionally.
-        delete queue[messageId]
-      }
-    })
-  }
-}
-
-function flushVolatile(client, queue) {
-  if (queue) {
-    client.log('flushVolatile :: deleting volatile messages from the queue and setting their callbacks as error function')
-    Object.keys(queue).forEach(function (messageId) {
-      if (queue[messageId].volatile && typeof queue[messageId].cb === 'function') {
-        queue[messageId].cb(new Error('Connection closed'))
-        delete queue[messageId]
-      }
-    })
-  }
-}
-
 
 /**
  * MqttClient constructor
@@ -123,6 +50,11 @@ function flushVolatile(client, queue) {
  * (see Connection#connect)
  */
 class MqttClient extends EventEmitter {
+
+  static defaultId() {
+    return 'mqttjs_' + Math.random().toString(16).substr(2, 8)
+  }
+
   constructor(streamBuilder, options) {
     super()
 
@@ -151,7 +83,7 @@ class MqttClient extends EventEmitter {
     this.log('MqttClient :: options.rejectUnauthorized', options.rejectUnauthorized)
     this.log('MqttClient :: options.properties.topicAliasMaximum', options.properties ? options.properties.topicAliasMaximum : undefined)
 
-    this.options.clientId = (typeof options.clientId === 'string') ? options.clientId : defaultId()
+    this.options.clientId = (typeof options.clientId === 'string') ? options.clientId : MqttClient.defaultId()
 
     this.log('MqttClient :: clientId', this.options.clientId)
 
@@ -355,7 +287,7 @@ class MqttClient extends EventEmitter {
     // Echo stream close
     this.stream.on('close', function () {
       that.log('(%s)stream :: on close', that.options.clientId)
-      flushVolatile(that, that.outgoing)
+      that._flushVolatile(that.outgoing)
       that.log('stream: emit close to MqttClient')
       that.emit('close')
     })
@@ -373,7 +305,7 @@ class MqttClient extends EventEmitter {
       }
     }
     // avoid message queue
-    sendPacket(this, connectPacket)
+    this._writePacket(connectPacket)
 
     // Echo connection errors
     parser.on('error', this.emit.bind(this, 'error'))
@@ -387,7 +319,7 @@ class MqttClient extends EventEmitter {
       }
       if (this.options.properties.authenticationMethod && this.options.authPacket && typeof this.options.authPacket === 'object') {
         const authPacket = { cmd: 'auth', reasonCode: 0, ...this.options.authPacket }
-        sendPacket(this, authPacket)
+        this._writePacket(authPacket)
       }
     }
 
@@ -399,6 +331,60 @@ class MqttClient extends EventEmitter {
       that.log('!!connectTimeout hit!! Calling _cleanUp with force `true`')
       that._cleanUp(true)
     }, this.options.connectTimeout)
+  }
+
+  _flushVolatile(queue) {
+    if (queue) {
+      this.log('_flushVolatile :: deleting volatile messages from the queue and setting their callbacks as error function')
+      Object.keys(queue).forEach(function (messageId) {
+        if (queue[messageId].volatile && typeof queue[messageId].cb === 'function') {
+          queue[messageId].cb(new Error('Connection closed'))
+          delete queue[messageId]
+        }
+      })
+    }
+  }
+
+  _flush(queue) {
+    if (queue) {
+      this.log('_flush: queue exists? %b', !!(queue))
+      Object.keys(queue).forEach(function (messageId) {
+        if (typeof queue[messageId].cb === 'function') {
+          queue[messageId].cb(new Error('Connection closed'))
+          // This is suspicious.  Why do we only delete this if we have a callback?
+          // If this is by-design, then adding no as callback would cause this to get deleted unintentionally.
+          delete queue[messageId]
+        }
+      })
+    }
+  }
+
+  _removeTopicAliasAndRecoverTopicName(packet) {
+    let alias
+    if (packet.properties) {
+      alias = packet.properties.topicAlias
+    }
+    
+    let topic = packet.topic.toString()
+
+    this.log('_removeTopicAliasAndRecoverTopicName :: alias %d, topic %o', alias, topic)
+  
+    if (topic.length === 0) {
+      // restore topic from alias
+      if (typeof alias === 'undefined') {
+        return new Error('Unregistered Topic Alias')
+      } else {
+        topic = this.topicAliasSend.getTopicByAlias(alias)
+        if (typeof topic === 'undefined') {
+          return new Error('Unregistered Topic Alias')
+        } else {
+          packet.topic = topic
+        }
+      }
+    }
+    if (alias) {
+      delete packet.properties.topicAlias
+    }
   }
 
   _checkDisconnecting(callback) {
@@ -981,7 +967,7 @@ class MqttClient extends EventEmitter {
     this.log('_cleanUp :: forced? %s', forced)
     if (forced) {
       if ((this.options.reconnectPeriod === 0) && this.options.clean) {
-        flush(this, this.outgoing)
+        this._flush(this.outgoing)
       }
       this.log('_cleanUp :: (%s) :: destroying stream', this.options.clientId)
       this.stream.destroy()
@@ -1025,7 +1011,7 @@ class MqttClient extends EventEmitter {
       // The cloned storePacket is for storing to resend on reconnect.
       // Topic Alias must not be used after disconnected.
       storePacket = clone(packet)
-      err = removeTopicAliasAndRecoverTopicName(this, storePacket)
+      err = this._removeTopicAliasAndRecoverTopicName(storePacket)
       if (err) {
         return cb && cb(err)
       }
@@ -1036,7 +1022,7 @@ class MqttClient extends EventEmitter {
         return cb && cb(err)
       }
       cbStorePut()
-      sendPacket(that, packet, cb)
+      that._writePacket(packet, cb)
     })
   }
 
@@ -1094,6 +1080,28 @@ class MqttClient extends EventEmitter {
     this.log('nop ::', err)
   }
 
+  /** Writes the packet to stream and emits events */
+  _writePacket(packet, cb) {
+    this.log('writePacket :: packet: %O', packet)
+    this.log('writePacket :: emitting `packetsend`')
+
+    this.emit('packetsend', packet)
+
+    // When writing a packet, reschedule the ping timer
+    this._shiftPingInterval()
+
+    this.log('writePacket :: writing to stream')
+    const result = mqttPacket.writeToStream(packet, this.stream, this.options)
+    this.log('writePacket :: writeToStream result %s', result)
+    if (!result && cb && cb !== this.nop) {
+      this.log('writePacket :: handle events on `drain` once through callback.')
+      this.stream.once('drain', cb)
+    } else if (cb) {
+      this.log('writePacket :: invoking cb')
+      cb()
+    }
+  }
+
   /**
    * _sendPacket - send or queue a packet
    * @param {Object} packet - packet options
@@ -1116,8 +1124,7 @@ class MqttClient extends EventEmitter {
     if (!this.connected) {
       // allow auth packets to be sent while authenticating with the broker (mqtt5 enhanced auth)
       if (packet.cmd === 'auth') {
-        this._shiftPingInterval()
-        sendPacket(this, packet, cb)
+        this._writePacket(this, packet, cb)
         return
       }
 
@@ -1126,16 +1133,13 @@ class MqttClient extends EventEmitter {
       return
     }
 
-    // When sending a packet, reschedule the ping timer
-    this._shiftPingInterval()
-
     // If "noStore" is true, the message is sent without being recorded in the store.
     // Messages that have not received puback or pubcomp remain in the store after disconnection
     // and are resent from the store upon reconnection.
     // For resend upon reconnection, "noStore" is set to true. This is because the message is already stored in the store.
     // This is to avoid interrupting other processes while recording to the store.
     if (noStore) {
-      sendPacket(this, packet, cb)
+      this._writePacket(packet, cb)
       return
     }
 
@@ -1146,7 +1150,7 @@ class MqttClient extends EventEmitter {
         this._storeAndSend(packet, cb, cbStorePut)
         return
       default:
-        sendPacket(this, packet, cb)
+        this._writePacket(packet, cb)
         return
     }
 
@@ -1163,7 +1167,7 @@ class MqttClient extends EventEmitter {
       case 0:
       /* falls through */
       default:
-        sendPacket(this, packet, cb)
+        this._writePacket(packet, cb)
         break
     }
     this.log('_sendPacket :: (%s) ::  end', this.options.clientId)
@@ -1187,7 +1191,7 @@ class MqttClient extends EventEmitter {
       // The cloned storePacket is for storing to resend on reconnect.
       // Topic Alias must not be used after disconnected.
       storePacket = clone(packet)
-      const err = removeTopicAliasAndRecoverTopicName(this, storePacket)
+      const err = this._removeTopicAliasAndRecoverTopicName(storePacket)
       if (err) {
         return cb && cb(err)
       }

--- a/lib/client.js
+++ b/lib/client.js
@@ -319,10 +319,7 @@ class MqttClient extends EventEmitter {
       }
       if (this.options.properties.authenticationMethod && this.options.authPacket && typeof this.options.authPacket === 'object') {
         const authPacket = { cmd: 'auth', reasonCode: 0, ...this.options.authPacket }
-        // prevent race condition in tests
-        setImmediate(() => {
-          this._writePacket(authPacket)
-        })
+        this._writePacket(authPacket)
       }
     }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1090,22 +1090,22 @@ class MqttClient extends EventEmitter {
 
   /** Writes the packet to stream and emits events */
   _writePacket(packet, cb) {
-    this.log('writePacket :: packet: %O', packet)
-    this.log('writePacket :: emitting `packetsend`')
+    this.log('_writePacket :: packet: %O', packet)
+    this.log('_writePacket :: emitting `packetsend`')
 
     this.emit('packetsend', packet)
 
     // When writing a packet, reschedule the ping timer
     this._shiftPingInterval()
 
-    this.log('writePacket :: writing to stream')
+    this.log('_writePacket :: writing to stream')
     const result = mqttPacket.writeToStream(packet, this.stream, this.options)
-    this.log('writePacket :: writeToStream result %s', result)
+    this.log('_writePacket :: writeToStream result %s', result)
     if (!result && cb && cb !== this.nop) {
-      this.log('writePacket :: handle events on `drain` once through callback.')
+      this.log('_writePacket :: handle events on `drain` once through callback.')
       this.stream.once('drain', cb)
     } else if (cb) {
-      this.log('writePacket :: invoking cb')
+      this.log('_writePacket :: invoking cb')
       cb()
     }
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -319,7 +319,10 @@ class MqttClient extends EventEmitter {
       }
       if (this.options.properties.authenticationMethod && this.options.authPacket && typeof this.options.authPacket === 'object') {
         const authPacket = { cmd: 'auth', reasonCode: 0, ...this.options.authPacket }
-        this._writePacket(authPacket)
+        // prevent race condition in tests
+        setImmediate(() => {
+          this._writePacket(authPacket)
+        })
       }
     }
 

--- a/lib/handlers/ack.js
+++ b/lib/handlers/ack.js
@@ -148,3 +148,4 @@ function handleAck(client, packet, done) {
 }
 
 module.exports = handleAck;
+module.exports.errors = errors;

--- a/lib/handlers/ack.js
+++ b/lib/handlers/ack.js
@@ -1,4 +1,51 @@
 
+// Other Socket Errors: EADDRINUSE, ECONNRESET, ENOTFOUND, ETIMEDOUT.
+
+const errors = {
+    0: '',
+    1: 'Unacceptable protocol version',
+    2: 'Identifier rejected',
+    3: 'Server unavailable',
+    4: 'Bad username or password',
+    5: 'Not authorized',
+    16: 'No matching subscribers',
+    17: 'No subscription existed',
+    128: 'Unspecified error',
+    129: 'Malformed Packet',
+    130: 'Protocol Error',
+    131: 'Implementation specific error',
+    132: 'Unsupported Protocol Version',
+    133: 'Client Identifier not valid',
+    134: 'Bad User Name or Password',
+    135: 'Not authorized',
+    136: 'Server unavailable',
+    137: 'Server busy',
+    138: 'Banned',
+    139: 'Server shutting down',
+    140: 'Bad authentication method',
+    141: 'Keep Alive timeout',
+    142: 'Session taken over',
+    143: 'Topic Filter invalid',
+    144: 'Topic Name invalid',
+    145: 'Packet identifier in use',
+    146: 'Packet Identifier not found',
+    147: 'Receive Maximum exceeded',
+    148: 'Topic Alias invalid',
+    149: 'Packet too large',
+    150: 'Message rate too high',
+    151: 'Quota exceeded',
+    152: 'Administrative action',
+    153: 'Payload format invalid',
+    154: 'Retain not supported',
+    155: 'QoS not supported',
+    156: 'Use another server',
+    157: 'Server moved',
+    158: 'Shared Subscriptions not supported',
+    159: 'Connection rate exceeded',
+    160: 'Maximum connect time',
+    161: 'Subscription Identifiers not supported',
+    162: 'Wildcard Subscriptions not supported'
+  }
 
 function handleAck(client, packet, done) {
     /* eslint no-fallthrough: "off" */

--- a/lib/handlers/ack.js
+++ b/lib/handlers/ack.js
@@ -1,0 +1,103 @@
+
+
+function handleAck(client, packet, done) {
+    /* eslint no-fallthrough: "off" */
+    const messageId = packet.messageId
+    const type = packet.cmd
+    let response = null
+    const cb = client.outgoing[messageId] ? client.outgoing[messageId].cb : null
+    let err
+
+    // Checking `!cb` happens to work, but it's not technically "correct".
+    //
+    // Why? client code assumes client "no callback" is the same as client "we're not
+    // waiting for responses" (puback, pubrec, pubcomp, suback, or unsuback).
+    //
+    // It would be better to check `if (!client.outgoing[messageId])` here, but
+    // there's no reason to change it and risk (another) regression.
+    //
+    // The only reason client code works is becaues code in MqttClient.publish,
+    // MqttClinet.subscribe, and MqttClient.unsubscribe ensures client we will
+    // have a callback even if the user doesn't pass one in.)
+    if (!cb) {
+        client.log('_handleAck :: Server sent an ack in error. Ignoring.')
+        // Server sent an ack in error, ignore it.
+        return
+    }
+
+    // Process
+    client.log('_handleAck :: packet type', type)
+    switch (type) {
+        case 'pubcomp':
+        // same thing as puback for QoS 2
+        case 'puback': {
+            const pubackRC = packet.reasonCode
+            // Callback - we're done
+            if (pubackRC && pubackRC > 0 && pubackRC !== 16) {
+                err = new Error('Publish error: ' + errors[pubackRC])
+                err.code = pubackRC
+                client._removeOutgoingAndStoreMessage(messageId, function () {
+                    cb(err, packet)
+                })
+            } else {
+                client._removeOutgoingAndStoreMessage(messageId, cb)
+            }
+
+            break
+        }
+        case 'pubrec': {
+            response = {
+                cmd: 'pubrel',
+                qos: 2,
+                messageId
+            }
+            const pubrecRC = packet.reasonCode
+
+            if (pubrecRC && pubrecRC > 0 && pubrecRC !== 16) {
+                err = new Error('Publish error: ' + errors[pubrecRC])
+                err.code = pubrecRC
+                client._removeOutgoingAndStoreMessage(messageId, function () {
+                    cb(err, packet)
+                })
+            } else {
+                client._sendPacket(response)
+            }
+            break
+        }
+        case 'suback': {
+            delete client.outgoing[messageId]
+            client.messageIdProvider.deallocate(messageId)
+            for (let grantedI = 0; grantedI < packet.granted.length; grantedI++) {
+                if ((packet.granted[grantedI] & 0x80) !== 0) {
+                    // suback with Failure status
+                    const topics = client.messageIdToTopic[messageId]
+                    if (topics) {
+                        topics.forEach(function (topic) {
+                            delete client._resubscribeTopics[topic]
+                        })
+                    }
+                }
+            }
+            delete client.messageIdToTopic[messageId]
+            client._invokeStoreProcessingQueue()
+            cb(null, packet)
+            break
+        }
+        case 'unsuback': {
+            delete client.outgoing[messageId]
+            client.messageIdProvider.deallocate(messageId)
+            client._invokeStoreProcessingQueue()
+            cb(null)
+            break
+        }
+        default:
+            client.emit('error', new Error('unrecognized packet type'))
+    }
+
+    if (client.disconnecting &&
+        Object.keys(client.outgoing).length === 0) {
+        client.emit('outgoingEmpty')
+    }
+}
+
+module.exports = handleAck;

--- a/lib/handlers/ack.js
+++ b/lib/handlers/ack.js
@@ -47,7 +47,7 @@ const errors = {
     162: 'Wildcard Subscriptions not supported'
   }
 
-function handleAck(client, packet, done) {
+function handleAck(client, packet) {
     /* eslint no-fallthrough: "off" */
     const messageId = packet.messageId
     const type = packet.cmd

--- a/lib/handlers/auth.js
+++ b/lib/handlers/auth.js
@@ -1,6 +1,6 @@
 
 
-function handleAuth(client, packet, done) {
+function handleAuth(client, packet) {
     const options = client.options
     const version = options.protocolVersion
     const rc = version === 5 ? packet.reasonCode : packet.returnCode

--- a/lib/handlers/auth.js
+++ b/lib/handlers/auth.js
@@ -1,0 +1,33 @@
+
+
+function handleAuth(client, packet, done) {
+    const options = client.options
+    const version = options.protocolVersion
+    const rc = version === 5 ? packet.reasonCode : packet.returnCode
+
+    if (version !== 5) {
+      const err = new Error('Protocol error: Auth packets are only supported in MQTT 5. Your version:' + version)
+      err.code = rc
+      client.emit('error', err)
+      return
+    }
+
+    client.handleAuth(packet, function (err, packet) {
+      if (err) {
+        client.emit('error', err)
+        return
+      }
+
+      if (rc === 24) {
+        client.reconnecting = false
+        client._sendPacket(packet)
+      } else {
+        const error = new Error('Connection refused: ' + errors[rc])
+        err.code = rc
+        client.emit('error', error)
+      }
+    })
+}
+
+
+module.exports = handleAuth

--- a/lib/handlers/connack.js
+++ b/lib/handlers/connack.js
@@ -1,0 +1,44 @@
+
+
+function handleConnack(client, packet, done) {
+    client.log('_handleConnack')
+    const options = client.options
+    const version = options.protocolVersion
+    const rc = version === 5 ? packet.reasonCode : packet.returnCode
+
+    clearTimeout(client.connackTimer)
+    delete client.topicAliasSend
+
+    if (packet.properties) {
+      if (packet.properties.topicAliasMaximum) {
+        if (packet.properties.topicAliasMaximum > 0xffff) {
+          client.emit('error', new Error('topicAliasMaximum from broker is out of range'))
+          return
+        }
+        if (packet.properties.topicAliasMaximum > 0) {
+          client.topicAliasSend = new TopicAliasSend(packet.properties.topicAliasMaximum)
+        }
+      }
+      if (packet.properties.serverKeepAlive && options.keepalive) {
+        options.keepalive = packet.properties.serverKeepAlive
+        client._shiftPingInterval()
+      }
+      if (packet.properties.maximumPacketSize) {
+        if (!options.properties) { options.properties = {} }
+        options.properties.maximumPacketSize = packet.properties.maximumPacketSize
+      }
+    }
+
+    if (rc === 0) {
+      client.reconnecting = false
+      client._onConnect(packet)
+    } else if (rc > 0) {
+      const err = new Error('Connection refused: ' + errors[rc])
+      err.code = rc
+      client.emit('error', err)
+    }
+
+    done()
+}
+
+module.exports = handleConnack

--- a/lib/handlers/connack.js
+++ b/lib/handlers/connack.js
@@ -1,4 +1,5 @@
 const { errors } = require('./ack')
+const TopicAliasSend = require('../topic-alias-send')
 
 function handleConnack(client, packet) {
     client.log('_handleConnack')

--- a/lib/handlers/connack.js
+++ b/lib/handlers/connack.js
@@ -1,6 +1,6 @@
+const { errors } = require('./ack')
 
-
-function handleConnack(client, packet, done) {
+function handleConnack(client, packet) {
     client.log('_handleConnack')
     const options = client.options
     const version = options.protocolVersion
@@ -10,35 +10,33 @@ function handleConnack(client, packet, done) {
     delete client.topicAliasSend
 
     if (packet.properties) {
-      if (packet.properties.topicAliasMaximum) {
-        if (packet.properties.topicAliasMaximum > 0xffff) {
-          client.emit('error', new Error('topicAliasMaximum from broker is out of range'))
-          return
+        if (packet.properties.topicAliasMaximum) {
+            if (packet.properties.topicAliasMaximum > 0xffff) {
+                client.emit('error', new Error('topicAliasMaximum from broker is out of range'))
+                return
+            }
+            if (packet.properties.topicAliasMaximum > 0) {
+                client.topicAliasSend = new TopicAliasSend(packet.properties.topicAliasMaximum)
+            }
         }
-        if (packet.properties.topicAliasMaximum > 0) {
-          client.topicAliasSend = new TopicAliasSend(packet.properties.topicAliasMaximum)
+        if (packet.properties.serverKeepAlive && options.keepalive) {
+            options.keepalive = packet.properties.serverKeepAlive
+            client._shiftPingInterval()
         }
-      }
-      if (packet.properties.serverKeepAlive && options.keepalive) {
-        options.keepalive = packet.properties.serverKeepAlive
-        client._shiftPingInterval()
-      }
-      if (packet.properties.maximumPacketSize) {
-        if (!options.properties) { options.properties = {} }
-        options.properties.maximumPacketSize = packet.properties.maximumPacketSize
-      }
+        if (packet.properties.maximumPacketSize) {
+            if (!options.properties) { options.properties = {} }
+            options.properties.maximumPacketSize = packet.properties.maximumPacketSize
+        }
     }
 
     if (rc === 0) {
-      client.reconnecting = false
-      client._onConnect(packet)
+        client.reconnecting = false
+        client._onConnect(packet)
     } else if (rc > 0) {
-      const err = new Error('Connection refused: ' + errors[rc])
-      err.code = rc
-      client.emit('error', err)
+        const err = new Error('Connection refused: ' + errors[rc])
+        err.code = rc
+        client.emit('error', err)
     }
-
-    done()
 }
 
 module.exports = handleConnack

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -1,0 +1,57 @@
+const handlePublish = require('./publish')
+const handleAuth = require('./auth')
+const handleConnack = require('./connack')
+const handleAck = require('./ack')
+const handlePubRel = require('./pubrel')
+
+function handle(client, packet, done) {
+    const options = client.options
+
+    if (options.protocolVersion === 5 && options.properties && options.properties.maximumPacketSize && options.properties.maximumPacketSize < packet.length) {
+      client.emit('error', new Error('exceeding packets size ' + packet.cmd))
+      client.end({ reasonCode: 149, properties: { reasonString: 'Maximum packet size was exceeded' } })
+      return client
+    }
+    client.log('_handlePacket :: emitting packetreceive')
+    client.emit('packetreceive', packet)
+
+    switch (packet.cmd) {
+      case 'publish':
+        handlePublish(client, packet, done)
+        break
+      case 'puback':
+      case 'pubrec':
+      case 'pubcomp':
+      case 'suback':
+      case 'unsuback':
+        handleAck(client, packet, done)
+        done()
+        break
+      case 'pubrel':
+        handlePubRel(client, packet, done)
+        done()
+        break
+      case 'connack':
+        handleConnack(client, packet, done)
+        break
+      case 'auth':
+        handleAuth(client, packet)
+        done()
+        break
+      case 'pingresp':
+        client.pingResp = true
+        done()
+        break
+      case 'disconnect':
+        client.emit('disconnect', packet)
+        done()
+        break
+      default:
+        // do nothing
+        // maybe we should do an error handling
+        // or just log it
+        break
+    }
+}
+
+module.exports = handle

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -2,7 +2,7 @@ const handlePublish = require('./publish')
 const handleAuth = require('./auth')
 const handleConnack = require('./connack')
 const handleAck = require('./ack')
-const handlePubRel = require('./pubrel')
+const handlePubrel = require('./pubrel')
 
 function handle(client, packet, done) {
     const options = client.options
@@ -28,7 +28,7 @@ function handle(client, packet, done) {
         done()
         break
       case 'pubrel':
-        handlePubRel(client, packet, done)
+        handlePubrel(client, packet, done)
         done()
         break
       case 'connack':

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -24,15 +24,16 @@ function handle(client, packet, done) {
       case 'pubcomp':
       case 'suback':
       case 'unsuback':
-        handleAck(client, packet, done)
+        handleAck(client, packet)
         done()
         break
       case 'pubrel':
-        handlePubrel(client, packet, done)
+        handlePubrel(client, packet)
         done()
         break
       case 'connack':
-        handleConnack(client, packet, done)
+        handleConnack(client, packet)
+        done()
         break
       case 'auth':
         handleAuth(client, packet)
@@ -50,6 +51,8 @@ function handle(client, packet, done) {
         // do nothing
         // maybe we should do an error handling
         // or just log it
+        client.log('_handlePacket :: unknown command')
+        done()
         break
     }
 }

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -28,8 +28,7 @@ function handle(client, packet, done) {
         done()
         break
       case 'pubrel':
-        handlePubrel(client, packet)
-        done()
+        handlePubrel(client, packet, done)
         break
       case 'connack':
         handleConnack(client, packet)

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -39,6 +39,7 @@ function handle(client, packet, done) {
         done()
         break
       case 'pingresp':
+        // this will be checked in _checkPing client method every keepalive interval
         client.pingResp = true
         done()
         break
@@ -47,9 +48,7 @@ function handle(client, packet, done) {
         done()
         break
       default:
-        // do nothing
-        // maybe we should do an error handling
-        // or just log it
+        // TODO: unknown packet received. Should we emit an error?
         client.log('_handlePacket :: unknown command')
         done()
         break

--- a/lib/handlers/publish.js
+++ b/lib/handlers/publish.js
@@ -25,7 +25,7 @@
   */
 function handlePublish(client, packet, done) {
     client.log('_handlePublish: packet %o', packet)
-    done = typeof done !== 'undefined' ? done : nop
+    done = typeof done !== 'undefined' ? done : client.nop
     let topic = packet.topic.toString()
     const message = packet.payload
     const qos = packet.qos

--- a/lib/handlers/publish.js
+++ b/lib/handlers/publish.js
@@ -1,3 +1,4 @@
+const validReasonCodes = [0, 16, 128, 131, 135, 144, 145, 151, 153]
 
 /*
   those late 2 case should be rewrite to comply with coding style:
@@ -31,7 +32,6 @@ function handlePublish(client, packet, done) {
     const qos = packet.qos
     const messageId = packet.messageId
     const options = client.options
-    const validReasonCodes = [0, 16, 128, 131, 135, 144, 145, 151, 153]
     if (client.options.protocolVersion === 5) {
       let alias
       if (packet.properties) {

--- a/lib/handlers/publish.js
+++ b/lib/handlers/publish.js
@@ -25,7 +25,7 @@ const validReasonCodes = [0, 16, 128, 131, 135, 144, 145, 151, 153]
   for now i just suppressed the warnings
   */
 function handlePublish(client, packet, done) {
-    client.log('_handlePublish: packet %o', packet)
+    client.log('handlePublish: packet %o', packet)
     done = typeof done !== 'undefined' ? done : client.nop
     let topic = packet.topic.toString()
     const message = packet.payload
@@ -43,29 +43,29 @@ function handlePublish(client, packet, done) {
             const gotTopic = client.topicAliasRecv.getTopicByAlias(alias)
             if (gotTopic) {
               topic = gotTopic
-              client.log('_handlePublish :: topic complemented by alias. topic: %s - alias: %d', topic, alias)
+              client.log('handlePublish :: topic complemented by alias. topic: %s - alias: %d', topic, alias)
             } else {
-              client.log('_handlePublish :: unregistered topic alias. alias: %d', alias)
+              client.log('handlePublish :: unregistered topic alias. alias: %d', alias)
               client.emit('error', new Error('Received unregistered Topic Alias'))
               return
             }
           } else {
-            client.log('_handlePublish :: topic alias out of range. alias: %d', alias)
+            client.log('handlePublish :: topic alias out of range. alias: %d', alias)
             client.emit('error', new Error('Received Topic Alias is out of range'))
             return
           }
         } else {
           if (client.topicAliasRecv.put(topic, alias)) {
-            client.log('_handlePublish :: registered topic: %s - alias: %d', topic, alias)
+            client.log('handlePublish :: registered topic: %s - alias: %d', topic, alias)
           } else {
-            client.log('_handlePublish :: topic alias out of range. alias: %d', alias)
+            client.log('handlePublish :: topic alias out of range. alias: %d', alias)
             client.emit('error', new Error('Received Topic Alias is out of range'))
             return
           }
         }
       }
     }
-    client.log('_handlePublish: qos %d', qos)
+    client.log('handlePublish: qos %d', qos)
     switch (qos) {
       case 2: {
         options.customHandleAcks(topic, message, packet, function (error, code) {
@@ -111,7 +111,7 @@ function handlePublish(client, packet, done) {
         break
       default:
         // do nothing
-        client.log('_handlePublish: unknown QoS. Doing nothing.')
+        client.log('handlePublish: unknown QoS. Doing nothing.')
         // log or throw an error about unknown qos
         break
     }

--- a/lib/handlers/publish.js
+++ b/lib/handlers/publish.js
@@ -1,0 +1,120 @@
+
+/*
+  those late 2 case should be rewrite to comply with coding style:
+
+  case 1:
+  case 0:
+    // do not wait sending a puback
+    // no callback passed
+    if (1 === qos) {
+      this._sendPacket({
+        cmd: 'puback',
+        messageId: messageId
+      });
+    }
+    // emit the message event for both qos 1 and 0
+    this.emit('message', topic, message, packet);
+    this.handleMessage(packet, done);
+    break;
+  default:
+    // do nothing but every switch mus have a default
+    // log or throw an error about unknown qos
+    break;
+
+  for now i just suppressed the warnings
+  */
+function handlePublish(client, packet, done) {
+    client.log('_handlePublish: packet %o', packet)
+    done = typeof done !== 'undefined' ? done : nop
+    let topic = packet.topic.toString()
+    const message = packet.payload
+    const qos = packet.qos
+    const messageId = packet.messageId
+    const options = client.options
+    const validReasonCodes = [0, 16, 128, 131, 135, 144, 145, 151, 153]
+    if (client.options.protocolVersion === 5) {
+      let alias
+      if (packet.properties) {
+        alias = packet.properties.topicAlias
+      }
+      if (typeof alias !== 'undefined') {
+        if (topic.length === 0) {
+          if (alias > 0 && alias <= 0xffff) {
+            const gotTopic = client.topicAliasRecv.getTopicByAlias(alias)
+            if (gotTopic) {
+              topic = gotTopic
+              client.log('_handlePublish :: topic complemented by alias. topic: %s - alias: %d', topic, alias)
+            } else {
+              client.log('_handlePublish :: unregistered topic alias. alias: %d', alias)
+              client.emit('error', new Error('Received unregistered Topic Alias'))
+              return
+            }
+          } else {
+            client.log('_handlePublish :: topic alias out of range. alias: %d', alias)
+            client.emit('error', new Error('Received Topic Alias is out of range'))
+            return
+          }
+        } else {
+          if (client.topicAliasRecv.put(topic, alias)) {
+            client.log('_handlePublish :: registered topic: %s - alias: %d', topic, alias)
+          } else {
+            client.log('_handlePublish :: topic alias out of range. alias: %d', alias)
+            client.emit('error', new Error('Received Topic Alias is out of range'))
+            return
+          }
+        }
+      }
+    }
+    client.log('_handlePublish: qos %d', qos)
+    switch (qos) {
+      case 2: {
+        options.customHandleAcks(topic, message, packet, function (error, code) {
+          if (!(error instanceof Error)) {
+            code = error
+            error = null
+          }
+          if (error) { return client.emit('error', error) }
+          if (validReasonCodes.indexOf(code) === -1) { return client.emit('error', new Error('Wrong reason code for pubrec')) }
+          if (code) {
+            client._sendPacket({ cmd: 'pubrec', messageId, reasonCode: code }, done)
+          } else {
+            client.incomingStore.put(packet, function () {
+              client._sendPacket({ cmd: 'pubrec', messageId }, done)
+            })
+          }
+        })
+        break
+      }
+      case 1: {
+        // emit the message event
+        options.customHandleAcks(topic, message, packet, function (error, code) {
+          if (!(error instanceof Error)) {
+            code = error
+            error = null
+          }
+          if (error) { return client.emit('error', error) }
+          if (validReasonCodes.indexOf(code) === -1) { return client.emit('error', new Error('Wrong reason code for puback')) }
+          if (!code) { client.emit('message', topic, message, packet) }
+          client.handleMessage(packet, function (err) {
+            if (err) {
+              return done && done(err)
+            }
+            client._sendPacket({ cmd: 'puback', messageId, reasonCode: code }, done)
+          })
+        })
+        break
+      }
+      case 0:
+        // emit the message event
+        client.emit('message', topic, message, packet)
+        client.handleMessage(packet, done)
+        break
+      default:
+        // do nothing
+        client.log('_handlePublish: unknown QoS. Doing nothing.')
+        // log or throw an error about unknown qos
+        break
+    }
+}
+
+module.exports = handlePublish

--- a/lib/handlers/pubrel.js
+++ b/lib/handlers/pubrel.js
@@ -1,0 +1,26 @@
+
+
+function handlePubRel(client, packet, done) {
+    client.log('handling pubrel packet')
+    callback = typeof callback !== 'undefined' ? callback : nop
+    const messageId = packet.messageId
+
+    const comp = { cmd: 'pubcomp', messageId }
+
+    client.incomingStore.get(packet, function (err, pub) {
+      if (!err) {
+        client.emit('message', pub.topic, pub.payload, pub)
+        client.handleMessage(pub, function (err) {
+          if (err) {
+            return callback(err)
+          }
+          client.incomingStore.del(pub, nop)
+          client._sendPacket(comp, callback)
+        })
+      } else {
+        client._sendPacket(comp, callback)
+      }
+    })
+}
+
+module.exports = handlePubRel

--- a/lib/handlers/pubrel.js
+++ b/lib/handlers/pubrel.js
@@ -1,8 +1,8 @@
 
 
-function handlePubRel(client, packet, done) {
+function handlePubrel(client, packet, done) {
     client.log('handling pubrel packet')
-    callback = typeof callback !== 'undefined' ? callback : nop
+    callback = typeof callback !== 'undefined' ? callback : client.nop
     const messageId = packet.messageId
 
     const comp = { cmd: 'pubcomp', messageId }
@@ -14,7 +14,7 @@ function handlePubRel(client, packet, done) {
           if (err) {
             return callback(err)
           }
-          client.incomingStore.del(pub, nop)
+          client.incomingStore.del(pub, client.nop)
           client._sendPacket(comp, callback)
         })
       } else {
@@ -23,4 +23,4 @@ function handlePubRel(client, packet, done) {
     })
 }
 
-module.exports = handlePubRel
+module.exports = handlePubrel

--- a/lib/handlers/pubrel.js
+++ b/lib/handlers/pubrel.js
@@ -2,7 +2,7 @@
 
 function handlePubrel(client, packet, done) {
     client.log('handling pubrel packet')
-    callback = typeof callback !== 'undefined' ? callback : client.nop
+    callback = typeof done !== 'undefined' ? done : client.nop
     const messageId = packet.messageId
 
     const comp = { cmd: 'pubcomp', messageId }

--- a/test/abstract_client.js
+++ b/test/abstract_client.js
@@ -40,7 +40,7 @@ const handlePublish = require('../lib/handlers/publish')
 module.exports = function (server, config) {
   const version = config.protocolVersion || 4
 
-  function connect (opts) {
+  function connect(opts) {
     opts = { ...config, ...opts }
     return mqtt.connect(opts)
   }
@@ -828,7 +828,7 @@ module.exports = function (server, config) {
 
       server.on('client', onClient)
 
-      function onClient (serverClient) {
+      function onClient(serverClient) {
         serverClient.once('connect', function () {
           server.removeListener('client', onClient)
         })
@@ -854,7 +854,7 @@ module.exports = function (server, config) {
 
       server.on('client', onClient)
 
-      function onClient (serverClient) {
+      function onClient(serverClient) {
         serverClient.once('connect', function () {
           server.removeListener('client', onClient)
         })
@@ -1159,7 +1159,7 @@ module.exports = function (server, config) {
       let countSent = 0
       let countReceived = 0
 
-      function publishNext () {
+      function publishNext() {
         client.publish('test', 'test', { qos: 2 }, function (err) {
           assert.ifError(err)
           countSent++
@@ -1196,7 +1196,7 @@ module.exports = function (server, config) {
       })
     })
 
-    function testQosHandleMessage (qos, done) {
+    function testQosHandleMessage(qos, done) {
       const client = connect()
 
       let messageEventCount = 0
@@ -1276,34 +1276,34 @@ module.exports = function (server, config) {
 
     it('should silently ignore errors thrown by `handleMessage` and return when no callback is passed ' +
       'into `handlePublish` method', function (done) {
-      const client = connect()
+        const client = connect()
 
-      client.handleMessage = function (packet, callback) {
-        callback(new Error('Error thrown by the application'))
-      }
+        client.handleMessage = function (packet, callback) {
+          callback(new Error('Error thrown by the application'))
+        }
 
-      try {
-        handlePublish(client, {
-          messageId: Math.floor(65535 * Math.random()),
-          topic: 'test',
-          payload: 'test',
-          qos: 1
-        })
-        client.end(true, done)
-      } catch (err) {
-        client.end(true, () => { done(err) })
-      }
-    })
+        try {
+          handlePublish(client, {
+            messageId: Math.floor(65535 * Math.random()),
+            topic: 'test',
+            payload: 'test',
+            qos: 1
+          })
+          client.end(true, done)
+        } catch (err) {
+          client.end(true, () => { done(err) })
+        }
+      })
 
     it('should handle error with async incoming store in QoS 1 `handlePublish` method', function (done) {
       class AsyncStore {
-        put (packet, cb) {
+        put(packet, cb) {
           process.nextTick(function () {
             cb(null, 'Error')
           })
         }
 
-        close (cb) {
+        close(cb) {
           cb()
         }
       }
@@ -1323,25 +1323,25 @@ module.exports = function (server, config) {
 
     it('should handle error with async incoming store in QoS 2 `handlePublish` method', function (done) {
       class AsyncStore {
-        put (packet, cb) {
+        put(packet, cb) {
           process.nextTick(function () {
             cb(null, 'Error')
           })
         }
 
-        del (packet, cb) {
+        del(packet, cb) {
           process.nextTick(function () {
             cb(new Error('Error'))
           })
         }
 
-        get (packet, cb) {
+        get(packet, cb) {
           process.nextTick(function () {
             cb(null, { cmd: 'publish' })
           })
         }
 
-        close (cb) {
+        close(cb) {
           cb()
         }
       }
@@ -1361,25 +1361,25 @@ module.exports = function (server, config) {
 
     it('should handle error with async incoming store in QoS 2 `handlePubrel` method', function (done) {
       class AsyncStore {
-        put (packet, cb) {
+        put(packet, cb) {
           process.nextTick(function () {
             cb(null, 'Error')
           })
         }
 
-        del (packet, cb) {
+        del(packet, cb) {
           process.nextTick(function () {
             cb(new Error('Error'))
           })
         }
 
-        get (packet, cb) {
+        get(packet, cb) {
           process.nextTick(function () {
             cb(null, { cmd: 'publish' })
           })
         }
 
-        close (cb) {
+        close(cb) {
           cb()
         }
       }
@@ -1398,26 +1398,26 @@ module.exports = function (server, config) {
     it('should handle success with async incoming store in QoS 2 `handlePubrel` method', function (done) {
       let delComplete = false
       class AsyncStore {
-        put (packet, cb) {
+        put(packet, cb) {
           process.nextTick(function () {
             cb(null, 'Error')
           })
         }
 
-        del (packet, cb) {
+        del(packet, cb) {
           process.nextTick(function () {
             delComplete = true
             cb(null)
           })
         }
 
-        get (packet, cb) {
+        get(packet, cb) {
           process.nextTick(function () {
             cb(null, { cmd: 'publish' })
           })
         }
 
-        close (cb) {
+        close(cb) {
           cb()
         }
       }
@@ -1470,37 +1470,37 @@ module.exports = function (server, config) {
 
     it('should silently ignore errors thrown by `handleMessage` and return when no callback is passed ' +
       'into `handlePubrel` method', function (done) {
-      const store = new Store()
-      const client = connect({ incomingStore: store })
+        const store = new Store()
+        const client = connect({ incomingStore: store })
 
-      const messageId = Math.floor(65535 * Math.random())
-      const topic = 'test'
-      const payload = 'test'
-      const qos = 2
+        const messageId = Math.floor(65535 * Math.random())
+        const topic = 'test'
+        const payload = 'test'
+        const qos = 2
 
-      client.handleMessage = function (packet, callback) {
-        callback(new Error('Error thrown by the application'))
-      }
+        client.handleMessage = function (packet, callback) {
+          callback(new Error('Error thrown by the application'))
+        }
 
-      client.once('connect', function () {
-        client.subscribe(topic, { qos: 2 })
+        client.once('connect', function () {
+          client.subscribe(topic, { qos: 2 })
 
-        store.put({
-          messageId,
-          topic,
-          payload,
-          qos,
-          cmd: 'publish'
-        }, function () {
-          try {
-            handlePubrel(client, { cmd: 'pubrel', messageId })
-            client.end(true, done)
-          } catch (err) {
-            client.end(true, () => { done(err) })
-          }
+          store.put({
+            messageId,
+            topic,
+            payload,
+            qos,
+            cmd: 'publish'
+          }, function () {
+            try {
+              handlePubrel(client, { cmd: 'pubrel', messageId })
+              client.end(true, done)
+            } catch (err) {
+              client.end(true, () => { done(err) })
+            }
+          })
         })
       })
-    })
 
     it('should keep message order', function (done) {
       let publishCount = 0
@@ -1571,7 +1571,7 @@ module.exports = function (server, config) {
       })
     })
 
-    function testCallbackStorePutByQoS (qos, clean, expected, done) {
+    function testCallbackStorePutByQoS(qos, clean, expected, done) {
       const client = connect({
         clean,
         clientId: 'testId'
@@ -1579,7 +1579,7 @@ module.exports = function (server, config) {
 
       const callbacks = []
 
-      function cbStorePut () {
+      function cbStorePut() {
         callbacks.push('storeput')
       }
 
@@ -1835,7 +1835,13 @@ module.exports = function (server, config) {
       const client = connect({ keepalive: 1, reconnectPeriod: 100 })
 
       // Fake no pingresp being send by stubbing the _handlePingresp function
-      client._handlePingresp = function () { }
+      client.on('packetreceive', function (packet) {
+        if (packet.cmd === 'pingresp') {
+          setImmediate(() => {
+            client.pingResp = false
+          })
+        }
+      })
 
       client.once('connect', function () {
         client.once('connect', function () {
@@ -2461,7 +2467,7 @@ module.exports = function (server, config) {
       })
     })
 
-    function testMultiplePubrel (shouldSendPubcompFail, done) {
+    function testMultiplePubrel(shouldSendPubcompFail, done) {
       const client = connect()
       const testTopic = 'test'
       const testMessage = 'message'
@@ -2499,34 +2505,34 @@ module.exports = function (server, config) {
           }
           case 'pubrec':
           case 'pubcomp':
-          {
-            // for both pubrec and pubcomp, reply with pubrel, simulating the server not receiving the pubcomp
-            if (packet.cmd === 'pubcomp') {
-              pubcompCount++
-              if (pubcompCount === 2) {
-                // end the test once the client has gone through two rounds of replying to pubrel messages
-                assert.strictEqual(pubrelCount, 2)
-                assert.strictEqual(handleMessageCount, 1)
-                assert.strictEqual(emitMessageCount, 1)
-                client._sendPacket = origSendPacket
-                client.end(true, done)
-                break
+            {
+              // for both pubrec and pubcomp, reply with pubrel, simulating the server not receiving the pubcomp
+              if (packet.cmd === 'pubcomp') {
+                pubcompCount++
+                if (pubcompCount === 2) {
+                  // end the test once the client has gone through two rounds of replying to pubrel messages
+                  assert.strictEqual(pubrelCount, 2)
+                  assert.strictEqual(handleMessageCount, 1)
+                  assert.strictEqual(emitMessageCount, 1)
+                  client._sendPacket = origSendPacket
+                  client.end(true, done)
+                  break
+                }
               }
-            }
 
-            // simulate the pubrel message, either in response to pubrec or to mock pubcomp failing to be received
-            const pubrel = { cmd: 'pubrel', messageId: mid }
-            pubrelCount++
-            handle(client, pubrel, function (err) {
-              if (shouldSendFail) {
-                assert.exists(err)
-                assert.instanceOf(err, Error)
-              } else {
-                assert.notExists(err)
-              }
-            })
-            break
-          }
+              // simulate the pubrel message, either in response to pubrec or to mock pubcomp failing to be received
+              const pubrel = { cmd: 'pubrel', messageId: mid }
+              pubrelCount++
+              handle(client, pubrel, function (err) {
+                if (shouldSendFail) {
+                  assert.exists(err)
+                  assert.instanceOf(err, Error)
+                } else {
+                  assert.notExists(err)
+                }
+              })
+              break
+            }
         }
       }
 
@@ -2702,7 +2708,7 @@ module.exports = function (server, config) {
         check()
       })
 
-      function check () {
+      function check() {
         if (serverPublished && clientCalledBack) {
           client.end(true, done)
         }
@@ -2762,7 +2768,7 @@ module.exports = function (server, config) {
         check()
       })
 
-      function check () {
+      function check() {
         if (serverPublished && clientCalledBack) {
           client.end(true, done)
         }

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -10,7 +10,7 @@ const port = parsed.port || (isHttps ? 443 : 80)
 const host = parsed.hostname
 const protocol = isHttps ? 'wss' : 'ws'
 
-const client = mqtt.connect({ protocolId: 'MQIsdp', protocolVersion: 3, protocol, port, host })
+const client = mqtt.connect({ protocolId: 'MQIsdp', protocolVersion: 3, protocol, port, host, log: console.log.bind(console) })
 client.on('offline', function () {
   console.log('client offline')
 })

--- a/test/client_mqtt5.js
+++ b/test/client_mqtt5.js
@@ -617,16 +617,16 @@ describe('MQTT 5.0', function () {
 
   it('auth packet', function (done) {
     this.timeout(15000)
-    server.once('client', function (serverClient) {
+    const opts = { host: 'localhost', port: ports.PORTAND115, protocolVersion: 5, properties: { authenticationMethod: 'json' }, authPacket: {} }
+    const client = mqtt.connect(opts)
+    server.once('client', function (c) {
       console.log('server received client')
-      serverClient.on('auth', function (packet) {
+      c.on('auth', function (packet) {
         console.log('serverClient received auth: packet %o', packet)
-        serverClient.end(done)
+        client.end(done)
       })
     })
-    const opts = { host: 'localhost', port: ports.PORTAND115, protocolVersion: 5, properties: { authenticationMethod: 'json' }, authPacket: {} }
     console.log('calling mqtt connect')
-    mqtt.connect(opts)
   })
 
   it('Maximum Packet Size', function (done) {

--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -61,7 +61,7 @@ export interface IClientOptions extends ISecureClientOptions {
   outgoingStore?: Store
   queueQoSZero?: boolean
 
-  log?: (msg: string) => void
+  log?: (...args: any[]) => void
 
   autoUseTopicAlias?: boolean
   autoAssignTopicAlias?: boolean

--- a/types/lib/client-options.d.ts
+++ b/types/lib/client-options.d.ts
@@ -61,6 +61,8 @@ export interface IClientOptions extends ISecureClientOptions {
   outgoingStore?: Store
   queueQoSZero?: boolean
 
+  log?: (msg: string) => void
+
   autoUseTopicAlias?: boolean
   autoAssignTopicAlias?: boolean
 

--- a/types/lib/client.d.ts
+++ b/types/lib/client.d.ts
@@ -99,6 +99,8 @@ export declare class MqttClient extends events.EventEmitter {
   public options: IClientOptions
   public queueQoSZero: boolean
 
+  static defaultId (): string
+
   constructor (streamBuilder: (client: MqttClient) => IStream, options: IClientOptions)
 
   public on (event: 'connect', cb: OnConnectCallback): this


### PR DESCRIPTION
- Created `client.log` function that by default uses `debug` but can be overriden using `options.log`
- Created `client.nop`
- Moved all `client._handle` in `lib/handlers`
- Create `MqttClient.defaultId` static method
- Ensure shiftPingInterval is called every time a packet is written to the stream. Could fix #1257. An alternative could also to shift the ping interval every time a pingresp is received from server