### PR TITLE
feat: add compatibility with txiki.js

### DIFF
--- a/src/lib/is-browser.ts
+++ b/src/lib/is-browser.ts
@@ -25,6 +25,8 @@ const isStandardBrowserEnv = () => {
 	return false
 }
 
+const isTxikijsEnv = () => navigator.userAgent === "txiki.js";
+
 const isWebWorkerEnv = () =>
 	Boolean(
 		// eslint-disable-next-line no-restricted-globals
@@ -37,7 +39,7 @@ const isReactNativeEnv = () =>
 	typeof navigator !== 'undefined' && navigator.product === 'ReactNative'
 
 const isBrowser =
-	isStandardBrowserEnv() || isWebWorkerEnv() || isReactNativeEnv()
+	isStandardBrowserEnv() || isWebWorkerEnv() || isReactNativeEnv() || isTxikijsEnv()
 
 export const isWebWorker = isWebWorkerEnv()
 

--- a/src/lib/is-browser.ts
+++ b/src/lib/is-browser.ts
@@ -25,7 +25,8 @@ const isStandardBrowserEnv = () => {
 	return false
 }
 
-const isTxikijsEnv = () => navigator.userAgent === 'txiki.js'
+const isTxikijsEnv = () =>
+	typeof navigator !== 'undefined' && navigator.userAgent === 'txiki.js'
 
 const isWebWorkerEnv = () =>
 	Boolean(

--- a/src/lib/is-browser.ts
+++ b/src/lib/is-browser.ts
@@ -25,7 +25,7 @@ const isStandardBrowserEnv = () => {
 	return false
 }
 
-const isTxikijsEnv = () => navigator.userAgent === "txiki.js";
+const isTxikijsEnv = () => navigator.userAgent === 'txiki.js'
 
 const isWebWorkerEnv = () =>
 	Boolean(
@@ -39,7 +39,10 @@ const isReactNativeEnv = () =>
 	typeof navigator !== 'undefined' && navigator.product === 'ReactNative'
 
 const isBrowser =
-	isStandardBrowserEnv() || isWebWorkerEnv() || isReactNativeEnv() || isTxikijsEnv()
+	isStandardBrowserEnv() ||
+	isWebWorkerEnv() ||
+	isReactNativeEnv() ||
+	isTxikijsEnv()
 
 export const isWebWorker = isWebWorkerEnv()
 


### PR DESCRIPTION
[txiki.js](https://github.com/saghul/txiki.js) is a small JavaScript runtime compatible with most of the browser api; very nice for small embedded devices.

However, `MQTT.js` wrongly assume a `Node.js` compatibility because there is no `document` variable in the global space. Although, if it was using the browser ws, the lib would be compatible with it.

After discussion https://github.com/saghul/txiki.js/issues/557 with the creator of `txiki.js`, we both think that it should be the job to add the compatibility.

That's what I've added in the present PR.

Small remark, I also think that, in the future, it may be good to revisit the way `MQTT.js` determine if it can use native websocket or `Node.js` one through the `ws` module. Like checking if `WebSocket` exists in the global space, instead of trying to determine the runtime name or whatsoever sophisticated tricks.