### PR TITLE
fix: replace deprecated `url.parse` with `new URL`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ coverage
 test/typescript/.idea/*
 test/typescript/*.js
 test/typescript/*.map
+test-store*/*
 # VS Code stuff
 **/typings/**
 .vscode/

--- a/src/lib/connect/index.ts
+++ b/src/lib/connect/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import _debug from 'debug'
-import url from 'url'
 import MqttClient, {
 	IClientOptions,
 	MqttClientEventCallbacks,

--- a/src/lib/connect/index.ts
+++ b/src/lib/connect/index.ts
@@ -61,7 +61,8 @@ function connect(
 		parsedOptions.protocol = parsedUrl.protocol as MqttProtocol
 		parsedOptions.path = parsedUrl.pathname // TODO: See note below
 		// NOTE: new URL().pathname is not the same as url.parse().path. URL.pathname does not include the query string.
-		// To make it compatible with url.parse().path, we need to append the query string to the path.
+		// To make this field align with url.parse().path, we would need to append the query string to the path as below
+		// However I am not sure if this is required or used later in the code.
 		// if (parsedUrl.search) {
 		// 	parsedOptions.path += parsedUrl.search
 		// }

--- a/src/lib/connect/ws.ts
+++ b/src/lib/connect/ws.ts
@@ -19,7 +19,21 @@ const WSS_OPTIONS = [
 ]
 
 function buildUrl(opts: IClientOptions, client: MqttClient) {
-	let url = `${opts.protocol}://${opts.hostname}:${opts.port}${opts.path}`
+	const urlBuilder = new URL(`${opts.protocol}://${opts.host}`)
+	if (opts.port) {
+		urlBuilder.port = opts.port.toString()
+	}
+	urlBuilder.pathname = opts.path || '/'
+	Object.keys(opts.query || {}).forEach((key) => {
+		urlBuilder.searchParams.append(key, opts.query[key])
+	})
+	if (opts.username) {
+		urlBuilder.username = opts.username
+		if (opts.password) {
+			urlBuilder.password = opts.password.toString()
+		}
+	}
+	let url = urlBuilder.toString()
 	if (typeof opts.transformWsUrl === 'function') {
 		url = opts.transformWsUrl(url, opts, client)
 	}

--- a/test/mqtt.ts
+++ b/test/mqtt.ts
@@ -59,7 +59,7 @@ describe('mqtt', () => {
 
 			c.should.be.instanceOf(mqtt.MqttClient)
 			c.options.should.not.have.property('path')
-			c.options.should.have.property('host', '::1')
+			c.options.should.have.property('host', '[::1]')
 			c.end((err) => done(err))
 		})
 


### PR DESCRIPTION
closes #1569

Alters internal processing of connection URL. Removes `url.parse` and uses `new URL`  

This is done in a backwards compatible manor however I would recommend updating all types and function signatures to use the the `URL` object instead of a `string` (or as well as) but that may be more suited to a major bump.


NOTE: there are some TODOs in the code that need to be understood (and removed).

