### PR TITLE
fix: make `import mqtt from 'mqtt'` work in browsers

### DIFF
--- a/.airtap.yml
+++ b/.airtap.yml
@@ -1,8 +1,0 @@
-providers:
-  - airtap-playwright
-ui: mocha-bdd
-browsers:
-  - name: chromium
-    supports:
-      headless: true
-

--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ You can find all mqtt bundles versions in `dist` folder:
 - `mqtt.min.js` - iife format, minified
 - `mqtt.esm.js` - esm format minified
 
-Starting from MQTT.js 5.2.0 you can import mqtt in your code like this:
+Starting from MQTT.js > 5.2.0 you can import mqtt in your code like this:
 
 ```js
 import mqtt from 'mqtt'

--- a/README.md
+++ b/README.md
@@ -801,6 +801,8 @@ The callback is called when the packet has been removed.
 Closes the Store.
 
 <a name="browser"></a>
+<a name="webpack"></a>
+<a name="vite"></a>
 
 ## Browser
 
@@ -812,7 +814,15 @@ You can find all mqtt bundles versions in `dist` folder:
 - `mqtt.min.js` - iife format, minified
 - `mqtt.esm.js` - esm format minified
 
-In order to import them use one of the following:
+Starting from MQTT.js 5.2.0 you can import mqtt in your code like this:
+
+```js
+import mqtt from 'mqtt'
+```
+
+This will be automatically handled by your bundler.
+
+Otherwise you can choose to use a specific bundle like:
 
 ```js
 import * as mqtt from 'mqtt/dist/mqtt'
@@ -829,30 +839,6 @@ at <https://unpkg.com/mqtt/dist/mqtt.min.js>.
 See <http://unpkg.com> for the full documentation on version ranges.
 
 **Be sure to only use this bundle with `ws` or `wss` URLs in the browser. Others URL types will likey fail**
-
-<a name="webpack"></a>
-
-### Webpack
-
-If you are using webpack simply import MQTT.js in one of the following ways:
-
-```js
-import * as mqtt from 'mqtt/dist/mqtt'
-import * as mqtt from 'mqtt/dist/mqtt.min'
-import mqtt from 'mqtt/dist/mqtt.esm'
-```
-
-<a name="vite"></a>
-
-### Vite
-
-If you are using vite simply import MQTT.js like this:
-
-```js
-import * as mqtt from 'mqtt/dist/mqtt'
-import * as mqtt from 'mqtt/dist/mqtt.min'
-import mqtt from 'mqtt/dist/mqtt.esm'
-```
 
 <a name="qos"></a>
 

--- a/examples/vite-example/src/App.vue
+++ b/examples/vite-example/src/App.vue
@@ -1,10 +1,12 @@
 <script setup>
 import { ref } from 'vue'
-import { connect } from 'mqtt/dist/mqtt.min'
+import mqtt from 'mqtt'
+
+console.log('mqtt', mqtt)
 
 const connected = ref(false)
 
-const client = connect('wss://test.mosquitto.org:8081');
+const client = mqtt.connect('wss://test.mosquitto.org:8081');
 
 const messages = ref([])
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "help-me": "^4.2.0",
         "lru-cache": "^10.0.1",
         "minimist": "^1.2.8",
+        "mqtt": "^5.2.0",
         "mqtt-packet": "^9.0.0",
         "number-allocator": "^1.0.14",
         "readable-stream": "^4.4.2",
