### PR TITLE
feat: custom websocket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,28 @@ use the latest auth token, you must have some outside mechanism running that
 handles application-level authentication refreshing so that the websocket
 connection can simply grab the latest valid token or signed url.
 
+#### Customize Websockets with `createWebsocket` (Websocket Only)
+
+When you need to add a custom websocket subprotocol or header to open a connection
+through a proxy with custom authentication this callback allows you to create your own
+instance of a websocket which will be used in the mqtt client.
+
+```js
+  const createWebsocket = createWebsocket(url, websocketSubProtocols, options) => {
+    const subProtocols = [
+      websocketSubProtocols[0],
+      'myCustomSubprotocolOrOAuthToken',
+    ]
+    return new WebSocket(url, subProtocols)
+  }
+
+    const connection = await mqtt.connectAsync(<wss url>, {
+      ...,
+      createWebsocket: createWebsocket,
+    });
+```
+
+
 #### Enabling Reconnection with `reconnectPeriod` option
 
 To ensure that the mqtt client automatically tries to reconnect when the
@@ -429,6 +451,8 @@ The arguments are:
   - `transformWsUrl` : optional `(url, options, client) => url` function
     For ws/wss protocols only. Can be used to implement signing
     urls which upon reconnect can have become expired.
+  - `createWebsocket` : optional `url, websocketSubProtocols, options) => Websocket` function
+      For ws/wss protocols only. Can be used to implement a custom websocket subprotocol or implementation.
   - `resubscribe` : if connection is broken and reconnects,
     subscribed topics are automatically subscribed again (default `true`)
   - `messageIdProvider`: custom messageId provider. when `new UniqueMessageIdProvider()` is set, then non conflict messageId is provided.

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -218,6 +218,13 @@ export interface IClientOptions extends ISecureClientOptions {
 		client: MqttClient,
 	) => string
 
+	/** when defined this function will be called to create the Websocket instance, used to add custom protocols or websocket implementations */
+	createWebsocket?: (
+		url: string,
+		websocketSubProtocols: string[],
+		options: IClientOptions,
+	) => any
+
 	/** Custom message id provider */
 	messageIdProvider?: IMessageIdProvider
 

--- a/src/lib/connect/ws.ts
+++ b/src/lib/connect/ws.ts
@@ -108,11 +108,16 @@ function createWebSocket(
 	debug(
 		`creating new Websocket for url: ${url} and protocol: ${websocketSubProtocol}`,
 	)
-	const socket = new WS(
-		url,
-		[websocketSubProtocol],
-		opts.wsOptions as ClientOptions,
-	)
+	let socket: WS
+	if (opts.createWebsocket) {
+		socket = opts.createWebsocket(url, [websocketSubProtocol], opts)
+	} else {
+		socket = new WS(
+			url,
+			[websocketSubProtocol],
+			opts.wsOptions as ClientOptions,
+		)
+	}
 	return socket
 }
 
@@ -123,7 +128,12 @@ function createBrowserWebSocket(client: MqttClient, opts: IClientOptions) {
 			: 'mqtt'
 
 	const url = buildUrl(opts, client)
-	const socket = new WebSocket(url, [websocketSubProtocol])
+	let socket: WebSocket
+	if (opts.createWebsocket) {
+		socket = opts.createWebsocket(url, [websocketSubProtocol], opts)
+	} else {
+		socket = new WebSocket(url, [websocketSubProtocol])
+	}
 	socket.binaryType = 'arraybuffer'
 	return socket
 }


### PR DESCRIPTION
We need to add special protocols to connect to our mqtt broker over websocket. With this small addition (which hopefully helps others as well) we can do it very easy. Otherwhise we need to build our own streamBuilder and copy alot code.