### PR TITLE
fix: resubscribe when no session present (#895)

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -2106,7 +2106,7 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		if (
 			!this._firstConnection &&
 			(this.options.clean ||
-				(this.options.protocolVersion === 5 &&
+				(this.options.protocolVersion >= 4 &&
 					!this.connackPacket.sessionPresent)) &&
 			_resubscribeTopicsKeys.length > 0
 		) {

--- a/test/server_helpers_for_client_tests.ts
+++ b/test/server_helpers_for_client_tests.ts
@@ -36,6 +36,9 @@ export default function serverBuilder(
 			if (!serverClient.writable) return false
 			let rc = 'returnCode'
 			const connack = {}
+			if (serverClient.options.protocolVersion >= 4) {
+				connack['sessionPresent'] = false
+			}
 			if (
 				serverClient.options &&
 				serverClient.options.protocolVersion === 5


### PR DESCRIPTION
The combination **clean=false,  resubscribe=true, sessionPresent=false** should now trigger a resubscribe for MQTT v3.1.1, not only for v5.

Closes #895, #1288