### PR TITLE
fix(test): close open connections

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -385,7 +385,10 @@ export type OnMessageCallback = (
 export type OnPacketCallback = (packet: Packet) => void
 export type OnCloseCallback = () => void
 export type OnErrorCallback = (error: Error | ErrorWithReasonCode) => void
-export type PacketCallback = (error?: Error, packet?: Packet) => any
+export type PacketCallback = (
+	error?: Error | ErrorWithReasonCode,
+	packet?: Packet,
+) => any
 export type CloseCallback = (error?: Error) => void
 
 export interface MqttClientEventCallbacks {

--- a/src/lib/handlers/ack.ts
+++ b/src/lib/handlers/ack.ts
@@ -1,6 +1,6 @@
 // Other Socket Errors: EADDRINUSE, ECONNRESET, ENOTFOUND, ETIMEDOUT.
 
-import { PacketHandler } from '../shared'
+import { PacketHandler, ErrorWithReasonCode } from '../shared'
 
 export const ReasonCodes = {
 	0: '',
@@ -82,8 +82,10 @@ const handleAck: PacketHandler = (client, packet) => {
 			const pubackRC = packet.reasonCode
 			// Callback - we're done
 			if (pubackRC && pubackRC > 0 && pubackRC !== 16) {
-				err = new Error(`Publish error: ${ReasonCodes[pubackRC]}`)
-				err.code = pubackRC
+				err = new ErrorWithReasonCode(
+					`Publish error: ${ReasonCodes[pubackRC]}`,
+					pubackRC,
+				)
 				client['_removeOutgoingAndStoreMessage'](messageId, () => {
 					cb(err, packet)
 				})
@@ -102,8 +104,10 @@ const handleAck: PacketHandler = (client, packet) => {
 			const pubrecRC = packet.reasonCode
 
 			if (pubrecRC && pubrecRC > 0 && pubrecRC !== 16) {
-				err = new Error(`Publish error: ${ReasonCodes[pubrecRC]}`)
-				err.code = pubrecRC
+				err = new ErrorWithReasonCode(
+					`Publish error: ${ReasonCodes[pubrecRC]}`,
+					pubrecRC,
+				)
 				client['_removeOutgoingAndStoreMessage'](messageId, () => {
 					cb(err, packet)
 				})

--- a/test/abstract_client.ts
+++ b/test/abstract_client.ts
@@ -822,7 +822,6 @@ export default function abstractTest(server, config, ports) {
 						},
 					})
 				})
-
 			})
 		})
 

--- a/test/abstract_client.ts
+++ b/test/abstract_client.ts
@@ -64,6 +64,7 @@ export default function abstractTest(server, config, ports) {
 	async function beforeEachExec() {
 		await cleanMethod.closeClientAndServer()
 		await cleanMethod.executeAllMethods()
+		cleanMethod.reset({ method: { removeOnce: true } })
 	}
 
 	async function afterExec() {
@@ -720,6 +721,7 @@ export default function abstractTest(server, config, ports) {
 					outgoingStore,
 					queueQoSZero: true,
 				})
+				cleanMethod.setClient(client)
 				client.on('packetreceive', (packet) => {
 					if (packet.cmd === 'connack') {
 						setImmediate(() => {
@@ -730,7 +732,6 @@ export default function abstractTest(server, config, ports) {
 				})
 				client.publish('test', 'payload1', { qos: 2 })
 				client.publish('test', 'payload2', { qos: 2 })
-				cleanMethod.setClient(client)
 			})
 		})
 
@@ -800,6 +801,8 @@ export default function abstractTest(server, config, ports) {
 			server2.listen(ports.PORTAND72, () => {
 				client = connect(clientOptions)
 
+				cleanMethod.setClient(client)
+
 				client.once('close', () => {
 					client.once('connect', () => {
 						client.publish('test', 'payload2', { qos: 1 }, () => {
@@ -820,7 +823,6 @@ export default function abstractTest(server, config, ports) {
 					})
 				})
 
-				cleanMethod.setClient(client)
 			})
 		})
 
@@ -1170,6 +1172,8 @@ export default function abstractTest(server, config, ports) {
 					reconnectPeriod: 0,
 				})
 
+				cleanMethod.setClient(client)
+
 				client.once('connect', () => {
 					client.publish(
 						'a',
@@ -1193,8 +1197,6 @@ export default function abstractTest(server, config, ports) {
 						},
 					)
 				})
-
-				cleanMethod.setClient(client)
 			})
 		})
 
@@ -1250,6 +1252,8 @@ export default function abstractTest(server, config, ports) {
 					reconnectPeriod: 0,
 				})
 
