### PR TITLE
Backport #1752

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -32,14 +32,6 @@ const defaultConnectOptions = {
   resubscribe: true
 }
 
-const socketErrors = [
-  'ECONNREFUSED',
-  'EADDRINUSE',
-  'ECONNRESET',
-  'ENOTFOUND'
-]
-
-// Other Socket Errors: EADDRINUSE, ECONNRESET, ENOTFOUND.
 
 const errors = {
   0: '',
@@ -454,7 +446,9 @@ MqttClient.prototype._setupStream = function () {
 
   function streamErrorHandler (error) {
     debug('streamErrorHandler :: error', error.message)
-    if (socketErrors.includes(error.code)) {
+    // error.code will only be set on NodeJS env, browse don't allow to detect erros on sockets
+    // also emitting errors on browser seems to create issues 
+    if (error.code) {
       // handle error
       debug('streamErrorHandler :: emitting error')
       that.emit('error', error)


### PR DESCRIPTION
Backport to version that supports NodeJS 14

As discussed in https://github.com/mqttjs/MQTT.js/issues/1756

Here is a backport of the #1752 fix to the v4 codebase