### PR TITLE
fix: Fixed import to remove error

### DIFF
--- a/src/lib/shared.ts
+++ b/src/lib/shared.ts
@@ -1,5 +1,5 @@
 import type { Packet } from 'mqtt-packet'
-import type internal from 'stream'
+import * as stream from 'stream'
 import type MqttClient from './client'
 import type { IClientOptions } from './client'
 
@@ -9,7 +9,7 @@ export type GenericCallback<T> = (error?: Error, result?: T) => void
 
 export type VoidCallback = () => void
 
-export type IStream = internal.Duplex
+export type IStream = stream.Duplex
 
 export type StreamBuilder = (
 	client: MqttClient,


### PR DESCRIPTION
node_modules/mqtt/build/lib/shared.d.ts:3:13 - error TS1259: Module '"stream"' can only be default-imported using the 'esModuleInterop' flag

3 import type internal from 'stream';
              ~~~~~~~~

  node_modules/@types/node/stream.d.ts:1726:5
    1726     export = internal;
             ~~~~~~~~~~~~~~~~~~
    This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.