### PR TITLE
fix: prevent url.parse to set `path` option

### DIFF
--- a/src/lib/connect/index.ts
+++ b/src/lib/connect/index.ts
@@ -86,6 +86,7 @@ function connect(
 				host: parsed.hostname,
 				protocol: parsed.protocol,
 				query: parsed.query,
+				auth: parsed.auth,
 			},
 			...opts,
 		} as IClientOptions

--- a/src/lib/connect/index.ts
+++ b/src/lib/connect/index.ts
@@ -80,7 +80,15 @@ function connect(
 			parsed.port = Number(parsed.port)
 		}
 
-		opts = { ...parsed, ...opts } as IClientOptions
+		opts = {
+			...{
+				port: parsed.port,
+				host: parsed.hostname,
+				protocol: parsed.protocol,
+				query: parsed.query,
+			},
+			...opts,
+		} as IClientOptions
 
 		if (opts.protocol === null) {
 			throw new Error('Missing protocol')

--- a/test/mqtt.ts
+++ b/test/mqtt.ts
@@ -34,6 +34,15 @@ describe('mqtt', () => {
 			c.end((err) => done(err))
 		})
 
+		it('should not set `path` when parsing url', function _test(t, done) {
+			const c = mqtt.connect('mqtt://[::1]')
+
+			c.should.be.instanceOf(mqtt.MqttClient)
+			c.options.should.not.have.property('path')
+			c.options.should.have.property('host', '::1')
+			c.end((err) => done(err))
+		})
+
 		it('should return an MqttClient with username and password options set', function _test(t, done) {
 			const c = mqtt.connect('mqtt://user@localhost:1883')
 


### PR DESCRIPTION
Fixes #1870