### PR TITLE
Fix: Correct return type of `validateTopis` to include `null`

### DIFF
--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -33,7 +33,7 @@ export function validateTopic(topic: string): boolean {
  * @param {Array} topics - Array of topics
  * @returns {String} If the topics is valid, returns null. Otherwise, returns the invalid one
  */
-export function validateTopics(topics: string[]): string {
+export function validateTopics(topics: string[]): string | null {
 	if (topics.length === 0) {
 		return 'empty_topic_list'
 	}


### PR DESCRIPTION
 Updated the return type of the validateTopics function from `string` to `string | null` to accurately reflect its behavior.

What was the issue?
The function can return `null` when all topics are valid, but the original type definition for return type was `string` only, 