### PR TITLE
fix: close and end callbacks not executed in the WeChat mini program

### DIFF
--- a/src/lib/connect/wx.ts
+++ b/src/lib/connect/wx.ts
@@ -75,6 +75,7 @@ function bindEventHandler() {
 	})
 
 	socketTask.onClose(() => {
+    stream.emit('close')
 		stream.end()
 		stream.destroy()
 	})


### PR DESCRIPTION
When developing a project with WeChat mini program, I want to execute some tasks after disconnecting from the MQTT connection, but I found that the callbacks for close and end are not executed properly. This bug only occurs in the WeChat mini program.

<img width="577" alt="image" src="https://github.com/mqttjs/MQTT.js/assets/119273236/6afa1c0f-2ad0-4b0b-93fb-a4c57310273a">
