### PR TITLE
fix: ignore packets after `end()`

### DIFF
--- a/src/lib/handlers/index.ts
+++ b/src/lib/handlers/index.ts
@@ -6,6 +6,11 @@ import handlePubrel from './pubrel'
 import { PacketHandler } from '../shared'
 
 const handle: PacketHandler = (client, packet, done) => {
+	if (client.disconnecting) {
+		done()
+		return
+	}
+
 	const { options } = client
 
 	if (

--- a/test/abstract_client.ts
+++ b/test/abstract_client.ts
@@ -2865,6 +2865,29 @@ export default function abstractTest(server, config, ports) {
 			})
 		})
 
+		it('should ignore packets when disconnecting', function _test(t, done) {
+			const client = connect()
+
+			client.end()
+			handle(
+				client,
+				{
+					cmd: 'publish',
+					messageId: 1,
+					topic: 'test',
+					payload: 'test',
+					qos: 1,
+					dup: false,
+					retain: false,
+				},
+				done,
+			)
+
+			client.on('packetreceive', () => {
+				done(new Error('packet should be ignored while disconnecting'))
+			})
+		})
+
 		it('should reconnect after stream disconnect', function _test(t, done) {
 			const client = connect()
 


### PR DESCRIPTION
Ref #846