### PR TITLE
fix: crash with React Native

### DIFF
--- a/src/lib/is-browser.ts
+++ b/src/lib/is-browser.ts
@@ -2,5 +2,5 @@ const isBrowser =
 	(typeof window !== 'undefined' && typeof window.document !== 'undefined') ||
 	// eslint-disable-next-line no-restricted-globals
 	(typeof self !== 'undefined' && typeof self.postMessage === 'function') || // is web worker 
-  (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') // while navigator is deprecated
+  (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') // while navigator.product is deprecated
 export default isBrowser

--- a/src/lib/is-browser.ts
+++ b/src/lib/is-browser.ts
@@ -1,6 +1,6 @@
 const isBrowser =
 	(typeof window !== 'undefined' && typeof window.document !== 'undefined') ||
 	// eslint-disable-next-line no-restricted-globals
-	(typeof self !== 'undefined' && typeof self.postMessage === 'function') // is web worker
-
+	(typeof self !== 'undefined' && typeof self.postMessage === 'function') || // is web worker 
+  (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') // while navigator is deprecated
 export default isBrowser

--- a/src/lib/is-browser.ts
+++ b/src/lib/is-browser.ts
@@ -1,6 +1,6 @@
 const isBrowser =
 	(typeof window !== 'undefined' && typeof window.document !== 'undefined') ||
 	// eslint-disable-next-line no-restricted-globals
-	(typeof self !== 'undefined' && typeof self.postMessage === 'function') || // is web worker 
-  (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') // while navigator.product is deprecated
+	(typeof self !== 'undefined' && typeof self.postMessage === 'function') || // is web worker
+	(typeof navigator !== 'undefined' && navigator.product === 'ReactNative') // while navigator.product is deprecated
 export default isBrowser


### PR DESCRIPTION
RN [support Websocket](https://reactnative.dev/docs/network#websocket-support), better to use it directly.

**Sample code for detecting is React native:** 
https://snack.expo.dev/-QQjqDN-8

Discussion: 

- [navigator.product ](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/product)is removed from modern web standard
- React native is not a browser, should we put it in `isBrowser` function?