+				cleanMethod.setClient(client)
+
 				client.once('connect', () => {
 					client.publish(
 						'a',
@@ -1273,8 +1277,6 @@ export default function abstractTest(server, config, ports) {
 						},
 					)
 				})
-
-				cleanMethod.setClient(client)
 			})
 		})
 
@@ -1787,6 +1789,8 @@ export default function abstractTest(server, config, ports) {
 					outgoingStore,
 				})
 
+				cleanMethod.setClient(client)
+
 				client.on('connect', () => {
 					if (!reconnect) {
 						client.publish('topic', 'payload1', { qos: 1 })
@@ -1806,8 +1810,6 @@ export default function abstractTest(server, config, ports) {
 						reconnect = true
 					}
 				})
-
-				cleanMethod.setClient(client)
 			})
 		})
 
@@ -3608,6 +3610,8 @@ export default function abstractTest(server, config, ports) {
 					reconnectPeriod: 100,
 				})
 
+				cleanMethod.setClient(client)
+
 				client.on('reconnect', () => {
 					reconnectEvent = true
 				})
@@ -3633,8 +3637,6 @@ export default function abstractTest(server, config, ports) {
 						done()
 					}
 				})
-
-				cleanMethod.setClient(client)
 			})
 		})
 
@@ -3691,6 +3693,8 @@ export default function abstractTest(server, config, ports) {
 					outgoingStore,
 				})
 
+				cleanMethod.setClient(client)
+
 				client.on('connect', () => {
 					if (!reconnect) {
 						client.subscribe('test', { qos: 2 }, () => {})
@@ -3701,8 +3705,6 @@ export default function abstractTest(server, config, ports) {
 					assert.strictEqual(topic, 'topic')
 					assert.strictEqual(message.toString(), 'payload')
 				})
-
-				cleanMethod.setClient(client)
 			})
 		})
 
@@ -3739,6 +3741,8 @@ export default function abstractTest(server, config, ports) {
 					reconnectPeriod: 0,
 				})
 
+				cleanMethod.setClient(client)
+
 				client.on('connect', () => {
 					client.subscribe('test', { qos: 2 }, (e) => {
 						if (!e) {
@@ -3759,8 +3763,6 @@ export default function abstractTest(server, config, ports) {
 						client.reconnect()
 					}
 				})
-
-				cleanMethod.setClient(client)
 			})
 		})
 
@@ -3803,14 +3805,14 @@ export default function abstractTest(server, config, ports) {
 					outgoingStore,
 				})
 
+				cleanMethod.setClient(client)
+
 				client.on('connect', () => {
 					if (!reconnect) {
 						client.publish('topic', 'payload', { qos: 1 })
 					}
 				})
 				client.on('error', () => {})
-
-				cleanMethod.setClient(client)
 			})
 		})
 
@@ -3853,14 +3855,14 @@ export default function abstractTest(server, config, ports) {
 					outgoingStore,
 				})
 
+				cleanMethod.setClient(client)
+
 				client.on('connect', () => {
 					if (!reconnect) {
 						client.publish('topic', 'payload', { qos: 2 })
 					}
 				})
 				client.on('error', () => {})
-
-				cleanMethod.setClient(client)
 			})
 		})
 
@@ -3908,6 +3910,8 @@ export default function abstractTest(server, config, ports) {
 					outgoingStore,
 				})
 
+				cleanMethod.setClient(client)
+
 				client.on('connect', () => {
 					if (!reconnect) {
 						client.publish(
@@ -3923,8 +3927,6 @@ export default function abstractTest(server, config, ports) {
 					}
 				})
 				client.on('error', () => {})
-
-				cleanMethod.setClient(client)
 			})
 		})
 
@@ -3995,6 +3997,8 @@ export default function abstractTest(server, config, ports) {
 					outgoingStore,
 				})
 
+				cleanMethod.setClient(client)
+
 				client['nextId'] = 65535
 
 				client.on('connect', () => {
@@ -4005,8 +4009,6 @@ export default function abstractTest(server, config, ports) {
 					}
 				})
 				client.on('error', () => {})
-
-				cleanMethod.setClient(client)
 			})
 		})
 

--- a/test/abstract_client.ts
+++ b/test/abstract_client.ts
@@ -89,7 +89,8 @@ class CleanBeforeMethod {
 
 		for (const result of results) {
 			if (result.status === 'rejected') {
-				Promise.reject(result.reason)
+				if (result.reason instanceof Error) throw result.reason
+				else throw new Error(result.reason)
 			}
 		}
 	}
