### PR TITLE
fix(browser): force closing client doesn't destroy websocket correctly

### DIFF
--- a/src/lib/BufferedDuplex.ts
+++ b/src/lib/BufferedDuplex.ts
@@ -77,6 +77,12 @@ export class BufferedDuplex extends Duplex {
 		this.proxy.end(callback)
 	}
 
+	_destroy(err: Error, callback: (error: Error) => void): void {
+		this.writeQueue = []
+		this.proxy.destroy(err)
+		callback(err)
+	}
+
 	/** Method to call when socket is ready to stop buffering writes */
 	socketReady() {
 		this.emit('connect')


### PR DESCRIPTION
Fixes #1817