### PR TITLE
fix(connect): path is lost when using servers

### DIFF
--- a/src/lib/connect/index.ts
+++ b/src/lib/connect/index.ts
@@ -207,6 +207,7 @@ function connect(
 
 			opts.host = opts.servers[client._reconnectCount].host
 			opts.port = opts.servers[client._reconnectCount].port
+			opts.path = opts.servers[client._reconnectCount].path
 			opts.protocol = !opts.servers[client._reconnectCount].protocol
 				? opts.defaultProtocol
 				: opts.servers[client._reconnectCount].protocol


### PR DESCRIPTION
When using `servers` option, path is not copied from server. However, this path may be needed for `ws` (and `wss`)

```js
const client = mqtt.connect({
    servers: [
        {"host":"192.168.30.1", "protocol": "mqtt", "port": 1883},
        {"host":"192.168.30.1", "protocol": "ws", "port": 8084, "path": "/mqtt"}
    ],
});
```

Say client is unable to connect using `mqtt://` and tries to fallback using `ws://`, then path will always be set to `/`. With this patch, path is copied from server to client options.