### PR TITLE
fix: typo in `client.ts`

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -248,7 +248,7 @@ export interface IClientOptions extends ISecureClientOptions {
 	 */
 	clean?: boolean
 	/**
-	 *  10 seconds, set to 0 to disable
+	 *  60 seconds, set to 0 to disable
 	 */
 	keepalive?: number
 	/**


### PR DESCRIPTION
`defaultConnectOptions.keepalive = 60` in `client.ts`