### PR TITLE
fix: suback Error Codes Handling

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,3 +68,12 @@ node -r esbuild-register --test --test-name-pattern="should resend in-flight QoS
 ```
 
 You can also run tests in watch mode using the `--watch` flag.
+
+## Lint
+
+You can run and automatically fix linting issues with
+
+```sh
+npm run lint-fix
+```
+

--- a/src/lib/handlers/ack.ts
+++ b/src/lib/handlers/ack.ts
@@ -54,7 +54,7 @@ const handleAck: PacketHandler = (client, packet) => {
 	const type = packet.cmd
 	let response = null
 	const cb = client.outgoing[messageId] ? client.outgoing[messageId].cb : null
-	let err
+	let err = null
 
 	// Checking `!cb` happens to work, but it's not technically "correct".
 	//
@@ -129,9 +129,6 @@ const handleAck: PacketHandler = (client, packet) => {
 							delete client['_resubscribeTopics'][topic]
 						})
 					}
-					client['_removeOutgoingAndStoreMessage'](messageId, () => {
-						cb(err, packet)
-					})
 				}
 			}
 			delete client.messageIdToTopic[messageId]

--- a/test/abstract_client.ts
+++ b/test/abstract_client.ts
@@ -3997,7 +3997,7 @@ export default function abstractTest(server, config, ports) {
 						if (subErr) {
 							assert.strictEqual(
 								subErr.message,
-								'Error: Subscribe error: Not authorized',
+								'Subscribe error: Not authorized',
 							)
 							return done(endErr)
 						}

--- a/test/abstract_client.ts
+++ b/test/abstract_client.ts
@@ -474,7 +474,7 @@ export default function abstractTest(server, config, ports) {
 			// fake a port
 			const client = connect({ reconnectPeriod: 20, port: 4557 })
 
-			client.on('error', () => {})
+			client.on('error', () => { })
 
 			client.on('offline', () => {
 				client.end(true, done)
@@ -1389,7 +1389,7 @@ export default function abstractTest(server, config, ports) {
 
 		it(
 			'should silently ignore errors thrown by `handleMessage` and return when no callback is passed ' +
-				'into `handlePublish` method',
+			'into `handlePublish` method',
 			function _test(t, done) {
 				const client = connect()
 
@@ -1643,7 +1643,7 @@ export default function abstractTest(server, config, ports) {
 
 		it(
 			'should silently ignore errors thrown by `handleMessage` and return when no callback is passed ' +
-				'into `handlePubrel` method',
+			'into `handlePubrel` method',
 			function _test(t, done) {
 				const store = new Store()
 				const client = connect({ incomingStore: store })
@@ -1697,7 +1697,7 @@ export default function abstractTest(server, config, ports) {
 			const server2 = serverBuilder(config.protocol, (serverClient) => {
 				// errors are not interesting for this test
 				// but they might happen on some platforms
-				serverClient.on('error', () => {})
+				serverClient.on('error', () => { })
 
 				serverClient.on('connect', (packet) => {
 					const connack =
@@ -2058,64 +2058,63 @@ export default function abstractTest(server, config, ports) {
 		})
 
 		const reschedulePing = (reschedulePings: boolean) => {
-			it(`should ${
-				!reschedulePings ? 'not ' : ''
-			}reschedule pings if publishing at a higher rate than keepalive and reschedulePings===${reschedulePings}`, function _test(t, done) {
-				const intervalMs = 3000
-				const client = connect({
-					keepalive: intervalMs / 1000,
-					reschedulePings,
-				})
+			it(`should ${!reschedulePings ? 'not ' : ''
+				}reschedule pings if publishing at a higher rate than keepalive and reschedulePings===${reschedulePings}`, function _test(t, done) {
+					const intervalMs = 3000
+					const client = connect({
+						keepalive: intervalMs / 1000,
+						reschedulePings,
+					})
 
-				const spyReschedule = sinon.spy(
-					client,
-					'_reschedulePing' as any,
-				)
+					const spyReschedule = sinon.spy(
+						client,
+						'_reschedulePing' as any,
+					)
 
-				let received = 0
+					let received = 0
 
-				client.on('packetreceive', (packet) => {
-					if (packet.cmd === 'puback') {
-						process.nextTick(() => {
-							clock.tick(intervalMs)
+					client.on('packetreceive', (packet) => {
+						if (packet.cmd === 'puback') {
+							process.nextTick(() => {
+								clock.tick(intervalMs)
 
-							received++
+								received++
 
-							if (received === 2) {
-								if (reschedulePings) {
-									assert.strictEqual(
-										spyReschedule.callCount,
-										received,
-									)
-								} else {
-									assert.strictEqual(
-										spyReschedule.callCount,
-										0,
-									)
+								if (received === 2) {
+									if (reschedulePings) {
+										assert.strictEqual(
+											spyReschedule.callCount,
+											received,
+										)
+									} else {
+										assert.strictEqual(
+											spyReschedule.callCount,
+											0,
+										)
+									}
+									client.end(true, done)
 								}
-								client.end(true, done)
-							}
+							})
+
+							clock.tick(1)
+						}
+					})
+
+					server.once('client', (serverClient) => {
+						serverClient.on('publish', () => {
+							// needed to trigger the setImmediate inside server publish listener and send suback
+							clock.tick(1)
 						})
+					})
 
-						clock.tick(1)
-					}
-				})
-
-				server.once('client', (serverClient) => {
-					serverClient.on('publish', () => {
-						// needed to trigger the setImmediate inside server publish listener and send suback
-						clock.tick(1)
+					client.once('connect', () => {
+						// reset call count (it's called also on connack)
+						spyReschedule.resetHistory()
+						// use qos1 so the puback is received (to reschedule ping)
+						client.publish('foo', 'bar', { qos: 1 })
+						client.publish('foo', 'bar', { qos: 1 })
 					})
 				})
-
-				client.once('connect', () => {
-					// reset call count (it's called also on connack)
-					spyReschedule.resetHistory()
-					// use qos1 so the puback is received (to reschedule ping)
-					client.publish('foo', 'bar', { qos: 1 })
-					client.publish('foo', 'bar', { qos: 1 })
-				})
-			})
 		}
 
 		reschedulePing(true)
@@ -2444,6 +2443,48 @@ export default function abstractTest(server, config, ports) {
 				})
 			})
 		})
+
+		if (version === 5) {
+			it('should fire a callback with error for topic it does not have access to', function _test(t, done) {
+
+				const server2 = serverBuilder(config.protocol, (serverClient) => {
+					serverClient.on('connect', (packet) => {
+						const connack =
+							version === 5 ? { reasonCode: 0 } : { returnCode: 0 }
+						serverClient.connack(connack)
+					})
+					serverClient.on('subscribe', (packet) => {
+						serverClient.suback({
+							messageId: packet.messageId,
+							granted: packet.subscriptions.map((e) => 135),
+						})
+					})
+				})
+
+				server2.listen(ports.PORTAND49, () => {
+					const client = connect({
+						...config,
+						port: ports.PORTAND49,
+						host: 'localhost',
+					})
+
+					client.subscribe('$SYS/#', (subErr) => {
+						client.end(true, (endErr) => {
+							server2.close((err2) => {
+								if (subErr) {
+									assert.strictEqual(
+										subErr.message,
+										'Subscribe error: Not authorized',
+									)
+									return done(err2 || endErr)
+								}
+								done(new Error('Suback errors do NOT work'))
+							})
+						})
+					})
+				})
+			})
+		}
 
 		it('should fire a callback with error if disconnected (options provided)', function _test(t, done) {
 			const client = connect()
@@ -3133,9 +3174,9 @@ export default function abstractTest(server, config, ports) {
 								const reconnectPeriodDuringTest = end - start
 								if (
 									reconnectPeriodDuringTest >=
-										test.period - reconnectSlushTime &&
+									test.period - reconnectSlushTime &&
 									reconnectPeriodDuringTest <=
-										test.period + reconnectSlushTime
+									test.period + reconnectSlushTime
 								) {
 									// give the connection a 200 ms slush window
 									done()
@@ -3279,7 +3320,7 @@ export default function abstractTest(server, config, ports) {
 
 				server.once('client', (serverClient) => {
 					// ignore errors
-					serverClient.on('error', () => {})
+					serverClient.on('error', () => { })
 					serverClient.on('publish', () => {
 						setImmediate(() => {
 							serverClient.stream.destroy()
@@ -3593,7 +3634,7 @@ export default function abstractTest(server, config, ports) {
 
 				client.on('connect', () => {
 					if (!reconnect) {
-						client.subscribe('test', { qos: 2 }, () => {})
+						client.subscribe('test', { qos: 2 }, () => { })
 						reconnect = true
 					}
 				})
@@ -3702,7 +3743,7 @@ export default function abstractTest(server, config, ports) {
 						client.publish('topic', 'payload', { qos: 1 })
 					}
 				})
-				client.on('error', () => {})
+				client.on('error', () => { })
 			})
 		})
 
@@ -3750,7 +3791,7 @@ export default function abstractTest(server, config, ports) {
 						client.publish('topic', 'payload', { qos: 2 })
 					}
 				})
-				client.on('error', () => {})
+				client.on('error', () => { })
 			})
 		})
 
@@ -3812,7 +3853,7 @@ export default function abstractTest(server, config, ports) {
 						)
 					}
 				})
-				client.on('error', () => {})
+				client.on('error', () => { })
 			})
 		})
 
@@ -3826,7 +3867,7 @@ export default function abstractTest(server, config, ports) {
 			const server2 = serverBuilder(config.protocol, (serverClient) => {
 				// errors are not interesting for this test
 				// but they might happen on some platforms
-				serverClient.on('error', () => {})
+				serverClient.on('error', () => { })
 
 				serverClient.on('connect', (packet) => {
 					const connack =
@@ -3892,7 +3933,7 @@ export default function abstractTest(server, config, ports) {
 						client.publish('topic', 'payload3', { qos: 1 })
 					}
 				})
-				client.on('error', () => {})
+				client.on('error', () => { })
 			})
 		})
 
@@ -3972,37 +4013,6 @@ export default function abstractTest(server, config, ports) {
 				server.removeAllListeners('client')
 				cachedClientListeners.forEach((listener) => {
 					server.on('client', listener)
-				})
-			})
-
-			it('should return an error (via callbacks) for topic it does not have access to', function _test(t, done) {
-				const client = connect({ ...config })
-
-				server.on('client', (serverClient) => {
-					serverClient.on('connect', () => {
-						serverClient.connack(connack)
-					})
-
-					serverClient.on('subscribe', (packet) => {
-						// Send an unauthorized error
-						serverClient.suback({
-							granted: [0x87],
-							messageId: packet.messageId,
-						})
-					})
-				})
-
-				client.subscribe('$SYS/#', (subErr) => {
-					client.end(true, (endErr) => {
-						if (subErr) {
-							assert.strictEqual(
-								subErr.message,
-								'Subscribe error: Not authorized',
-							)
-							return done(endErr)
-						}
-						done(new Error('Suback errors do NOT work'))
-					})
 				})
 			})
 

--- a/test/abstract_client.ts
+++ b/test/abstract_client.ts
@@ -3976,18 +3976,29 @@ export default function abstractTest(server, config, ports) {
 			})
 
 			it('should return an error (via callbacks) for topic it does not have access to', function _test(t, done) {
-				const client = connect()
+				const client = connect({ ...config })
 
 				server.on('client', (serverClient) => {
-					serverClient.on('subscribe', () => {
+					serverClient.on('connect', () => {
+						serverClient.connack(connack)
+					})
+
+					serverClient.on('subscribe', (packet) => {
 						// Send an unauthorized error
-						serverClient.suback({ granted: [0x87], messageId: 123542 })
+						serverClient.suback({
+							granted: [ 0x87 ],
+							messageId: packet.messageId,
+						})
 					})
 				})
 
 				client.subscribe('$SYS/#', (subErr) => {
 					client.end(true, (endErr) => {
 						if (subErr) {
+							assert.strictEqual(
+								subErr.message,
+								'Error: Subscribe error: Not authorized',
+							)
 							return done(endErr)
 						}
 						done(new Error('Suback errors do NOT work'))

--- a/test/abstract_client.ts
+++ b/test/abstract_client.ts
@@ -3986,7 +3986,7 @@ export default function abstractTest(server, config, ports) {
 					serverClient.on('subscribe', (packet) => {
 						// Send an unauthorized error
 						serverClient.suback({
-							granted: [ 0x87 ],
+							granted: [0x87],
 							messageId: packet.messageId,
 						})
 					})

--- a/test/abstract_client.ts
+++ b/test/abstract_client.ts
@@ -3975,6 +3975,26 @@ export default function abstractTest(server, config, ports) {
 				})
 			})
 
+			it('should return an error (via callbacks) for topic it does not have access to', function _test(t, done) {
+				const client = connect()
+
+				server.on('client', (serverClient) => {
+					serverClient.on('subscribe', () => {
+						// Send an unauthorized error
+						serverClient.suback({ granted: [0x87], messageId: 123542 })
+					})
+				})
+
+				client.subscribe('$SYS/#', (subErr) => {
+					client.end(true, (endErr) => {
+						if (subErr) {
+							return done(endErr)
+						}
+						done(new Error('Suback errors do NOT work'))
+					})
+				})
+			})
+
 			it('should resubscribe even if disconnect is before suback', function _test(t, done) {
 				const client = connect({ reconnectPeriod: 100, ...config })
 				let subscribeCount = 0

--- a/test/runTests.ts
+++ b/test/runTests.ts
@@ -17,7 +17,7 @@ const start = Date.now()
 
 const testStream = run({
 	files,
-	timeout: 90 * 1000,
+	timeout: 60 * 1000,
 	concurrency: cpus().length,
 })
 

--- a/test/runTests.ts
+++ b/test/runTests.ts
@@ -17,7 +17,7 @@ const start = Date.now()
 
 const testStream = run({
 	files,
-	timeout: 60 * 1000,
+	timeout: 90 * 1000,
 	concurrency: cpus().length,
 })
 


### PR DESCRIPTION
- Add error handling for failed suback requests
  - specified constant the suback return code value
  - copied error object used in other packet handlers, adjusted for this packet
  - added error callback method used in other packet handlers
  - passed error object to the callback method

Now the error creates the expected Exception with detail and is available from all error callbacks, consistent with the rest of the library.

## Test Cases

### Subscribing to Unauthorized topic

```
error: Error: Subscribe error: Not authorized
    at handleAck (/Users/tsteinholz/Development/MQTT.js/build/lib/handlers/ack.js:102:27)
    at handle (/Users/tsteinholz/Development/MQTT.js/build/lib/handlers/index.js:36:31)
    at work (/Users/tsteinholz/Development/MQTT.js/build/lib/client.js:221:40)
    at writable._write (/Users/tsteinholz/Development/MQTT.js/build/lib/client.js:246:13)
    at writeOrBuffer (/Users/tsteinholz/Development/MQTT.js/node_modules/readable-stream/lib/internal/streams/writable.js:334:12)
    at _write (/Users/tsteinholz/Development/MQTT.js/node_modules/readable-stream/lib/internal/streams/writable.js:283:10)
    at Writable.write (/Users/tsteinholz/Development/MQTT.js/node_modules/readable-stream/lib/internal/streams/writable.js:286:10)
    at TLSSocket.ondata (node:internal/streams/readable:1007:22)
    at TLSSocket.emit (node:events:519:28)
    at addChunk (node:internal/streams/readable:559:12) {
  code: 135
}
granted: [
  {
    topic: 'topic/user/does/NOT/have/access/to,
    qos: 1,
    nl: false,
    rap: false,
    rh: 0,
    properties: undefined
  }
]
```

### Subscribing to authorized topic

```
error: undefined
granted: [
  {
    topic: 'topic/user/has/access/to',
    qos: 1,
    nl: false,
    rap: false,
    rh: 0,
    properties: undefined
  }
]
```