### PR TITLE
fix: move protocol "clean" after merge of parsedOptions

### DIFF
--- a/src/lib/connect/index.ts
+++ b/src/lib/connect/index.ts
@@ -79,10 +79,7 @@ function connect(
 			throw new Error('Missing protocol')
 		}
 
-    opts.protocol = opts.protocol.replace(
-      /:$/,
-      '',
-    ) as MqttProtocol
+		opts.protocol = opts.protocol.replace(/:$/, '') as MqttProtocol
 	}
 
 	opts.unixSocket = opts.unixSocket || opts.protocol?.includes('+unix')

--- a/src/lib/connect/index.ts
+++ b/src/lib/connect/index.ts
@@ -72,17 +72,17 @@ function connect(
 		parsedOptions.protocol = parsedUrl.protocol as MqttProtocol
 		parsedOptions.path = parsedUrl.path
 
-		parsedOptions.protocol = parsedOptions.protocol?.replace(
-			/:$/,
-			'',
-		) as MqttProtocol
-
 		opts = { ...parsedOptions, ...opts }
 
 		// when parsing an url expect the protocol to be set
 		if (!opts.protocol) {
 			throw new Error('Missing protocol')
 		}
+
+    opts.protocol = opts.protocol.replace(
+      /:$/,
+      '',
+    ) as MqttProtocol
 	}
 
 	opts.unixSocket = opts.unixSocket || opts.protocol?.includes('+unix')

--- a/test/node/mqtt.ts
+++ b/test/node/mqtt.ts
@@ -264,5 +264,19 @@ describe('mqtt', () => {
 			c.options.should.have.property('clientId', '123')
 			c.end((err) => done(err))
 		})
+
+		it('should return an MqttClient with mqtts protocol when connect is called with mqtts:/ url and protocol (mqtts:) is specified in options', function _test(t, done) {
+			const url = 'mqtts://localhost:1883'
+			const parsedUrl = new URL(url)
+			const protocol = parsedUrl.protocol as 'mqtt' | 'mqtts'
+
+			const c = mqtt.connect(url, {
+				protocol,
+			})
+
+			c.should.be.instanceOf(mqtt.MqttClient)
+			c.options.should.have.property('protocol', 'mqtts')
+			c.end((err) => done(err))
+		})
 	})
 })


### PR DESCRIPTION
With this [commit](https://github.com/mqttjs/MQTT.js/commit/1004c78db7d6763f21c98fa3db2f12e688ca33ff) the removal of the “:”, for the protocol passed in connect options, was moved before the merge of parsedOptions.

```
parsedOptions.protocol = parsedOptions.protocol?.replace(
	/:$/,
	'',
) as MqttProtocol

opts = { ...parsedOptions, ...opts }

```

Previously, if someone passed as a protocol “mqtts:” (Protocol returned by the [URL interface](https://developer.mozilla.org/en-US/docs/Web/API/URL/protocol)) this was “cleaned” by removing the “:”.

By moving the replace after the options merge, a backward compatibility is maintained for those, like me, who find themselves having to update deps in codes where the protocol was passed in by taking the value from the URL interface.

I know that the documentation as protocol values does not accept “:”, but so far it has accepted them anyway and fixed if url is passed.

I also think that if the URL interface returns the protocol in this way, it may be convenient to pass it directly without having to modify it.