### PR TITLE
fix: publish/subscribe/unsubscribe types and missing types exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mqtt",
   "description": "A library for the MQTT protocol",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "contributors": [
     "Adam Rudd <adamvrr@gmail.com>",
     "Matteo Collina <matteo.collina@gmail.com> (https://github.com/mcollina)",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mqtt",
   "description": "A library for the MQTT protocol",
-  "version": "5.0.5",
+  "version": "5.0.4",
   "contributors": [
     "Adam Rudd <adamvrr@gmail.com>",
     "Matteo Collina <matteo.collina@gmail.com> (https://github.com/mcollina)",

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -355,6 +355,7 @@ export type ISubscriptionMap = {
 	resubscribe?: boolean
 }
 
+export { IConnackPacket, IDisconnectPacket, IPublishPacket, Packet }
 export type OnConnectCallback = (packet: IConnackPacket) => void
 export type OnDisconnectCallback = (packet: IDisconnectPacket) => void
 export type ClientSubscribeCallback = (

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -977,7 +977,10 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		return this
 	}
 
-	public publishAsync(topic: string, message: string | Buffer): Promise<Packet | undefined>
+	public publishAsync(
+		topic: string,
+		message: string | Buffer,
+	): Promise<Packet | undefined>
 	public publishAsync(
 		topic: string,
 		message: string | Buffer,
@@ -1347,7 +1350,9 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		return this
 	}
 
-	public unsubscribeAsync(topic: string | string[]): Promise<Packet | undefined>
+	public unsubscribeAsync(
+		topic: string | string[],
+	): Promise<Packet | undefined>
 	public unsubscribeAsync(
 		topic: string | string[],
 		opts?: IClientSubscribeOptions,

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -880,19 +880,19 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	public publish(
 		topic: string,
 		message: string | Buffer,
-		callback?: DoneCallback,
+		callback?: PacketCallback,
 	): MqttClient
 	public publish(
 		topic: string,
 		message: string | Buffer,
 		opts?: IClientPublishOptions,
-		callback?: DoneCallback,
+		callback?: PacketCallback,
 	): MqttClient
 	public publish(
 		topic: string,
 		message: string | Buffer,
 		opts?: IClientPublishOptions | DoneCallback,
-		callback?: DoneCallback,
+		callback?: PacketCallback,
 	): MqttClient {
 		this.log('publish :: message `%s` to topic `%s`', message, topic)
 		const { options } = this
@@ -977,23 +977,23 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		return this
 	}
 
-	public publishAsync(topic: string, message: string | Buffer): Promise<void>
+	public publishAsync(topic: string, message: string | Buffer): Promise<Packet | undefined>
 	public publishAsync(
 		topic: string,
 		message: string | Buffer,
 		opts?: IClientPublishOptions,
-	): Promise<void>
+	): Promise<Packet | undefined>
 	public publishAsync(
 		topic: string,
 		message: string | Buffer,
 		opts?: IClientPublishOptions,
-	): Promise<void> {
+	): Promise<Packet | undefined> {
 		return new Promise((resolve, reject) => {
-			this.publish(topic, message, opts, (err) => {
+			this.publish(topic, message, opts, (err, packet) => {
 				if (err) {
 					reject(err)
 				} else {
-					resolve()
+					resolve(packet)
 				}
 			})
 		})
@@ -1347,21 +1347,21 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		return this
 	}
 
-	public unsubscribeAsync(topic: string | string[]): Promise<void>
+	public unsubscribeAsync(topic: string | string[]): Promise<Packet | undefined>
 	public unsubscribeAsync(
 		topic: string | string[],
 		opts?: IClientSubscribeOptions,
-	): Promise<void>
+	): Promise<Packet | undefined>
 	public unsubscribeAsync(
 		topic: string | string[],
 		opts?: IClientSubscribeOptions,
-	): Promise<void> {
+	): Promise<Packet | undefined> {
 		return new Promise((resolve, reject) => {
-			this.unsubscribe(topic, opts, (err) => {
+			this.unsubscribe(topic, opts, (err, packet) => {
 				if (err) {
 					reject(err)
 				} else {
-					resolve()
+					resolve(packet)
 				}
 			})
 		})

--- a/test/abstract_client.ts
+++ b/test/abstract_client.ts
@@ -372,7 +372,7 @@ export default function abstractTest(server, config) {
 		it('should emit connect', function _test(done) {
 			const client = connect()
 			client.once('connect', (packet: mqtt.IConnackPacket) => {
-				assert.equal(packet.cmd, "connack")
+				assert.equal(packet.cmd, 'connack')
 				client.end(true, (err) => done(err))
 			})
 			client.once('error', done)
@@ -1135,19 +1135,24 @@ export default function abstractTest(server, config) {
 				})
 
 				client.once('connect', () => {
-					client.publish('a', 'b', pubOpts, (err, packet?: mqtt.Packet) => {
-						assert.exists(packet)
-						if (version === 5) {
-							assert.strictEqual(err.code, pubackReasonCode)
-						} else {
-							assert.ifError(err)
-						}
-						setImmediate(() => {
-							client.end(() => {
-								server2.close(done)
+					client.publish(
+						'a',
+						'b',
+						pubOpts,
+						(err, packet?: mqtt.Packet) => {
+							assert.exists(packet)
+							if (version === 5) {
+								assert.strictEqual(err.code, pubackReasonCode)
+							} else {
+								assert.ifError(err)
+							}
+							setImmediate(() => {
+								client.end(() => {
+									server2.close(done)
+								})
 							})
-						})
-					})
+						},
+					)
 				})
 			})
 		})
@@ -1204,19 +1209,24 @@ export default function abstractTest(server, config) {
 				})
 
 				client.once('connect', () => {
-					client.publish('a', 'b', pubOpts, (err, packet?: mqtt.Packet) => {
-						assert.exists(packet)
-						if (version === 5) {
-							assert.strictEqual(err.code, pubrecReasonCode)
-						} else {
-							assert.ifError(err)
-						}
-						setImmediate(() => {
-							client.end(true, () => {
-								server2.close(done)
+					client.publish(
+						'a',
+						'b',
+						pubOpts,
+						(err, packet?: mqtt.Packet) => {
+							assert.exists(packet)
+							if (version === 5) {
+								assert.strictEqual(err.code, pubrecReasonCode)
+							} else {
+								assert.ifError(err)
+							}
+							setImmediate(() => {
+								client.end(true, () => {
+									server2.close(done)
+								})
 							})
-						})
-					})
+						},
+					)
 				})
 			})
 		})
@@ -2381,12 +2391,15 @@ export default function abstractTest(server, config) {
 
 			//
 			client.subscribe(testPacket.topic)
-			client.once('message', (topic, message, packet: mqtt.IPublishPacket) => {
-				assert.strictEqual(topic, testPacket.topic)
-				assert.strictEqual(message.toString(), testPacket.payload)
-				assert.strictEqual(packet.cmd, 'publish')
-				client.end(true, done)
-			})
+			client.once(
+				'message',
+				(topic, message, packet: mqtt.IPublishPacket) => {
+					assert.strictEqual(topic, testPacket.topic)
+					assert.strictEqual(message.toString(), testPacket.payload)
+					assert.strictEqual(packet.cmd, 'publish')
+					client.end(true, done)
+				},
+			)
 
 			server.once('client', (serverClient) => {
 				serverClient.on('subscribe', () => {

--- a/test/abstract_client.ts
+++ b/test/abstract_client.ts
@@ -1079,7 +1079,9 @@ export default function abstractTest(server, config) {
 			const client = connect()
 
 			client.once('connect', () => {
-				client.publish('a', 'b', () => {
+				// callback args can be typed
+				client.publish('a', 'b', (_, packet?: mqtt.Packet) => {
+					assert.isUndefined(packet)
 					client.end((err) => done(err))
 				})
 			})
@@ -1090,7 +1092,8 @@ export default function abstractTest(server, config) {
 			const opts: IClientPublishOptions = { qos: 1 }
 
 			client.once('connect', () => {
-				client.publish('a', 'b', opts, () => {
+				client.publish('a', 'b', opts, (_, packet?: mqtt.Packet) => {
+					assert.exists(packet)
 					client.end((err) => done(err))
 				})
 			})
@@ -1132,7 +1135,8 @@ export default function abstractTest(server, config) {
 				})
 
 				client.once('connect', () => {
-					client.publish('a', 'b', pubOpts, (err) => {
+					client.publish('a', 'b', pubOpts, (err, packet?: mqtt.Packet) => {
+						assert.exists(packet)
 						if (version === 5) {
 							assert.strictEqual(err.code, pubackReasonCode)
 						} else {
@@ -1153,7 +1157,8 @@ export default function abstractTest(server, config) {
 			const opts: IClientPublishOptions = { qos: 2 }
 
 			client.once('connect', () => {
-				client.publish('a', 'b', opts, () => {
+				client.publish('a', 'b', opts, (_, packet?: mqtt.Packet) => {
+					assert.exists(packet)
 					client.end((err) => done(err))
 				})
 			})
@@ -1199,7 +1204,8 @@ export default function abstractTest(server, config) {
 				})
 
 				client.once('connect', () => {
-					client.publish('a', 'b', pubOpts, (err) => {
+					client.publish('a', 'b', pubOpts, (err, packet?: mqtt.Packet) => {
+						assert.exists(packet)
 						if (version === 5) {
 							assert.strictEqual(err.code, pubrecReasonCode)
 						} else {
@@ -1908,7 +1914,9 @@ export default function abstractTest(server, config) {
 			const topic = 'topic'
 
 			client.once('connect', () => {
-				client.unsubscribe(topic, () => {
+				// callback args can be typed
+				client.unsubscribe(topic, (_, packet?: mqtt.Packet) => {
+					assert.isUndefined(packet)
 					client.end(true, done)
 				})
 			})

--- a/test/abstract_client.ts
+++ b/test/abstract_client.ts
@@ -371,7 +371,8 @@ export default function abstractTest(server, config) {
 
 		it('should emit connect', function _test(done) {
 			const client = connect()
-			client.once('connect', () => {
+			client.once('connect', (packet: mqtt.IConnackPacket) => {
+				assert.equal(packet.cmd, "connack")
 				client.end(true, (err) => done(err))
 			})
 			client.once('error', done)
@@ -2372,7 +2373,7 @@ export default function abstractTest(server, config) {
 
 			//
 			client.subscribe(testPacket.topic)
-			client.once('message', (topic, message, packet) => {
+			client.once('message', (topic, message, packet: mqtt.IPublishPacket) => {
 				assert.strictEqual(topic, testPacket.topic)
 				assert.strictEqual(message.toString(), testPacket.payload)
 				assert.strictEqual(packet.cmd, 'publish')
@@ -2397,7 +2398,7 @@ export default function abstractTest(server, config) {
 			}
 
 			client.subscribe(testPacket.topic)
-			client.on('packetreceive', (packet) => {
+			client.on('packetreceive', (packet: mqtt.Packet) => {
 				if (packet.cmd === 'publish') {
 					assert.strictEqual(packet.qos, 1)
 					assert.strictEqual(packet.topic, testPacket.topic)

--- a/test/client_mqtt5.ts
+++ b/test/client_mqtt5.ts
@@ -1048,10 +1048,13 @@ describe('MQTT 5.0', () => {
 		}
 
 		const client = mqtt.connect(opts)
-		client.once('disconnect', (disconnectPacket: mqtt.IDisconnectPacket) => {
-			assert.strictEqual(disconnectPacket.reasonCode, 128)
-			client.end(true, (err) => done(err))
-		})
+		client.once(
+			'disconnect',
+			(disconnectPacket: mqtt.IDisconnectPacket) => {
+				assert.strictEqual(disconnectPacket.reasonCode, 128)
+				client.end(true, (err) => done(err))
+			},
+		)
 	})
 
 	it('pubrec handling custom reason code', function test(done) {

--- a/test/client_mqtt5.ts
+++ b/test/client_mqtt5.ts
@@ -1048,7 +1048,7 @@ describe('MQTT 5.0', () => {
 		}
 
 		const client = mqtt.connect(opts)
-		client.once('disconnect', (disconnectPacket) => {
+		client.once('disconnect', (disconnectPacket: mqtt.IDisconnectPacket) => {
 			assert.strictEqual(disconnectPacket.reasonCode, 128)
 			client.end(true, (err) => done(err))
 		})


### PR DESCRIPTION
Fixes some of the issues mentioned in #1686.

In particular:
1) exporting missing types from callbacks
3) missing callback argument

I tried to figure out how to fix 2) and 3) (inconsistent error argument declaration in callbacks and runtime/typing mismatch) but it goes deeper into the library (writing to streams) than I am comfortable with.
Maybe it is easier than I think, but I believe it needs some more overview of the project than I have.