### PR TITLE
fix(types): unsubscribe options type

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1402,11 +1402,11 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	): Promise<Packet | undefined>
 	public unsubscribeAsync(
 		topic: string | string[],
-		opts?: IClientSubscribeOptions,
+		opts?: IClientUnsubscribeProperties,
 	): Promise<Packet | undefined>
 	public unsubscribeAsync(
 		topic: string | string[],
-		opts?: IClientSubscribeOptions,
+		opts?: IClientUnsubscribeProperties,
 	): Promise<Packet | undefined> {
 		return new Promise((resolve, reject) => {
 			this.unsubscribe(topic, opts, (err, packet) => {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -323,7 +323,7 @@ export interface IClientReconnectOptions {
 }
 export interface IClientSubscribeProperties {
 	/*
-	 *  MQTT 5.0 properies object of subscribe
+	 *  MQTT 5.0 properties object of subscribe
 	 * */
 	properties?: ISubscribePacket['properties']
 }
@@ -368,6 +368,13 @@ export type ISubscriptionMap = {
 	[topic: string]: IClientSubscribeOptions
 } & {
 	resubscribe?: boolean
+}
+
+export interface IClientUnsubscribeProperties {
+  /*
+   *  MQTT 5.0 properties object for unsubscribe
+   * */
+  properties?: IUnsubscribePacket['properties']
 }
 
 export { IConnackPacket, IDisconnectPacket, IPublishPacket, Packet }
@@ -1300,7 +1307,7 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	public unsubscribe(topic: string | string[]): MqttClient
 	public unsubscribe(
 		topic: string | string[],
-		opts?: IClientSubscribeOptions,
+		opts?: IClientUnsubscribeProperties,
 	): MqttClient
 	public unsubscribe(
 		topic: string | string[],
@@ -1308,12 +1315,12 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	): MqttClient
 	public unsubscribe(
 		topic: string | string[],
-		opts?: IClientSubscribeOptions,
+		opts?: IClientUnsubscribeProperties,
 		callback?: PacketCallback,
 	): MqttClient
 	public unsubscribe(
 		topic: string | string[],
-		opts?: IClientSubscribeOptions | PacketCallback,
+		opts?: IClientUnsubscribeProperties | PacketCallback,
 		callback?: PacketCallback,
 	): MqttClient {
 		if (typeof topic === 'string') {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -371,10 +371,10 @@ export type ISubscriptionMap = {
 }
 
 export interface IClientUnsubscribeProperties {
-  /*
-   *  MQTT 5.0 properties object for unsubscribe
-   * */
-  properties?: IUnsubscribePacket['properties']
+	/*
+	 *  MQTT 5.0 properties object for unsubscribe
+	 * */
+	properties?: IUnsubscribePacket['properties']
 }
 
 export { IConnackPacket, IDisconnectPacket, IPublishPacket, Packet }


### PR DESCRIPTION
https://github.com/mqttjs/MQTT.js/issues/1920

Potential concern: while this change is "accurate", there may be a backwards compatibility concern if someone is explicitly using the incorrect existing typing.  This would create a build-time error but would also notify the developer that the subscribe-related fields are useless.