@@ -702,17 +703,19 @@ export default function abstractTest(server, config, ports) {
 		it('should not interrupt messages', function _test(t, done) {
 			cleanBeforeMethod.add(async () => {
 				if (client) {
-					await new Promise<void>((resolve) => {
-						client.end(true, () => {
-							resolve()
+					await new Promise<void>((resolve, reject) => {
+						client.end(true, (err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
 
-				if (server2) {
-					await new Promise<void>((resolve) => {
-						server2.close(() => {
-							resolve()
+				if (server2?.listening) {
+					await new Promise<void>((resolve, reject) => {
+						server2.close((err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
@@ -788,17 +791,19 @@ export default function abstractTest(server, config, ports) {
 		it('should not overtake the messages stored in the level-db-store', function _test(t, done) {
 			cleanBeforeMethod.add(async () => {
 				if (client) {
-					await new Promise<void>((resolve) => {
-						client.end(true, () => {
-							resolve()
+					await new Promise<void>((resolve, reject) => {
+						client.end(true, (err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
 
-				if (server2) {
-					await new Promise<void>((resolve) => {
-						server2.close(() => {
-							resolve()
+				if (server2?.listening) {
+					await new Promise<void>((resolve, reject) => {
+						server2.close((err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
@@ -1199,17 +1204,19 @@ export default function abstractTest(server, config, ports) {
 		it('should fire a callback (qos 1) on error', function _test(t, done) {
 			cleanBeforeMethod.add(async () => {
 				if (client) {
-					await new Promise<void>((resolve) => {
-						client.end(true, () => {
-							resolve()
+					await new Promise<void>((resolve, reject) => {
+						client.end(true, (err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
 
-				if (server2) {
-					await new Promise<void>((resolve) => {
-						server2.close(() => {
-							resolve()
+				if (server2?.listening) {
+					await new Promise<void>((resolve, reject) => {
+						server2.close((err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
@@ -1290,17 +1297,19 @@ export default function abstractTest(server, config, ports) {
 		it('should fire a callback (qos 2) on error', function _test(t, done) {
 			cleanBeforeMethod.add(async () => {
 				if (client) {
-					await new Promise<void>((resolve) => {
-						client.end(true, () => {
-							resolve()
+					await new Promise<void>((resolve, reject) => {
+						client.end(true, (err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
 
-				if (server2) {
-					await new Promise<void>((resolve) => {
-						server2.close(() => {
-							resolve()
+				if (server2?.listening) {
+					await new Promise<void>((resolve, reject) => {
+						server2.close((err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
@@ -1825,17 +1834,19 @@ export default function abstractTest(server, config, ports) {
 		it('should keep message order', function _test(t, done) {
 			cleanBeforeMethod.add(async () => {
 				if (client) {
-					await new Promise<void>((resolve) => {
-						client.end(true, () => {
-							resolve()
+					await new Promise<void>((resolve, reject) => {
+						client.end(true, (err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
 
-				if (server2) {
-					await new Promise<void>((resolve) => {
-						server2.close(() => {
-							resolve()
+				if (server2?.listening) {
+					await new Promise<void>((resolve, reject) => {
+						server2.close((err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
@@ -3687,17 +3698,19 @@ export default function abstractTest(server, config, ports) {
 		it('should not resubscribe when reconnecting if suback is error', function _test(t, done) {
 			cleanBeforeMethod.add(async () => {
 				if (client) {
-					await new Promise<void>((resolve) => {
-						client.end(true, () => {
-							resolve()
+					await new Promise<void>((resolve, reject) => {
+						client.end(true, (err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
 
-				if (server2) {
-					await new Promise<void>((resolve) => {
-						server2.close(() => {
-							resolve()
+				if (server2?.listening) {
+					await new Promise<void>((resolve, reject) => {
+						server2.close((err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
@@ -3761,17 +3774,19 @@ export default function abstractTest(server, config, ports) {
 		it('should preserved incomingStore after disconnecting if clean is false', function _test(t, done) {
 			cleanBeforeMethod.add(async () => {
 				if (client) {
-					await new Promise<void>((resolve) => {
-						client.end(true, () => {
-							resolve()
+					await new Promise<void>((resolve, reject) => {
+						client.end(true, (err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
 
-				if (server2) {
-					await new Promise<void>((resolve) => {
-						server2.close(() => {
-							resolve()
+				if (server2?.listening) {
+					await new Promise<void>((resolve, reject) => {
+						server2.close((err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
@@ -3843,17 +3858,19 @@ export default function abstractTest(server, config, ports) {
 		it('should clear outgoing if close from server', function _test(t, done) {
 			cleanBeforeMethod.add(async () => {
 				if (client) {
-					await new Promise<void>((resolve) => {
-						client.end(true, () => {
-							resolve()
+					await new Promise<void>((resolve, reject) => {
+						client.end(true, (err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
 
-				if (server2) {
-					await new Promise<void>((resolve) => {
-						server2.close(() => {
-							resolve()
+				if (server2?.listening) {
+					await new Promise<void>((resolve, reject) => {
+						server2.close((err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
@@ -3915,17 +3932,19 @@ export default function abstractTest(server, config, ports) {
 		it('should resend in-flight QoS 1 publish messages from the client if clean is false', function _test(t, done) {
 			cleanBeforeMethod.add(async () => {
 				if (client) {
-					await new Promise<void>((resolve) => {
-						client.end(true, () => {
-							resolve()
+					await new Promise<void>((resolve, reject) => {
+						client.end(true, (err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
 
-				if (server2) {
-					await new Promise<void>((resolve) => {
-						server2.close(() => {
-							resolve()
+				if (server2?.listening) {
+					await new Promise<void>((resolve, reject) => {
+						server2.close((err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
@@ -3979,17 +3998,19 @@ export default function abstractTest(server, config, ports) {
 		it('should resend in-flight QoS 2 publish messages from the client if clean is false', function _test(t, done) {
 			cleanBeforeMethod.add(async () => {
 				if (client) {
-					await new Promise<void>((resolve) => {
-						client.end(true, () => {
-							resolve()
+					await new Promise<void>((resolve, reject) => {
+						client.end(true, (err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
 
-				if (server2) {
-					await new Promise<void>((resolve) => {
-						server2.close(() => {
-							resolve()
+				if (server2?.listening) {
+					await new Promise<void>((resolve, reject) => {
+						server2.close((err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
@@ -4043,17 +4064,19 @@ export default function abstractTest(server, config, ports) {
 		it('should resend in-flight QoS 2 pubrel messages from the client if clean is false', function _test(t, done) {
 			cleanBeforeMethod.add(async () => {
 				if (client) {
-					await new Promise<void>((resolve) => {
-						client.end(true, () => {
-							resolve()
+					await new Promise<void>((resolve, reject) => {
+						client.end(true, (err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
 
-				if (server2) {
-					await new Promise<void>((resolve) => {
-						server2.close(() => {
-							resolve()
+				if (server2?.listening) {
+					await new Promise<void>((resolve, reject) => {
+						server2.close((err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
@@ -4121,17 +4144,19 @@ export default function abstractTest(server, config, ports) {
 		it('should resend in-flight publish messages by published order', function _test(t, done) {
 			cleanBeforeMethod.add(async () => {
 				if (client) {
-					await new Promise<void>((resolve) => {
-						client.end(true, () => {
-							resolve()
+					await new Promise<void>((resolve, reject) => {
+						client.end(true, (err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}
 
-				if (server2) {
-					await new Promise<void>((resolve) => {
-						server2.close(() => {
-							resolve()
+				if (server2?.listening) {
+					await new Promise<void>((resolve, reject) => {
+						server2.close((err) => {
+							if (err) reject(err)
+							else resolve()
 						})
 					})
 				}

--- a/test/abstract_client.ts
+++ b/test/abstract_client.ts
@@ -8,7 +8,7 @@ import levelStore from 'mqtt-level-store'
 import Store from '../src/lib/store'
 import serverBuilder from './server_helpers_for_client_tests'
 import handlePubrel from '../src/lib/handlers/pubrel'
-import CleanMethod from './helpers/clean_method'
+import TeardownHelper from './helpers/TeardownHelper'
 import handle from '../src/lib/handlers/index'
 import handlePublish from '../src/lib/handlers/publish'
 import mqtt, {
@@ -59,18 +59,16 @@ export default function abstractTest(server, config, ports) {
 		return mqtt.connect(opts)
 	}
 
-	const cleanMethod = new CleanMethod()
+	const teardownHelper = new TeardownHelper()
 
 	async function beforeEachExec() {
-		await cleanMethod.closeClientAndServer()
-		await cleanMethod.executeAllMethods()
-		cleanMethod.reset({ method: { removeOnce: true } })
+		await teardownHelper.runAll()
+		teardownHelper.reset({ removeOnce: true })
 	}
 
 	async function afterExec() {
-		await cleanMethod.closeClientAndServer()
-		await cleanMethod.executeAllMethods()
-		cleanMethod.reset()
+		await teardownHelper.runAll()
+		teardownHelper.reset()
 	}
 
 	after(afterExec)
@@ -708,7 +706,7 @@ export default function abstractTest(server, config, ports) {
 				})
 			})
 
-			cleanMethod.setServer(server2)
+			teardownHelper.addServer(server2)
 
 			server2.listen(ports.PORTAND50, () => {
 				client = connect({
@@ -721,7 +719,7 @@ export default function abstractTest(server, config, ports) {
 					outgoingStore,
 					queueQoSZero: true,
 				})
-				cleanMethod.setClient(client)
+				teardownHelper.addClient(client)
 				client.on('packetreceive', (packet) => {
 					if (packet.cmd === 'connack') {
 						setImmediate(() => {
@@ -736,7 +734,7 @@ export default function abstractTest(server, config, ports) {
 		})
 
 		it('should not overtake the messages stored in the level-db-store', function _test(t, done) {
-			cleanMethod.add({ executeOnce: true }, async () => {
+			teardownHelper.add({ executeOnce: true }, async () => {
 				await new Promise<void>((resolve) => {
 					fs.rm(storePath, { recursive: true }, () => {
 						resolve()
@@ -785,7 +783,7 @@ export default function abstractTest(server, config, ports) {
 				})
 			})
 
-			cleanMethod.setServer(server2)
+			teardownHelper.addServer(server2)
 
 			const clientOptions = {
 				port: ports.PORTAND72,
@@ -801,7 +799,7 @@ export default function abstractTest(server, config, ports) {
 			server2.listen(ports.PORTAND72, () => {
 				client = connect(clientOptions)
 
-				cleanMethod.setClient(client)
+				teardownHelper.addClient(client)
 
 				client.once('close', () => {
 					client.once('connect', () => {
@@ -1160,7 +1158,7 @@ export default function abstractTest(server, config, ports) {
 				})
 			})
 
-			cleanMethod.setServer(server2)
+			teardownHelper.addServer(server2)
 
 			server2.listen(ports.PORTAND72, () => {
 				client = connect({
@@ -1171,7 +1169,7 @@ export default function abstractTest(server, config, ports) {
 					reconnectPeriod: 0,
 				})
 
-				cleanMethod.setClient(client)
+				teardownHelper.addClient(client)
 
 				client.once('connect', () => {
 					client.publish(
@@ -1240,7 +1238,7 @@ export default function abstractTest(server, config, ports) {
 				})
 			})
 
-			cleanMethod.setServer(server2)
+			teardownHelper.addServer(server2)
 
 			server2.listen(ports.PORTAND103, () => {
 				client = connect({
@@ -1251,7 +1249,7 @@ export default function abstractTest(server, config, ports) {
 					reconnectPeriod: 0,
 				})
 
-				cleanMethod.setClient(client)
+				teardownHelper.addClient(client)
 
 				client.once('connect', () => {
 					client.publish(
@@ -1775,7 +1773,7 @@ export default function abstractTest(server, config, ports) {
 				})
 			})
 
-			cleanMethod.setServer(server2)
+			teardownHelper.addServer(server2)
 
 			server2.listen(ports.PORTAND50, () => {
 				client = connect({
@@ -1788,7 +1786,7 @@ export default function abstractTest(server, config, ports) {
 					outgoingStore,
 				})
 
-				cleanMethod.setClient(client)
+				teardownHelper.addClient(client)
 
 				client.on('connect', () => {
 					if (!reconnect) {
@@ -3600,7 +3598,7 @@ export default function abstractTest(server, config, ports) {
 				})
 			})
 
-			cleanMethod.setServer(server2)
+			teardownHelper.addServer(server2)
 
 			server2.listen(ports.PORTAND49, () => {
 				client = connect({
@@ -3609,7 +3607,7 @@ export default function abstractTest(server, config, ports) {
 					reconnectPeriod: 100,
 				})
 
-				cleanMethod.setClient(client)
+				teardownHelper.addClient(client)
 
 				client.on('reconnect', () => {
 					reconnectEvent = true
@@ -3679,7 +3677,7 @@ export default function abstractTest(server, config, ports) {
 				})
 			})
 
-			cleanMethod.setServer(server2)
+			teardownHelper.addServer(server2)
 
 			server2.listen(ports.PORTAND50, () => {
 				client = connect({
@@ -3692,7 +3690,7 @@ export default function abstractTest(server, config, ports) {
 					outgoingStore,
 				})
 
-				cleanMethod.setClient(client)
+				teardownHelper.addClient(client)
 
 				client.on('connect', () => {
 					if (!reconnect) {
@@ -3728,7 +3726,7 @@ export default function abstractTest(server, config, ports) {
 				})
 			})
 
-			cleanMethod.setServer(server2)
+			teardownHelper.addServer(server2)
 
 			server2.listen(ports.PORTAND50, () => {
 				client = connect({
@@ -3740,7 +3738,7 @@ export default function abstractTest(server, config, ports) {
 					reconnectPeriod: 0,
 				})
 
-				cleanMethod.setClient(client)
+				teardownHelper.addClient(client)
 
 				client.on('connect', () => {
 					client.subscribe('test', { qos: 2 }, (e) => {
@@ -3791,7 +3789,7 @@ export default function abstractTest(server, config, ports) {
 				})
 			})
 
-			cleanMethod.setServer(server2)
+			teardownHelper.addServer(server2)
 
 			server2.listen(ports.PORTAND50, () => {
 				client = connect({
@@ -3804,7 +3802,7 @@ export default function abstractTest(server, config, ports) {
 					outgoingStore,
 				})
 
-				cleanMethod.setClient(client)
+				teardownHelper.addClient(client)
 
 				client.on('connect', () => {
 					if (!reconnect) {
@@ -3841,7 +3839,7 @@ export default function abstractTest(server, config, ports) {
 				})
 			})
 
-			cleanMethod.setServer(server2)
+			teardownHelper.addServer(server2)
 
 			server2.listen(ports.PORTAND50, () => {
 				client = connect({
@@ -3854,7 +3852,7 @@ export default function abstractTest(server, config, ports) {
 					outgoingStore,
 				})
 
-				cleanMethod.setClient(client)
+				teardownHelper.addClient(client)
 
 				client.on('connect', () => {
 					if (!reconnect) {
@@ -3896,7 +3894,7 @@ export default function abstractTest(server, config, ports) {
 				})
 			})
 
-			cleanMethod.setServer(server2)
+			teardownHelper.addServer(server2)
 
 			server2.listen(ports.PORTAND50, () => {
 				client = connect({
@@ -3909,7 +3907,7 @@ export default function abstractTest(server, config, ports) {
 					outgoingStore,
 				})
 
-				cleanMethod.setClient(client)
+				teardownHelper.addClient(client)
 
 				client.on('connect', () => {
 					if (!reconnect) {
@@ -3983,7 +3981,7 @@ export default function abstractTest(server, config, ports) {
 				})
 			})
 
-			cleanMethod.setServer(server2)
+			teardownHelper.addServer(server2)
 
 			server2.listen(ports.PORTAND50, () => {
 				client = connect({
@@ -3996,7 +3994,7 @@ export default function abstractTest(server, config, ports) {
 					outgoingStore,
 				})
 
-				cleanMethod.setClient(client)
+				teardownHelper.addClient(client)
 
 				client['nextId'] = 65535
 

--- a/test/helpers/TeardownHelper.ts
+++ b/test/helpers/TeardownHelper.ts
@@ -14,7 +14,7 @@ type AddOptions = {
 	executeOnce?: boolean
 }
 
-type ResetMethodOptions = {
+type ResetOptions = {
 	/**
 	 * @description
 	 * If `true`, only the methods that have the option `executeOnce` set to `true` will be removed.
@@ -22,10 +22,6 @@ type ResetMethodOptions = {
 	 * @default false
 	 */
 	removeOnce?: boolean
-}
-
-type ResetOptions = {
-	method?: ResetMethodOptions
 }
 
 /**
@@ -39,22 +35,22 @@ type ResetOptions = {
  * import { describe, it } from 'node:test'
  * import mqtt from './src'
  * import serverBuilder from './test/server_helpers_for_client_tests'
- * import CleanMethod from './test/helpers/clean_method'
+ * import TeardownHelper from './test/helpers/TeardownHelper'
  *
  *
  * describe('Test', () => {
- *     const cleanMethod = new CleanMethod()
+ *     const teardownHelper = new TeardownHelper()
  *
  *     it('should clean the client and server', (t, done) => {
  *         t.after(async () => {
- *             await cleanMethod.closeClientAndServer()
+ *             await teardownHelper.runAll()
  *         })
  *
  *         const server = serverBuilder('8883')
  *         const client = mqtt.connect('mqtt://localhost')
  *
- *         cleanMethod.setServer(server)
- *         cleanMethod.setClient(client)
+ *         teardownHelper.addServer(server)
+ *         teardownHelper.addClient(client)
  *     })
  * })
  * ```
@@ -64,15 +60,15 @@ type ResetOptions = {
  * import { describe, it, after } from 'node:test'
  * import mqtt from './src'
  * import serverBuilder from './test/server_helpers_for_client_tests'
- * import CleanMethod from './test/helpers/clean_method'
+ * import TeardownHelper from './test/helpers/TeardownHelper'
  *
  *
  * describe('Test', () => {
  *
- *     const cleanMethod = new CleanMethod()
+ *     const teardownHelper = new TeardownHelper()
  *     let server = serverBuilder('8883')
  *
- *     cleanMethod.add({}, async () => {
+ *     teardownHelper.add({}, async () => {
  *         if (server?.listening) {
  *             await new Promise<void>((resolve, reject) => {
  *                 server.close((err) => {
@@ -84,14 +80,14 @@ type ResetOptions = {
  *     })
  *
  *     after(async () => {
- *         await cleanMethod.closeAllMethods()
+ *         await teardownHelper.runAll()
  *     })
  *
  *     it('should clean the client and server', (t, done) => {
  *         server = serverBuilder('8883')
  *         const client = mqtt.connect('mqtt://localhost')
  *
- *         cleanMethod.setClient(client)
+ *         teardownHelper.addClient(client)
  *         done()
  *     })
  *
@@ -156,7 +152,7 @@ class TeardownHelper {
 	 * @description
 	 * Remove all methods stored.
 	 */
-	reset(options?: ResetMethodOptions) {
+	reset(options?: ResetOptions) {
 		if (options?.removeOnce) {
 			for (const [id, { options: methodOptions }] of this.#methods) {
 				if (methodOptions.executeOnce) {
@@ -208,7 +204,7 @@ class TeardownHelper {
 	 * @param id Method id to be executed.
 	 *
 	 * @description
-	 * Execute a method stored by its id
+	 * Execute a method stored by its id.
 	 * If the method has the option `executeOnce` set to `true`, it will be removed after execution.
 	 */
 	async run(id: string) {

--- a/test/helpers/clean_method.ts
+++ b/test/helpers/clean_method.ts
@@ -1,0 +1,311 @@
+import type { MqttClient } from 'src'
+import { randomUUID } from 'node:crypto'
+import serverBuilder from '../server_helpers_for_client_tests'
+
+type ServerBuilderInstance = ReturnType<typeof serverBuilder>
+
+type AddOptions = {
+	/**
+	 * @description
+	 * If `true`, the method will be executed only one time and then removed from the store.
+	 *
+	 * @default true
+	 */
+	executeOnce?: boolean
+}
+
+type ResetMethodOptions = {
+	/**
+	 * @description
+	 * If `true`, only the methods that have the option `executeOnce` set to `true` will be removed.
+	 *
+	 * @default false
+	 */
+	removeOnce?: boolean
+}
+
+type ResetOptions = {
+	method?: ResetMethodOptions
+}
+
+/**
+ * @description
+ * Class to help clean the environment or close opened connections after tests finish.
+ * Also, you can add custom methods to be executed after the tests finish, like
+ * deleting temporary files or closing connections.
+ *
+ * @example
+ * ```
+ * import { describe, it } from 'node:test'
+ * import mqtt from './src'
+ * import serverBuilder from './test/server_helpers_for_client_tests'
+ * import CleanMethod from './test/helpers/clean_method'
+ *
+ *
+ * describe('Test', () => {
+ *     const cleanMethod = new CleanMethod()
+ *
+ *     it('should clean the client and server', (t, done) => {
+ *         t.after(async () => {
+ *             await cleanMethod.closeClientAndServer()
+ *         })
+ *
+ *         const server = serverBuilder('8883')
+ *         const client = mqtt.connect('mqtt://localhost')
+ *
+ *         cleanMethod.setServer(server)
+ *         cleanMethod.setClient(client)
+ *     })
+ * })
+ * ```
+ *
+ * @example
+ * ```
+ * import { describe, it, after } from 'node:test'
+ * import mqtt from './src'
+ * import serverBuilder from './test/server_helpers_for_client_tests'
+ * import CleanMethod from './test/helpers/clean_method'
+ *
+ *
+ * describe('Test', () => {
+ *
+ *     const cleanMethod = new CleanMethod()
+ *     let server = serverBuilder('8883')
+ *
+ *     cleanMethod.add({}, async () => {
+ *         if (server?.listening) {
+ *             await new Promise<void>((resolve, reject) => {
+ *                 server.close((err) => {
+ *                     if (err) reject(err)
+ *                     else resolve()
+ *                 })
+ *             })
+ *         }
+ *     })
+ *
+ *     after(async () => {
+ *         await cleanMethod.closeAllMethods()
+ *     })
+ *
+ *     it('should clean the client and server', (t, done) => {
+ *         server = serverBuilder('8883')
+ *         const client = mqtt.connect('mqtt://localhost')
+ *
+ *         cleanMethod.setClient(client)
+ *         done()
+ *     })
+ *
+ * })
+ * ```
+ */
+class CleanMethod {
+	#client: MqttClient | null
+
+	#server: ServerBuilderInstance | null
+
+	#methods: Map<
+		string,
+		{
+			options: AddOptions
+			method: Promise<any> | ((...args: any[]) => Promise<any>)
+			args: any[]
+		}
+	>
+
+	constructor() {
+		this.#client = null
+		this.#server = null
+		this.#methods = new Map()
+	}
+
+	/**
+	 * @description
+	 * Set the client to be used as default to close.
+	 */
+	setClient(client: MqttClient | null) {
+		this.#client = client
+	}
+
+	/**
+	 * @description
+	 * Set the server to be used as default to close.
+	 */
+	setServer(server: ServerBuilderInstance | null) {
+		this.#server = server
+	}
+
+	/**
+	 * @param options Options to be passed to the method.
+	 * @param method It can be a promise or a function that returns a promise.
+	 * @param args Arguments to be passed to the method.
+	 *
+	 * @description
+	 * Add a method to be executed
+	 */
+	add<T extends (...args: any[]) => Promise<void>>(
+		options: AddOptions | undefined,
+		method: Promise<void> | T,
+		...args: Parameters<T>
+	): string {
+		const id = randomUUID()
+
+		this.#methods.set(id, {
+			method,
+			args,
+			options: { executeOnce: true, ...options },
+		})
+
+		return id
+	}
+
+	/**
+	 *
+	 * @description
+	 * Restart the class to its initial state.
+	 * Set the client and server to `null` and remove all methods stored.
+	 */
+	reset(options?: ResetOptions) {
+		this.#client = null
+		this.#server = null
+
+		this.resetMethods(options?.method)
+	}
+
+	/**
+	 * @description
+	 * Remove all methods stored.
+	 */
+	resetMethods(options?: ResetMethodOptions) {
+		if (options?.removeOnce) {
+			for (const [id, { options: methodOptions }] of this.#methods) {
+				if (methodOptions.executeOnce) {
+					this.#methods.delete(id)
+				}
+			}
+		} else {
+			this.#methods.clear()
+		}
+	}
+
+	/**
+	 * @description
+	 * Close the `client` connection.
+	 *
+	 * @default
+	 * Use the `client` set in the class.
+	 */
+	async closeClient(client?: MqttClient | null) {
+		const clientToClean = client ?? this.#client
+
+		if (clientToClean) {
+			await new Promise<void>((resolve, reject) => {
+				clientToClean.end(true, (err) => {
+					if (err) reject(err)
+					else resolve()
+				})
+			})
+		}
+	}
+
+	/**
+	 * @description
+	 * Close the `server` connection.
+	 *
+	 * @default
+	 * Use the `server` set in the class.
+	 */
+	async closeServer(server?: ServerBuilderInstance | null) {
+		const serverToClean = server ?? this.#server
+
+		if (serverToClean?.listening) {
+			await new Promise<void>((resolve, reject) => {
+				serverToClean.close((err) => {
+					if (err) reject(err)
+					else resolve()
+				})
+			})
+		}
+	}
+
+	/**
+	 * @description
+	 * Close the `client` and `server` connections.
+	 *
+	 * @default
+	 * Use the `client` and `server` set in the class.
+	 */
+	async closeClientAndServer(options?: {
+		client?: MqttClient | null
+		server?: ServerBuilderInstance | null
+	}) {
+		await this.closeClient(options?.client)
+		await this.closeServer(options?.server)
+	}
+
+	/**
+	 * @param id Method id to be executed.
+	 *
+	 * @description
+	 * Execute a method stored by its id
+	 * If the method has the option `executeOnce` set to `true`, it will be removed after execution.
+	 */
+	async executeMethod(id: string) {
+		const method = this.#methods.get(id)
+
+		if (!method) {
+			return
+		}
+
+		if (method.options.executeOnce) {
+			this.#methods.delete(id)
+		}
+
+		if (method.method instanceof Promise) {
+			await method.method
+		} else {
+			await method.method(...method.args)
+		}
+	}
+
+	/**
+	 * @description
+	 * Execute all methods stored.
+	 * If a method has the option `executeOnce` set to `true`, it will be removed after execution.
+	 */
+	async executeAllMethods() {
+		if (this.#methods.size === 0) {
+			return
+		}
+
+		const methods: Array<Promise<any>> = []
+
+		for (const [id, { method, options, args }] of this.#methods) {
+			if (method instanceof Promise) {
+				methods.push(method)
+			} else {
+				const promise = new Promise<any>((resolve, reject) => {
+					method(...args)
+						.then(resolve)
+						.catch(reject)
+				})
+
+				methods.push(promise)
+			}
+
+			if (options.executeOnce) {
+				this.#methods.delete(id)
+			}
+		}
+
+		const results = await Promise.allSettled(methods)
+
+		for (const result of results) {
+			if (result.status === 'rejected') {
+				if (result.reason instanceof Error) throw result.reason
+				else throw new Error(result.reason)
+			}
+		}
+	}
+}
+
+export default CleanMethod


### PR DESCRIPTION
Improve the logic of close open connections when you instance a `serverBuilder` class or open a new connection using `client`. Call method `assert` interrupts the test and the method `after` will never called generating that the connections haven't closed yet will still open and other unit test will throw a error like `Error: listen EADDRINUSE: address already in use`.

This PR also remove the temp folders and files generated by this [`test`](https://github.com/mqttjs/MQTT.js/blob/2da3b3401db1bb880801c7264a2a51dc08d50f62/test/abstract_client.ts#L717) when failed.