### PR TITLE
fix: remove undefined user-properties before sending Packet

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -993,6 +993,11 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			}
 
 			if (options.protocolVersion === 5) {
+				for (const property in properties) {
+					if (properties[property] === undefined) {
+						delete properties[property]
+					}
+				}
 				packet.properties = properties
 			}
 


### PR DESCRIPTION
# Changes

- Remove `undefined` properties before sending packet

This fixes an error where the user sets a property to `undefined` which results in a `TypeError` (closes mqttjs/mqtt-packet#152).