### PR TITLE
docs: update Node.js Learn Event Emitter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ events.
 The `Client` class wraps a client connection to an
 MQTT broker over an arbitrary transport method (TCP, TLS,
 WebSocket, ecc).
-`Client` is an [EventEmitter](https://nodejs.dev/en/learn/the-nodejs-event-emitter/) that has it's own [events](#events)
+`Client` is an [EventEmitter](https://nodejs.org/en/learn/asynchronous-work/the-nodejs-event-emitter) that has it's own [events](#events)
 
 `Client` automatically handles the following:
 


### PR DESCRIPTION
The EventEmitter link https://nodejs.org/en/learn/the-nodejs-event-emitter/ in the Client docs is not working and the page could not be found.

Changed the link to the actual Node.js Learn Event Emitter URL https://nodejs.org/en/learn/asynchronous-work/the-nodejs-event-emitter 