@@ -11341,6 +11342,37 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mqtt": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.2.0.tgz",
+      "integrity": "sha512-IyMUQlUvf1bQodxL7qApSVKv/ILqNyqAJkE45C6CegO4yuGIHu8Yig5EdyaoADa5ietLU1jUZ1LOfDVckTYkJw==",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.5",
+        "@types/ws": "^8.5.9",
+        "commist": "^3.2.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.3.4",
+        "duplexify": "^4.1.2",
+        "help-me": "^4.2.0",
+        "lru-cache": "^10.0.1",
+        "minimist": "^1.2.8",
+        "mqtt-packet": "^9.0.0",
+        "number-allocator": "^1.0.14",
+        "readable-stream": "^4.4.2",
+        "reinterval": "^1.1.0",
+        "rfdc": "^1.3.0",
+        "split2": "^4.2.0",
+        "ws": "^8.14.2"
+      },
+      "bin": {
+        "mqtt": "build/bin/mqtt.js",
+        "mqtt_pub": "build/bin/pub.js",
+        "mqtt_sub": "build/bin/sub.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/mqtt-connection": {
@@ -25531,6 +25563,29 @@
           "integrity": "sha512-wW4GTZPePyh0RgOsM18oDyOUlXfurVRgoNyJfS+y7VWPyd0GYhQp5T2tycZFZjonH+hngxIfklGJhTP/ghidgQ==",
           "dev": true
         }
+      }
+    },
+    "mqtt": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.2.0.tgz",
+      "integrity": "sha512-IyMUQlUvf1bQodxL7qApSVKv/ILqNyqAJkE45C6CegO4yuGIHu8Yig5EdyaoADa5ietLU1jUZ1LOfDVckTYkJw==",
+      "requires": {
+        "@types/readable-stream": "^4.0.5",
+        "@types/ws": "^8.5.9",
+        "commist": "^3.2.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.3.4",
+        "duplexify": "^4.1.2",
+        "help-me": "^4.2.0",
+        "lru-cache": "^10.0.1",
+        "minimist": "^1.2.8",
+        "mqtt-packet": "^9.0.0",
+        "number-allocator": "^1.0.14",
+        "readable-stream": "^4.4.2",
+        "reinterval": "^1.1.0",
+        "rfdc": "^1.3.0",
+        "split2": "^4.2.0",
+        "ws": "^8.14.2"
       }
     },
     "mqtt-connection": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "url": "git://github.com/mqttjs/MQTT.js.git"
   },
   "main": "./build/mqtt.js",
+  "module": "./dist/mqtt.esm.js",
   "bin": {
     "mqtt_pub": "./build/bin/pub.js",
     "mqtt_sub": "./build/bin/sub.js",
@@ -35,7 +36,13 @@
     "src/"
   ],
   "exports": {
-    ".": "./build/mqtt.js",
+    ".": {
+      "browser": {
+        "import": "./dist/mqtt.esm.js", 
+        "default": "./dist/mqtt.js"
+      },
+      "default": "./build/mqtt.js"
+    },
     "./package.json": "./package.json",
     "./*.map": "./build/*.js.map",
     "./dist/*": "./dist/*.js",
@@ -95,7 +102,7 @@
     "node": ">=16.0.0"
   },
   "browser": {
-    "./mqtt.js": "./build/mqtt.js",
+    "./mqtt.js": "./dist/mqtt.js",
     "fs": false,
     "tls": false,
     "net": false
@@ -110,6 +117,7 @@
     "help-me": "^4.2.0",
     "lru-cache": "^10.0.1",
     "minimist": "^1.2.8",
+    "mqtt": "^5.2.0",
     "mqtt-packet": "^9.0.0",
     "number-allocator": "^1.0.14",
     "readable-stream": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "url": "git://github.com/mqttjs/MQTT.js.git"
   },
   "main": "./build/mqtt.js",
-  "module": "./dist/mqtt.esm.js",
   "bin": {
     "mqtt_pub": "./build/bin/pub.js",
     "mqtt_sub": "./build/bin/sub.js",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "url": "git://github.com/mqttjs/MQTT.js.git"
   },
   "main": "./build/mqtt.js",
+  "module": "./dist/mqtt.esm.js",
   "bin": {
     "mqtt_pub": "./build/bin/pub.js",
     "mqtt_sub": "./build/bin/sub.js",

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import mqtt from '../../dist/mqtt.esm.js';
+import mqtt from '../../'; // this will resolve to mqtt/dist/mqtt.esm.js
 
 // needed to test no-esm version /dist/mqtt.js
 /** @type { import('../../src/mqtt').MqttClient }*/


### PR DESCRIPTION
Users will be able to use `import mqtt from 'mqtt'` directly without using `/dist` imports

Fixes #1733 