### PR TITLE
fix: manual reconnect issues

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -2181,13 +2181,14 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	 * @api private
 	 */
 	private _onConnect(packet: IConnackPacket) {
-		this.connected = true
-
 		if (this.disconnected) {
+			this.disconnected = false
+			this.connected = true
 			this.emit('connect', packet)
 			return
 		}
 
+		this.connected = true
 		this.connackPacket = packet
 		this.messageIdProvider.clear()
 		this._setupKeepaliveManager()

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1457,6 +1457,8 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			})
 			if (this._deferredReconnect) {
 				this._deferredReconnect()
+			} else {
+				this.disconnecting = false
 			}
 		}
 
@@ -2179,6 +2181,8 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	 * @api private
 	 */
 	private _onConnect(packet: IConnackPacket) {
+		this.connected = true
+
 		if (this.disconnected) {
 			this.emit('connect', packet)
 			return
@@ -2187,8 +2191,6 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		this.connackPacket = packet
 		this.messageIdProvider.clear()
 		this._setupKeepaliveManager()
-
-		this.connected = true
 
 		/** check if there are packets in outgoing store and stream them */
 		const startStreamProcess = () => {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -2188,10 +2188,11 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			return
 		}
 
-		this.connected = true
 		this.connackPacket = packet
 		this.messageIdProvider.clear()
 		this._setupKeepaliveManager()
+
+		this.connected = true
 
 		/** check if there are packets in outgoing store and stream them */
 		const startStreamProcess = () => {


### PR DESCRIPTION
This resolves #1882 

There were two issues:
1. If a client was setup with resubscribe to true (the default behaviour) calling `reconnect` would cause the resubscribe to the topic to error.
2. If a client was setup with resubscribe set to false. Trying to subscribe to a topic again on the `connect` event once the reconnect had been manually called and completed would error. 