### PR TITLE
fix: move exported types out of dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "5.0.3",
       "license": "MIT",
       "dependencies": {
+        "@types/readable-stream": "^4.0.1",
+        "@types/ws": "^8.5.5",
         "commist": "^3.2.0",
         "concat-stream": "^2.0.0",
         "debug": "^4.3.4",
@@ -34,11 +36,9 @@
         "@types/chai": "^4.3.5",
         "@types/duplexify": "^3.6.1",
         "@types/mocha": "^10.0.1",
-        "@types/node": "^20.4.5",
-        "@types/readable-stream": "^4.0.0",
+        "@types/node": "^20.5.0",
         "@types/sinon": "^10.0.16",
         "@types/tape": "^5.6.0",
-        "@types/ws": "^8.5.5",
         "@typescript-eslint/eslint-plugin": "^6.2.1",
         "@typescript-eslint/parser": "^6.2.1",
         "airtap": "^4.0.4",
@@ -1367,10 +1367,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.4.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
-      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
-      "dev": true
+      "version": "20.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
+      "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -1379,10 +1378,9 @@
       "dev": true
     },
     "node_modules/@types/readable-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.0.tgz",
-      "integrity": "sha512-s6YqDV111kwuFsT9SwFC+FmZ5n1SEp4H9DXGg6Zqag0lPGeEvBGP9UaLJYpX4cxY7fAFnx2avy1QVvft0LLb7g==",
-      "dev": true,
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.1.tgz",
+      "integrity": "sha512-TSGmoAl2OVQ7sI1ToKoaonynp6kPdTDaBPvgMRz8ABvohWmYvimQqaZkaupTPjcOrpz8+ZdOBv3rCmAvBgVhqg==",
       "dependencies": {
         "@types/node": "*",
         "safe-buffer": "~5.1.1"
@@ -1391,8 +1389,7 @@
     "node_modules/@types/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -1438,7 +1435,6 @@
       "version": "8.5.5",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
       "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -16673,10 +16669,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.4.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
-      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
-      "dev": true
+      "version": "20.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
+      "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -16685,10 +16680,9 @@
       "dev": true
     },
     "@types/readable-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.0.tgz",
-      "integrity": "sha512-s6YqDV111kwuFsT9SwFC+FmZ5n1SEp4H9DXGg6Zqag0lPGeEvBGP9UaLJYpX4cxY7fAFnx2avy1QVvft0LLb7g==",
-      "dev": true,
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.1.tgz",
+      "integrity": "sha512-TSGmoAl2OVQ7sI1ToKoaonynp6kPdTDaBPvgMRz8ABvohWmYvimQqaZkaupTPjcOrpz8+ZdOBv3rCmAvBgVhqg==",
       "requires": {
         "@types/node": "*",
         "safe-buffer": "~5.1.1"
@@ -16697,8 +16691,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -16746,7 +16739,6 @@
       "version": "8.5.5",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
       "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,8 @@
     "net": false
   },
   "dependencies": {
+    "@types/readable-stream": "^4.0.1",
+    "@types/ws": "^8.5.5",
     "commist": "^3.2.0",
     "concat-stream": "^2.0.0",
     "debug": "^4.3.4",
@@ -120,11 +122,9 @@
     "@types/chai": "^4.3.5",
     "@types/duplexify": "^3.6.1",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^20.4.5",
-    "@types/readable-stream": "^4.0.0",
+    "@types/node": "^20.5.0",
     "@types/sinon": "^10.0.16",
     "@types/tape": "^5.6.0",
-    "@types/ws": "^8.5.5",
     "@typescript-eslint/eslint-plugin": "^6.2.1",
     "@typescript-eslint/parser": "^6.2.1",
     "airtap": "^4.0.4",


### PR DESCRIPTION
The types that are exported for this project use types from `readable-stream` and `ws`, so those types need to be included as proper dependencies that get shipped to consumers. This PR moves those dependencies out of the dev block, and also bumps the Node types to make sure they work with the latest additions to the `readable-stream` types (i.e. using `asyncDispose`).

This ought to fix #1673 (it does for one of my project seeing the same error as that issue).

One downside of this is that consuming projects will need to be on a fairly recent version of `@types/node`, but I don't think that's the worst thing vs. not working at all for TS projects right now.