### PR TITLE
fix: garbage at pingTimer

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -647,9 +647,9 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			this.log('close :: clearing connackTimer')
 			clearTimeout(this.connackTimer)
 
-			this.log('close :: clearing ping timer')
+			this.log('close :: destroy ping timer')
 			if (this.pingTimer !== null) {
-				this.pingTimer.clear()
+				this.pingTimer.destroy()
 				this.pingTimer = null
 			}
 
@@ -1768,8 +1768,8 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		}
 
 		if (this.pingTimer !== null) {
-			this.log('_cleanUp :: clearing pingTimer')
-			this.pingTimer.clear()
+			this.log('_cleanUp :: destroy pingTimer')
+			this.pingTimer.destroy()
 			this.pingTimer = null
 		}
 

--- a/test/abstract_client.ts
+++ b/test/abstract_client.ts
@@ -89,12 +89,12 @@ export default function abstractTest(server, config, ports) {
 			const client = connect()
 
 			client.once('close', () => {
-				assert.notExists(client.pingTimer)
+				assert.notExists(client.pingTimer._interval)
 				client.end(true, (err) => done(err))
 			})
 
 			client.once('connect', () => {
-				assert.exists(client.pingTimer)
+				assert.exists(client.pingTimer._interval)
 				client.stream.end()
 			})
 		})
@@ -209,9 +209,9 @@ export default function abstractTest(server, config, ports) {
 			const client = connect()
 
 			client.once('connect', () => {
-				assert.exists(client.pingTimer)
+				assert.exists(client.pingTimer._interval)
 				client.end((err) => {
-					assert.notExists(client.pingTimer)
+					assert.notExists(client.pingTimer._interval)
 					done(err)
 				})
 			})
@@ -2036,7 +2036,10 @@ export default function abstractTest(server, config, ports) {
 			const client = connect({ keepalive: 3 })
 			client.once('connect', () => {
 				assert.exists(client.pingTimer)
+				assert.exists(client.pingTimer._interval)
 				client.end(true, done)
+				assert.exists(client.pingTimer)
+				assert.notExists(client.pingTimer._interval)
 			})
 		})
 


### PR DESCRIPTION
I found some garbage in the interval from pingTimer. When I log the heap, strings of the methode _checkPing() are retained.
A quick test with this.pingTimer.destroy() seems to fix the problem.

Fixes #1714 