### PR TITLE
docs: npm download count link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/mqttjs/MQTT.js/graphs/commit-activity)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/mqttjs/MQTT.js/pulls)
 
-[![node](https://img.shields.io/node/v/mqtt.svg) ![npm](https://img.shields.io/npm/v/mqtt.svg?logo=npm) ![NPM Downloads](https://img.shields.io/npm/dm/mqtt.svg)](https://www.npmjs.com/package/mqtt)
+[![node](https://img.shields.io/node/v/mqtt.svg) ![npm](https://img.shields.io/npm/v/mqtt.svg?logo=npm)](https://www.npmjs.com/package/mqtt)
+[![NPM Downloads](https://img.shields.io/npm/dm/mqtt.svg)](https://npm-compare.com/mqtt/#timeRange=THREE_YEARS)
 
 MQTT.js is a client library for the [MQTT](http://mqtt.org/) protocol, written
 in JavaScript for node.js and the browser.


### PR DESCRIPTION
I’d like to suggest updating the NPM Downloads badge in the README to link to the download trends page on npm-compare.com, which provides a dynamic, three-year download trend chart for [mqtt](https://npm-compare.com/mqtt/#timeRange=THREE_YEARS).

While the other badges already link to the [NPM package page](https://www.npmjs.com/package/mqtt), this particular NPM Downloads badge will benefit from linking to npm-compare.com, where users can see a more informative, visual representation of the download trends over time.

By the way, i'm a maintainer of npm-compare.com, If you need any additional features or insights from npm-compare.com, I’d be more than happy to assist.

Thanks for considering my suggestion. I look forward to your feedback!