### PR TITLE
bug: Invoke the unsubscribe ack callback with the Unsuback packet, not null

### DIFF
--- a/src/lib/handlers/ack.ts
+++ b/src/lib/handlers/ack.ts
@@ -144,7 +144,7 @@ const handleAck: PacketHandler = (client, packet) => {
 			delete client.outgoing[messageId]
 			client.messageIdProvider.deallocate(messageId)
 			client['_invokeStoreProcessingQueue']()
-			cb(null)
+			cb(null, packet)
 			break
 		}
 		default:


### PR DESCRIPTION
https://github.com/mqttjs/MQTT.js/issues/1512 (I cannot re-open the issue)