### PR TITLE
fix: keepalive issues

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -1,13 +1,15 @@
-import mqtt from '.'
+import mqtt from './src/index'
 
 const client = mqtt.connect('mqtts://test.mosquitto.org', {
-	keepalive: 60,
+	keepalive: 10,
 	port: 8883,
 	reconnectPeriod: 15000,
 	rejectUnauthorized: false,
 })
 
-const testTopic = 'presence'
+const randomNumber = Math.floor(Math.random() * 1000)
+
+const testTopic = `presence_${randomNumber.toString()}`
 
 function publish() {
 	const msg = `Hello mqtt ${new Date().toISOString()}`

--- a/example.ts
+++ b/example.ts
@@ -1,24 +1,23 @@
 import mqtt from '.'
 
-const client = mqtt.connect('mqtt://test.mosquitto.org', {
-	keepalive: 10,
+const client = mqtt.connect('mqtts://test.mosquitto.org', {
+	keepalive: 60,
+	port: 8883,
 	reconnectPeriod: 15000,
+	rejectUnauthorized: false,
 })
 
 const testTopic = 'presence'
 
 function publish() {
-	client.publish(
-		testTopic,
-		`Hello mqtt ${new Date().toISOString()}`,
-		(err2) => {
-			if (!err2) {
-				console.log('message published')
-			} else {
-				console.error(err2)
-			}
-		},
-	)
+	const msg = `Hello mqtt ${new Date().toISOString()}`
+	client.publish(testTopic, msg, { qos: 1 }, (err2) => {
+		if (!err2) {
+			console.log('message published')
+		} else {
+			console.error(err2)
+		}
+	})
 }
 
 client.subscribe(testTopic, (err) => {
@@ -31,10 +30,11 @@ client.subscribe(testTopic, (err) => {
 
 client.on('message', (topic, message) => {
 	console.log('received message "%s" from topic "%s"', message, topic)
-	setTimeout(() => {
-		publish()
-	}, 2000)
 })
+
+setInterval(() => {
+	publish()
+}, 2000)
 
 client.on('error', (err) => {
 	console.error(err)

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -2106,8 +2106,16 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			this.options.keepalive &&
 			this.options.reschedulePings
 		) {
-			this.pingTimer.reschedule()
+			this._reschedulePing()
 		}
+	}
+
+	/**
+	 * Mostly needed for test purposes
+	 */
+	private _reschedulePing() {
+		this.log('_reschedulePing :: rescheduling ping')
+		this.pingTimer.reschedule()
 	}
 
 	/**

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -2082,6 +2082,7 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 				},
 				this.options.timerVariant,
 			)
+			this.pingResp = Date.now()
 		}
 	}
 
@@ -2116,7 +2117,8 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	 */
 	private _checkPing() {
 		this.log('_checkPing :: checking ping...')
-		const timeSincePing = Date.now() - this.pingResp
+		// give 100ms offset to avoid ping timeout when receiving fast responses
+		const timeSincePing = Date.now() - this.pingResp - 100
 		if (timeSincePing <= this.options.keepalive * 1000) {
 			this.log('_checkPing :: ping response received in time')
 			this._sendPing()

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -2075,7 +2075,6 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		)
 
 		if (!this.pingTimer && this.options.keepalive) {
-			this.pingResp = Date.now()
 			this.pingTimer = new PingTimer(
 				this.options.keepalive,
 				() => {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -2095,11 +2095,12 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	}
 
 	/**
-	 * _shiftPingCheck - reschedule the ping interval
+
+	 * _shiftPingInterval - reschedule the ping interval
 	 *
 	 * @api private
 	 */
-	private _shiftPingCheck() {
+	private _shiftPingInterval() {
 		if (
 			this.pingTimer &&
 			this.options.keepalive &&

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -424,8 +424,6 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 
 	public messageIdProvider: IMessageIdProvider
 
-	public pingResp: boolean
-
 	public outgoing: Record<
 		number,
 		{ volatile: boolean; cb: (err: Error, packet?: Packet) => void }
@@ -434,6 +432,9 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	public messageIdToTopic: Record<number, string[]>
 
 	public noop: (error?: any) => void
+
+	/** Timestamp of last received control packet */
+	public pingResp: number
 
 	public pingTimer: PingTimer
 
@@ -659,11 +660,7 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			this.log('close :: clearing connackTimer')
 			clearTimeout(this.connackTimer)
 
-			this.log('close :: destroy ping timer')
-			if (this.pingTimer) {
-				this.pingTimer.destroy()
-				this.pingTimer = null
-			}
+			this._destroyPingTimer()
 
 			if (this.topicAliasRecv) {
 				this.topicAliasRecv.clear()
@@ -722,6 +719,7 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	public connect() {
 		const writable = new Writable()
 		const parser = mqttPacket.parser(this.options)
+
 		let completeParse = null
 		const packets = []
 
@@ -1782,11 +1780,7 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			this._setupReconnect()
 		}
 
-		if (this.pingTimer) {
-			this.log('_cleanUp :: destroy pingTimer')
-			this.pingTimer.destroy()
-			this.pingTimer = null
-		}
+		this._destroyPingTimer()
 
 		if (done && !this.connected) {
 			this.log(
@@ -1923,9 +1917,6 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		this.log('_writePacket :: emitting `packetsend`')
 
 		this.emit('packetsend', packet)
-
-		// When writing a packet, reschedule the ping timer
-		this._shiftPingInterval()
 
 		this.log('_writePacket :: writing to stream')
 		const result = mqttPacket.writeToStream(
@@ -2084,7 +2075,7 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		)
 
 		if (!this.pingTimer && this.options.keepalive) {
-			this.pingResp = true
+			this.pingResp = Date.now()
 			this.pingTimer = new PingTimer(
 				this.options.keepalive,
 				() => {
@@ -2095,12 +2086,20 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		}
 	}
 
+	private _destroyPingTimer() {
+		if (this.pingTimer) {
+			this.log('_destroyPingTimer :: destroying ping timer')
+			this.pingTimer.destroy()
+			this.pingTimer = null
+		}
+	}
+
 	/**
-	 * _shiftPingInterval - reschedule the ping interval
+	 * _shiftPingCheck - reschedule the ping interval
 	 *
 	 * @api private
 	 */
-	private _shiftPingInterval() {
+	private _shiftPingCheck() {
 		if (
 			this.pingTimer &&
 			this.options.keepalive &&
@@ -2117,18 +2116,21 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	 */
 	private _checkPing() {
 		this.log('_checkPing :: checking ping...')
-		if (this.pingResp) {
-			this.log(
-				'_checkPing :: ping response received. Clearing flag and sending `pingreq`',
-			)
-			this.pingResp = false
-			this._sendPacket({ cmd: 'pingreq' })
+		const timeSincePing = Date.now() - this.pingResp
+		if (timeSincePing <= this.options.keepalive * 1000) {
+			this.log('_checkPing :: ping response received in time')
+			this._sendPing()
 		} else {
 			// do a forced cleanup since socket will be in bad shape
 			this.emit('error', new Error('Keepalive timeout'))
 			this.log('_checkPing :: calling _cleanUp with force true')
 			this._cleanUp(true)
 		}
+	}
+
+	private _sendPing() {
+		this.log('_sendPing :: sending pingreq')
+		this._sendPacket({ cmd: 'pingreq' })
 	}
 
 	/**

--- a/src/lib/handlers/index.ts
+++ b/src/lib/handlers/index.ts
@@ -30,7 +30,7 @@ const handle: PacketHandler = (client, packet, done) => {
 
 	switch (packet.cmd) {
 		case 'publish':
-			client['_shiftPingCheck']()
+			client['_shiftPingInterval']()
 			handlePublish(client, packet, done)
 			break
 		case 'puback':
@@ -38,12 +38,12 @@ const handle: PacketHandler = (client, packet, done) => {
 		case 'pubcomp':
 		case 'suback':
 		case 'unsuback':
-			client['_shiftPingCheck']()
+			client['_shiftPingInterval']()
 			handleAck(client, packet)
 			done()
 			break
 		case 'pubrel':
-			client['_shiftPingCheck']()
+			client['_shiftPingInterval']()
 			handlePubrel(client, packet, done)
 			break
 		case 'connack':

--- a/src/lib/handlers/index.ts
+++ b/src/lib/handlers/index.ts
@@ -22,9 +22,6 @@ const handle: PacketHandler = (client, packet, done) => {
 		return client
 	}
 
-	client.log('_handlePacket :: emitting packetreceive')
-	client.emit('packetreceive', packet)
-
 	// keep track of last time we received a packet (for keepalive mechanism)
 	client.pingResp = Date.now()
 
@@ -32,6 +29,9 @@ const handle: PacketHandler = (client, packet, done) => {
 	if (packet.cmd !== 'pingresp') {
 		client['_shiftPingInterval']()
 	}
+
+	client.log('_handlePacket :: emitting packetreceive')
+	client.emit('packetreceive', packet)
 
 	switch (packet.cmd) {
 		case 'publish':


### PR DESCRIPTION
Actually keepalive is shifted every time a packet is written to stream. This is wrong as this doesn't mean the stream is up and in cases where there is a constant publish the keepalive never triggers as is keeps being shifted without closing the client.

With this PR we ensure that the keep alive timer is shifted only when we receive control packets as defined in specs: https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Ref363645900

Fixes #1727 