### PR TITLE
fix: update is-browser.ts to account `undefined` navigator

### DIFF
--- a/src/lib/is-browser.ts
+++ b/src/lib/is-browser.ts
@@ -4,8 +4,8 @@ const isStandardBrowserEnv = () => {
 		// Is the process an electron application
 		// check if we are in electron `renderer`
 		const electronRenderCheck =
-      (typeof navigator !== "undefined") &&
-			navigator?.userAgent?.toLowerCase().indexOf(' electron/') > -1
+			typeof navigator !== 'undefined' &&
+			navigator.userAgent?.toLowerCase().indexOf(' electron/') > -1
 		if (electronRenderCheck && process?.versions) {
 			const electronMainCheck = Object.prototype.hasOwnProperty.call(
 				process.versions,


### PR DESCRIPTION
Fixes error
```
ReferenceError: navigator is not defined
    at isStandardBrowserEnv (node_modules/mqtt/src/lib/is-browser.ts:7:4)
```

(error is thrown in electron 12.2.3 and electron 30.0.6)

https://github.com/mqttjs/MQTT.js/commit/6a03d29b86dc4fe8eae04eaf0f9fc661f1c3d1ea#commitcomment-142114121