### PR TITLE
feat: exported topic validation functions for external use

### DIFF
--- a/src/mqtt.ts
+++ b/src/mqtt.ts
@@ -24,5 +24,6 @@ export {
 }
 export * from './lib/client'
 export * from './lib/shared'
+export * from './lib/validations'
 export { ReasonCodes } from './lib/handlers/ack'
 export type { Timer } from './lib/get-timer'


### PR DESCRIPTION
This PR exposes the functions `validateTopic` and `validateTopics` so they are usable from outside the library as well.