### PR TITLE
feat(exports): add react-native entry point to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   ],
   "exports": {
     ".": {
+      "react-native": "./dist/mqtt.esm.js",
       "browser": {
         "import": "./dist/mqtt.esm.js",
         "default": "./dist/mqtt.min.js"


### PR DESCRIPTION
Ref [#1983](https://github.com/mqttjs/MQTT.js/issues/1983)

This PR introduces a small change to the `package.json` file, adding a new export field for React Native compatibility.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R40): Added the `"react-native"` export field pointing to `./dist/mqtt.esm.js` to support React Native environments.