### PR TITLE
fix(deps): removed unused 'reinterval' dependency and move two @type/ dependencies to devDependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "5.11.0",
       "license": "MIT",
       "dependencies": {
-        "@types/readable-stream": "^4.0.18",
-        "@types/ws": "^8.5.14",
         "commist": "^3.2.0",
         "concat-stream": "^2.0.0",
         "debug": "^4.4.0",
@@ -20,7 +18,6 @@
         "mqtt-packet": "^9.0.2",
         "number-allocator": "^1.0.14",
         "readable-stream": "^4.7.0",
-        "reinterval": "^1.1.0",
         "rfdc": "^1.4.1",
         "socks": "^2.8.3",
         "split2": "^4.2.0",
@@ -37,8 +34,10 @@
         "@release-it/conventional-changelog": "^7.0.2",
         "@types/chai": "^4.3.20",
         "@types/node": "^20.17.16",
+        "@types/readable-stream": "^4.0.18",
         "@types/sinon": "^17.0.3",
         "@types/tape": "^5.8.1",
+        "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "@web/test-runner": "^0.19.0",
@@ -3623,6 +3622,7 @@
       "version": "20.17.16",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.16.tgz",
       "integrity": "sha512-vOTpLduLkZXePLxHiHsBLp98mHGnl8RptV4YAO3HfKO5UHjDvySGbxKtpYfy8Sx5+WKcgc45qNreJJRVM3L6mw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -3656,6 +3656,7 @@
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.18.tgz",
       "integrity": "sha512-21jK/1j+Wg+7jVw1xnSwy/2Q1VgVjWuFssbYGTREPUBeZ+rqVFl2udq0IkxzPC0ZhOzVceUbyIACFZKLqKEBlA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -3665,7 +3666,9 @@
     "node_modules/@types/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -3746,9 +3749,10 @@
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.14.tgz",
-      "integrity": "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -14697,11 +14701,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/reinterval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
-      "integrity": "sha1-M2Hs+jymwYKDOA3Qu5VG85D17Oc="
-    },
     "node_modules/release-it": {
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/release-it/-/release-it-16.3.0.tgz",
@@ -17144,6 +17143,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unique-string": {
@@ -20603,6 +20603,7 @@
       "version": "20.17.16",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.16.tgz",
       "integrity": "sha512-vOTpLduLkZXePLxHiHsBLp98mHGnl8RptV4YAO3HfKO5UHjDvySGbxKtpYfy8Sx5+WKcgc45qNreJJRVM3L6mw==",
+      "dev": true,
       "requires": {
         "undici-types": "~6.19.2"
       }
@@ -20635,6 +20636,7 @@
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.18.tgz",
       "integrity": "sha512-21jK/1j+Wg+7jVw1xnSwy/2Q1VgVjWuFssbYGTREPUBeZ+rqVFl2udq0IkxzPC0ZhOzVceUbyIACFZKLqKEBlA==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "safe-buffer": "~5.1.1"
@@ -20643,7 +20645,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         }
       }
     },
@@ -20723,9 +20726,10 @@
       }
     },
     "@types/ws": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.14.tgz",
-      "integrity": "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -28773,11 +28777,6 @@
         "rc": "1.2.8"
       }
     },
-    "reinterval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
-      "integrity": "sha1-M2Hs+jymwYKDOA3Qu5VG85D17Oc="
-    },
     "release-it": {
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/release-it/-/release-it-16.3.0.tgz",
@@ -30600,7 +30599,8 @@
     "undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "unique-string": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -111,8 +111,6 @@
     "net": false
   },
   "dependencies": {
-    "@types/readable-stream": "^4.0.18",
-    "@types/ws": "^8.5.14",
     "commist": "^3.2.0",
     "concat-stream": "^2.0.0",
     "debug": "^4.4.0",
@@ -122,7 +120,6 @@
     "mqtt-packet": "^9.0.2",
     "number-allocator": "^1.0.14",
     "readable-stream": "^4.7.0",
-    "reinterval": "^1.1.0",
     "rfdc": "^1.4.1",
     "socks": "^2.8.3",
     "split2": "^4.2.0",
@@ -134,8 +131,10 @@
     "@release-it/conventional-changelog": "^7.0.2",
     "@types/chai": "^4.3.20",
     "@types/node": "^20.17.16",
+    "@types/readable-stream": "^4.0.18",
     "@types/sinon": "^17.0.3",
     "@types/tape": "^5.8.1",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "@web/test-runner": "^0.19.0",


### PR DESCRIPTION
# Description

This PR resolves #1985:
- Removes the unused `reinterval` dependency.
- Moves `@types/ws` to `devDependencies` from `dependencies`.
- Moves `@types/readable-stream` to `devDependencies` from `dependencies`.