### PR TITLE
fix(connect/ws): ensure proxy stream is writable

### DIFF
--- a/src/lib/connect/ws.ts
+++ b/src/lib/connect/ws.ts
@@ -256,7 +256,7 @@ const browserStreamBuilder: StreamBuilder = (client, opts) => {
 	 * https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/message_event
 	 */
 	async function onMessage(event: MessageEvent) {
-		if (!proxy || proxy.destroyed || !proxy.readable) {
+		if (!proxy || !proxy.readable || !proxy.writable) {
 			return
 		}
 		let { data } = event


### PR DESCRIPTION
Here the proxy stream is being written, so we need to check if it is writable ("which means the stream has not been destroyed, errored, or ended, see https://nodejs.org/dist/v18.19.0/docs/api/stream.html#writablewritable ).

Fixes #1914

I could reproduce the 'stream.push() after EOF' error in an app, but unfortunately have no idea how to use it for a reproduction. Hopefully this patch provides enough inspiration to write a test.