### PR TITLE
fix: Add warning when password is set without username

### DIFF
--- a/src/lib/connect/index.ts
+++ b/src/lib/connect/index.ts
@@ -99,6 +99,12 @@ function connect(
 	// merge in the auth options if supplied
 	parseAuthOptions(opts)
 
+	// if password is set without username, warn the user
+	// previously would fail silently
+	if (opts.password && !opts.username) {
+		console.warn("'password' option set without 'username' option")
+	}
+
 	// support clientId passed in the query string of the url
 	if (opts.query && typeof opts.query.clientId === 'string') {
 		opts.clientId = opts.query.clientId


### PR DESCRIPTION
Ref #1685 

This change implements a warning if a password is provided without a username in an ```IClientOptions``` object in the ```connect()``` function.

- [index.ts](https://github.com/mqttjs/MQTT.js/blob/main/src/lib/connect/index.ts): add condition after ```parseAuthOptions()``` to warn if no username has been set.