### PR TITLE
feat(mqtt5): implement re-authentication and handle auth success

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,7 +610,6 @@ Emitted when an MQTT 5 re-authentication completes successfully.
 
 Triggered after calling [`client.reauthenticate()`](#client-reauthenticate).
 
-
 ---
 
 <a name="client-connect"></a>

--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Also user can manually register topic-alias pair using PUBLISH topic:'some', ta:
 - [`mqtt.Client#removeOutgoingMessage()`](#removeOutgoingMessage)
 - [`mqtt.Client#reconnect()`](#reconnect)
 - [`mqtt.Client#reauthenticate()`](#client-reauthenticate)
+- [`mqtt.Client#reauthenticateAsync()`](#client-reauthenticate-async)
 - [`mqtt.Client#handleMessage()`](#handleMessage)
 - [`mqtt.Client#connected`](#connected)
 - [`mqtt.Client#reconnecting`](#reconnecting)
@@ -428,6 +429,8 @@ The arguments are:
     is received with an error.
   - `connectTimeout`: `30 * 1000` milliseconds, time to wait before a
     CONNACK is received
+  - `reauthTimeout`: `15 * 1000` milliseconds, time to wait for a
+    re-authentication response from the broker before failing the AUTH exchange
   - `username`: the username required by your broker, if any
   - `password`: the password required by your broker, if any
   - `socksProxy`: establish TCP and TLS connections via a socks proxy (URL, supported protocols are `socks5://`, `socks5h://`, `socks4://`, `socks4a://`)
@@ -604,11 +607,9 @@ and connections
 
 `function (packet) {}`
 
-Emitted when an MQTT 5 re-authentication completes successfully.
+Emitted when an MQTT 5 re-authentication completes successfully. Triggered after calling [`client.reauthenticate()`](#client-reauthenticate).
 
 - `packet` the AUTH packet received from the broker.
-
-Triggered after calling [`client.reauthenticate()`](#client-reauthenticate).
 
 ---
 
@@ -764,16 +765,19 @@ Start an MQTT 5 re-authentication exchange.
   - `reasonString` (`string`, optional)
   - `userProperties` (`object`, optional)
 
-- `callback` - `function (err, packet)`
-  - called when the AUTH exchange completes or fails
-
-Errors:
-- client is not connected
-- MQTT version is not 5
-- `authenticationData` is missing
-- `authenticationMethod` is missing from the initial CONNECT
+- `callback` - `function (err, packet)`, called when the AUTH exchange completes or fails.
 
 Emits `'reauth'` on successful completion.
+
+---
+
+<a name="client-reauthenticate-async"></a>
+
+### mqtt.Client#reauthenticateAsync(reauthOptions)
+
+Async [`reauthenticate`](#client-reauthenticate). Returns a `Promise<IAuthPacket>`
+that resolves with the AUTH packet from the broker on success, or rejects with
+an error on failure.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Also user can manually register topic-alias pair using PUBLISH topic:'some', ta:
 - [`mqtt.Client#endAsync()`](#end-async)
 - [`mqtt.Client#removeOutgoingMessage()`](#removeOutgoingMessage)
 - [`mqtt.Client#reconnect()`](#reconnect)
+- [`mqtt.Client#reauthenticate()`](#client-reauthenticate)
 - [`mqtt.Client#handleMessage()`](#handleMessage)
 - [`mqtt.Client#connected`](#connected)
 - [`mqtt.Client#reconnecting`](#reconnecting)
@@ -599,6 +600,17 @@ and connections
 - `packet` received packet, as defined in
   [mqtt-packet](https://github.com/mcollina/mqtt-packet)
 
+#### Event `'reauth'`
+
+`function (packet) {}`
+
+Emitted when an MQTT 5 re-authentication completes successfully.
+
+- `packet` the AUTH packet received from the broker.
+
+Triggered after calling [`client.reauthenticate()`](#client-reauthenticate).
+
+
 ---
 
 <a name="client-connect"></a>
@@ -739,6 +751,30 @@ After this function is called, the messageId is released and becomes reusable.
 ### mqtt.Client#reconnect()
 
 Connect again using the same options as connect()
+
+---
+
+<a name="client-reauthenticate"></a>
+
+### mqtt.Client#reauthenticate(reauthOptions, [callback])
+
+Start an MQTT 5 re-authentication exchange.
+
+- `reauthOptions`:
+  - `authenticationData` (`Buffer`)
+  - `reasonString` (`string`, optional)
+  - `userProperties` (`object`, optional)
+
+- `callback` - `function (err, packet)`
+  - called when the AUTH exchange completes or fails
+
+Errors:
+- client is not connected
+- MQTT version is not 5
+- `authenticationData` is missing
+- `authenticationMethod` is missing from the initial CONNECT
+
+Emits `'reauth'` on successful completion.
 
 ---
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -27,8 +27,8 @@ import DefaultMessageIdProvider, {
 } from './default-message-id-provider'
 import TopicAliasRecv from './topic-alias-recv'
 import {
+	ErrorWithReasonCode,
 	type DoneCallback,
-	type ErrorWithReasonCode,
 	ErrorWithSubackPacket,
 	type GenericCallback,
 	type IStream,
@@ -522,7 +522,8 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 
 	private connackPacket: IConnackPacket
 
-	private _reauthCallback: PacketCallback
+	/* @type {PacketCallback} - callback receives IAuthPacket */
+	private _reauthCallback: PacketCallback = null
 
 	public static defaultId() {
 		return `mqttjs_${Math.random().toString(16).substr(2, 8)}`
@@ -1683,7 +1684,7 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 
 	/**
 	 * reauthenticate - MQTT 5.0 Re-authentication
-	 * * @param {Object} reauthOptions - Re-authentication properties
+	 * @param {Object} reauthOptions - Re-authentication properties
 	 * @param {Buffer} [reauthOptions.authenticationData] - Binary data for auth exchange
 	 * @param {string} [reauthOptions.reasonString] - Human-readable reason for re-auth
 	 * @param {Object} [reauthOptions.userProperties] - Custom user properties
@@ -1697,54 +1698,31 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		>,
 		callback?: PacketCallback,
 	): MqttClient {
-		let error: Error | null = null
+		const fail = (msg: string) => {
+			const err = new Error(`reauthenticate: ${msg}`)
+			if (callback) callback(err)
+			else this.emit('error', err)
+			return this
+		}
 
 		if (this._reauthCallback) {
-			this._handleReauthCompleted(
+			this._handleReauth(
 				new Error(
 					'reauthenticate: interrupted by new reauthentication request',
 				),
 			)
 		}
 
-		if (this.options.protocolVersion !== 5) {
-			error = new Error(
-				'reauthenticate: this feature works only with mqtt-v5',
-			)
-		} else if (!this.connected) {
-			error = new Error('reauthenticate: client is not connected')
-		} else if (!reauthOptions.authenticationData) {
-			error = new Error('reauthenticate: authenticationData is required')
-		}
+		if (this.options.protocolVersion !== 5)
+			return fail('this feature works only with mqtt-v5')
+		else if (!this.connected) return fail('client is not connected')
+		else if (!reauthOptions.authenticationData)
+			return fail('authenticationData is required')
 
 		const method = this.options.properties?.authenticationMethod
 
-		if (!error && !method) {
-			error = new Error(
-				'reauthenticate: authenticationMethod is required from initial CONNECT',
-			)
-		}
-
-		if (error) {
-			if (callback) {
-				callback(error)
-			} else {
-				this.emit('error', error)
-			}
-			return this
-		}
-
-		if (
-			reauthOptions.authenticationData &&
-			Buffer.isBuffer(this.options.properties.authenticationData) &&
-			reauthOptions.authenticationData.equals(
-				this.options.properties.authenticationData,
-			)
-		) {
-			this.log(
-				'reauthenticate: sending same authenticationData as initial connection',
-			)
-		}
+		if (!method)
+			return fail('authenticationMethod is required from initial CONNECT')
 
 		const authPacket: IAuthPacket = {
 			cmd: 'auth',
@@ -1761,18 +1739,27 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	}
 
 	/**
-	 * _handleReauthCompleted
+	 * _handleReauth
 	 * Internal method to finalize the re-authentication process.
 	 * Clears the pending reauth callback and signals completion via callback or event.
 	 * @param {Error | null} err - The error if the re-authentication failed
 	 * @param {IAuthPacket} [packet] - The AUTH packet received from the broker
 	 * @api private
 	 */
-	public _handleReauthCompleted(err: Error | null, packet?: IAuthPacket) {
+	private _handleReauth(err: Error | null, packet?: IAuthPacket) {
+		if (!err && packet && packet.reasonCode !== 0) {
+			err = new ErrorWithReasonCode(
+				`Re-auth failed: ${packet.reasonCode}`,
+				packet.reasonCode,
+			)
+		}
+
 		if (this._reauthCallback) {
 			const cb = this._reauthCallback
 			this._reauthCallback = null
 			cb(err, packet)
+		} else if (err) {
+			this.emit('error', err)
 		}
 
 		if (!err && packet) {
@@ -1967,7 +1954,7 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		}
 
 		if (this._reauthCallback) {
-			this._handleReauthCompleted(new Error('client disconnected'))
+			this._handleReauth(new Error('client disconnected'))
 		}
 
 		if (!this.disconnecting && !this.reconnecting) {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -433,6 +433,7 @@ export interface MqttClientEventCallbacks {
 	reconnect: VoidCallback
 	offline: VoidCallback
 	outgoingEmpty: VoidCallback
+	reauth: OnPacketCallback
 }
 
 /**
@@ -1675,6 +1676,66 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		} else {
 			f()
 		}
+		return this
+	}
+
+	/**
+	 * reauthenticate - MQTT 5.0 Re-authentication
+	 */
+	public reauthenticate(
+		reAuthOptions: Pick<
+			NonNullable<IAuthPacket['properties']>,
+			'authenticationData' | 'reasonString' | 'userProperties'
+		>,
+		callback?: PacketCallback,
+	): MqttClient {
+		let error: Error | null = null
+
+		if (this.options.protocolVersion !== 5) {
+			error = new Error(
+				'reauthenticate: this feature works only with mqtt-v5',
+			)
+		} else if (!this.connected) {
+			error = new Error('reauthenticate: client is not connected')
+		} else if (!reAuthOptions.authenticationData) {
+			error = new Error('reauthenticate: authenticationData is required')
+		}
+
+		const method = this.options.properties?.authenticationMethod
+
+		if (!error && !method) {
+			error = new Error(
+				'reauthenticate: authenticationMethod is required from initial CONNECT',
+			)
+		}
+
+		if (error) {
+			if (callback) {
+				callback(error)
+			}
+			this.emit('error', error)
+			return this
+		}
+
+		if (
+			reAuthOptions.authenticationData ===
+			this.options.properties.authenticationData
+		) {
+			this.log(
+				'reauthenticate: sending same authenticationData as initial connection',
+			)
+		}
+
+		const authPacket: IAuthPacket = {
+			cmd: 'auth',
+			reasonCode: 0x19,
+			properties: {
+				authenticationMethod: method,
+				...reAuthOptions,
+			},
+		}
+
+		this._sendPacket(authPacket, callback)
 		return this
 	}
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1683,6 +1683,31 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	}
 
 	/**
+	 * reauthenticateAsync - MQTT 5.0 Re-authentication (Promise-based)
+	 * @param {Object} reauthOptions - Re-authentication properties
+	 * @param {Buffer} [reauthOptions.authenticationData] - Binary data for auth exchange
+	 * @param {string} [reauthOptions.reasonString] - Human-readable reason for re-auth
+	 * @param {Object} [reauthOptions.userProperties] - Custom user properties
+	 * @returns {Promise<IAuthPacket>} - Resolves with the AUTH packet from the broker
+	 */
+	public reauthenticateAsync(
+		reauthOptions: Pick<
+			NonNullable<IAuthPacket['properties']>,
+			'authenticationData' | 'reasonString' | 'userProperties'
+		>,
+	): Promise<IAuthPacket> {
+		return new Promise((resolve, reject) => {
+			this.reauthenticate(reauthOptions, (err, packet) => {
+				if (err) {
+					reject(err)
+				} else {
+					resolve(packet as IAuthPacket)
+				}
+			})
+		})
+	}
+
+	/**
 	 * reauthenticate - MQTT 5.0 Re-authentication
 	 * @param {Object} reauthOptions - Re-authentication properties
 	 * @param {Buffer} [reauthOptions.authenticationData] - Binary data for auth exchange

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -27,8 +27,8 @@ import DefaultMessageIdProvider, {
 } from './default-message-id-provider'
 import TopicAliasRecv from './topic-alias-recv'
 import {
-	type ErrorWithReasonCode,
 	type DoneCallback,
+	type ErrorWithReasonCode,
 	ErrorWithSubackPacket,
 	type GenericCallback,
 	type IStream,
@@ -180,7 +180,11 @@ export interface IClientOptions extends ISecureClientOptions {
 	 */
 	connectTimeout?: number
 	/**
-	 * 15 * 1000 milliseconds, time to wait for a re-authentication response
+	 * Maximum time (ms) to wait for the broker to complete a re-authentication
+	 * exchange after `reauthenticate()` is called. Covers the entire exchange,
+	 * including any 0x18 Continue Authentication round-trips.
+	 *
+	 * Set to 0 to disable. Default 15000.
 	 */
 	reauthTimeout?: number
 	/**
@@ -424,7 +428,10 @@ export type PacketCallback = (
 	packet?: Packet,
 ) => any
 export type CloseCallback = (error?: Error) => void
-type IAuthPacketCallback = (err?: Error | null, packet?: IAuthPacket) => void
+export type IAuthPacketCallback = (
+	err?: Error | null,
+	packet?: IAuthPacket,
+) => void
 
 export interface MqttClientEventCallbacks {
 	connect: OnConnectCallback
@@ -438,7 +445,7 @@ export interface MqttClientEventCallbacks {
 	reconnect: VoidCallback
 	offline: VoidCallback
 	outgoingEmpty: VoidCallback
-	reauth: OnPacketCallback
+	reauth: (packet: IAuthPacket) => void
 }
 
 /**
@@ -1784,9 +1791,11 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 
 		this._reauthCallback = callback
 
-		this.reauthTimer = setTimeout(() => {
-			this._finishReauth(new Error('reauthenticate: timed out'))
-		}, this.options.reauthTimeout)
+		if (this.options.reauthTimeout) {
+			this.reauthTimer = setTimeout(() => {
+				this._finishReauth(new Error('reauthenticate: timed out'))
+			}, this.options.reauthTimeout)
+		}
 
 		this._sendPacket(authPacket, (err) => {
 			if (err) this._finishReauth(err)
@@ -1802,7 +1811,7 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	 *
 	 * @param {Error | null} err - The error if the re-authentication failed
 	 * @param {IAuthPacket} [packet] - The AUTH packet received from the broker
-	 * @api public
+	 * @internal
 	 */
 	public _finishReauth(err: Error | null, packet?: IAuthPacket) {
 		clearTimeout(this.reauthTimer)
@@ -1813,14 +1822,10 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			this._reauthCallback = null
 			cb(err, packet)
 		} else if (err) {
-			if (this.listenerCount('error') > 0) {
-				this.emit('error', err)
-			} else {
-				this.log(
-					'_finishReauth :: unexpected reauth error with no pending callback. Ignoring. Error: %s',
-					err.message,
-				)
-			}
+			this.log(
+				'_finishReauth :: unexpected reauth error with no pending callback. Ignoring. Error: %s',
+				err.message,
+			)
 		}
 
 		if (!err && packet) {
@@ -2173,7 +2178,6 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			this.stream,
 			this.options,
 		)
-
 		this.log('_writePacket :: writeToStream result %s', result)
 		if (!result && cb && cb !== this.noop) {
 			this.log(

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -522,6 +522,8 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 
 	private connackPacket: IConnackPacket
 
+	private _reauthCallback: PacketCallback
+
 	public static defaultId() {
 		return `mqttjs_${Math.random().toString(16).substr(2, 8)}`
 	}
@@ -1681,9 +1683,15 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 
 	/**
 	 * reauthenticate - MQTT 5.0 Re-authentication
+	 * * @param {Object} reauthOptions - Re-authentication properties
+	 * @param {Buffer} [reauthOptions.authenticationData] - Binary data for auth exchange
+	 * @param {string} [reauthOptions.reasonString] - Human-readable reason for re-auth
+	 * @param {Object} [reauthOptions.userProperties] - Custom user properties
+	 * @param {PacketCallback} [callback] - Fired when the AUTH exchange completes or fails
+	 * @returns {MqttClient} - Returns the client instance
 	 */
 	public reauthenticate(
-		reAuthOptions: Pick<
+		reauthOptions: Pick<
 			NonNullable<IAuthPacket['properties']>,
 			'authenticationData' | 'reasonString' | 'userProperties'
 		>,
@@ -1691,13 +1699,21 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	): MqttClient {
 		let error: Error | null = null
 
+		if (this._reauthCallback) {
+			this._handleReauthCompleted(
+				new Error(
+					'reauthenticate: interrupted by new reauthentication request',
+				),
+			)
+		}
+
 		if (this.options.protocolVersion !== 5) {
 			error = new Error(
 				'reauthenticate: this feature works only with mqtt-v5',
 			)
 		} else if (!this.connected) {
 			error = new Error('reauthenticate: client is not connected')
-		} else if (!reAuthOptions.authenticationData) {
+		} else if (!reauthOptions.authenticationData) {
 			error = new Error('reauthenticate: authenticationData is required')
 		}
 
@@ -1712,14 +1728,18 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		if (error) {
 			if (callback) {
 				callback(error)
+			} else {
+				this.emit('error', error)
 			}
-			this.emit('error', error)
 			return this
 		}
 
 		if (
-			reAuthOptions.authenticationData ===
-			this.options.properties.authenticationData
+			reauthOptions.authenticationData &&
+			Buffer.isBuffer(this.options.properties.authenticationData) &&
+			reauthOptions.authenticationData.equals(
+				this.options.properties.authenticationData,
+			)
 		) {
 			this.log(
 				'reauthenticate: sending same authenticationData as initial connection',
@@ -1728,15 +1748,36 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 
 		const authPacket: IAuthPacket = {
 			cmd: 'auth',
-			reasonCode: 0x19,
+			reasonCode: 0x19, // Re-authentication (MQTT 5.0 Spec)
 			properties: {
+				...reauthOptions,
 				authenticationMethod: method,
-				...reAuthOptions,
 			},
 		}
 
-		this._sendPacket(authPacket, callback)
+		this._reauthCallback = callback
+		this._sendPacket(authPacket)
 		return this
+	}
+
+	/**
+	 * _handleReauthCompleted
+	 * Internal method to finalize the re-authentication process.
+	 * Clears the pending reauth callback and signals completion via callback or event.
+	 * @param {Error | null} err - The error if the re-authentication failed
+	 * @param {IAuthPacket} [packet] - The AUTH packet received from the broker
+	 * @api private
+	 */
+	public _handleReauthCompleted(err: Error | null, packet?: IAuthPacket) {
+		if (this._reauthCallback) {
+			const cb = this._reauthCallback
+			this._reauthCallback = null
+			cb(err, packet)
+		}
+
+		if (!err && packet) {
+			this.emit('reauth', packet)
+		}
 	}
 
 	/**
@@ -1923,6 +1964,10 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 					})
 				})
 			})
+		}
+
+		if (this._reauthCallback) {
+			this._handleReauthCompleted(new Error('client disconnected'))
 		}
 
 		if (!this.disconnecting && !this.reconnecting) {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -27,7 +27,7 @@ import DefaultMessageIdProvider, {
 } from './default-message-id-provider'
 import TopicAliasRecv from './topic-alias-recv'
 import {
-	ErrorWithReasonCode,
+	type ErrorWithReasonCode,
 	type DoneCallback,
 	ErrorWithSubackPacket,
 	type GenericCallback,
@@ -65,6 +65,7 @@ const defaultConnectOptions: IClientOptions = {
 	subscribeBatchSize: null,
 	writeCache: true,
 	timerVariant: 'auto',
+	reauthTimeout: 15 * 1000,
 }
 
 export type BaseMqttProtocol =
@@ -178,7 +179,10 @@ export interface IClientOptions extends ISecureClientOptions {
 	 * 30 * 1000 milliseconds, time to wait before a CONNACK is received
 	 */
 	connectTimeout?: number
-
+	/**
+	 * 15 * 1000 milliseconds, time to wait for a re-authentication response
+	 */
+	reauthTimeout?: number
 	/**
 	 * a Store for the incoming packets
 	 */
@@ -420,6 +424,7 @@ export type PacketCallback = (
 	packet?: Packet,
 ) => any
 export type CloseCallback = (error?: Error) => void
+type IAuthPacketCallback = (err?: Error | null, packet?: IAuthPacket) => void
 
 export interface MqttClientEventCallbacks {
 	connect: OnConnectCallback
@@ -501,6 +506,9 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 
 	private reconnectTimer: NodeJS.Timeout
 
+	/** Timer for re-authentication timeout */
+	private reauthTimer: NodeJS.Timeout
+
 	private _storeProcessing: boolean
 
 	/** keep a reference of packets that have been successfully processed from outgoing store  */
@@ -522,8 +530,7 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 
 	private connackPacket: IConnackPacket
 
-	/* @type {PacketCallback} - callback receives IAuthPacket */
-	private _reauthCallback: PacketCallback = null
+	private _reauthCallback: IAuthPacketCallback | null = null
 
 	public static defaultId() {
 		return `mqttjs_${Math.random().toString(16).substr(2, 8)}`
@@ -633,6 +640,9 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		this.connackTimer = null
 		// Reconnect timer
 		this.reconnectTimer = null
+		// Reauthenticate timer
+		this.reauthTimer = null
+
 		// Is processing store?
 		this._storeProcessing = false
 		// Packet Ids are put into the store during store processing
@@ -707,6 +717,9 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			this.log('close :: clearing connackTimer')
 			clearTimeout(this.connackTimer)
 
+			this.log('close :: clearing reauthTimer')
+			clearTimeout(this.reauthTimer)
+
 			this._destroyKeepaliveManager()
 
 			if (this.topicAliasRecv) {
@@ -715,6 +728,10 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 
 			this.log('close :: calling _setupReconnect')
 			this._setupReconnect()
+		})
+
+		this.on('error', (err) => {
+			this._cleanupPendingOperations(err)
 		})
 
 		if (!this.options.manualConnect) {
@@ -1684,11 +1701,14 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 
 	/**
 	 * reauthenticateAsync - MQTT 5.0 Re-authentication (Promise-based)
+	 *
 	 * @param {Object} reauthOptions - Re-authentication properties
-	 * @param {Buffer} [reauthOptions.authenticationData] - Binary data for auth exchange
+	 * @param {Buffer} reauthOptions.authenticationData - Binary data for auth exchange
 	 * @param {string} [reauthOptions.reasonString] - Human-readable reason for re-auth
 	 * @param {Object} [reauthOptions.userProperties] - Custom user properties
-	 * @returns {Promise<IAuthPacket>} - Resolves with the AUTH packet from the broker
+	 * @returns {Promise<IAuthPacket>} Resolves with the AUTH packet from the broker
+	 * @api public
+	 * @example const packet = await client.reauthenticateAsync({ authenticationData: Buffer.from('token') });
 	 */
 	public reauthenticateAsync(
 		reauthOptions: Pick<
@@ -1701,7 +1721,7 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 				if (err) {
 					reject(err)
 				} else {
-					resolve(packet as IAuthPacket)
+					resolve(packet)
 				}
 			})
 		})
@@ -1709,19 +1729,23 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 
 	/**
 	 * reauthenticate - MQTT 5.0 Re-authentication
+	 *
 	 * @param {Object} reauthOptions - Re-authentication properties
-	 * @param {Buffer} [reauthOptions.authenticationData] - Binary data for auth exchange
+	 * @param {Buffer} reauthOptions.authenticationData - Binary data for auth exchange
 	 * @param {string} [reauthOptions.reasonString] - Human-readable reason for re-auth
 	 * @param {Object} [reauthOptions.userProperties] - Custom user properties
-	 * @param {PacketCallback} [callback] - Fired when the AUTH exchange completes or fails
-	 * @returns {MqttClient} - Returns the client instance
+	 * @param {IAuthPacketCallback} [callback] - Fired when the AUTH exchange completes or fails
+	 * @returns {MqttClient} this - for chaining
+	 * @api public
+	 * @example client.reauthenticate({ authenticationData: Buffer.from('token') });
+	 * @example client.reauthenticate({ authenticationData: Buffer.from('token') }, console.log);
 	 */
 	public reauthenticate(
 		reauthOptions: Pick<
 			NonNullable<IAuthPacket['properties']>,
 			'authenticationData' | 'reasonString' | 'userProperties'
 		>,
-		callback?: PacketCallback,
+		callback?: IAuthPacketCallback,
 	): MqttClient {
 		const fail = (msg: string) => {
 			const err = new Error(`reauthenticate: ${msg}`)
@@ -1730,24 +1754,24 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			return this
 		}
 
-		if (this._reauthCallback) {
-			this._handleReauth(
-				new Error(
-					'reauthenticate: interrupted by new reauthentication request',
-				),
-			)
-		}
-
-		if (this.options.protocolVersion !== 5)
+		if (!reauthOptions) return fail('reauthOptions is required')
+		else if (this.options.protocolVersion !== 5)
 			return fail('this feature works only with mqtt-v5')
 		else if (!this.connected) return fail('client is not connected')
 		else if (!reauthOptions.authenticationData)
 			return fail('authenticationData is required')
 
 		const method = this.options.properties?.authenticationMethod
-
 		if (!method)
 			return fail('authenticationMethod is required from initial CONNECT')
+
+		if (this._reauthCallback) {
+			this._finishReauth(
+				new Error(
+					'reauthenticate: interrupted by new reauthentication request',
+				),
+			)
+		}
 
 		const authPacket: IAuthPacket = {
 			cmd: 'auth',
@@ -1759,32 +1783,44 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		}
 
 		this._reauthCallback = callback
-		this._sendPacket(authPacket)
+
+		this.reauthTimer = setTimeout(() => {
+			this._finishReauth(new Error('reauthenticate: timed out'))
+		}, this.options.reauthTimeout)
+
+		this._sendPacket(authPacket, (err) => {
+			if (err) this._finishReauth(err)
+		})
 		return this
 	}
 
 	/**
-	 * _handleReauth
-	 * Internal method to finalize the re-authentication process.
-	 * Clears the pending reauth callback and signals completion via callback or event.
+	 * _finishReauth - finalize the re-authentication process
+	 *
+	 * Internal method that clears the pending reauth timer and callback,
+	 * then signals completion via callback or event.
+	 *
 	 * @param {Error | null} err - The error if the re-authentication failed
 	 * @param {IAuthPacket} [packet] - The AUTH packet received from the broker
-	 * @api private
+	 * @api public
 	 */
-	private _handleReauth(err: Error | null, packet?: IAuthPacket) {
-		if (!err && packet && packet.reasonCode !== 0) {
-			err = new ErrorWithReasonCode(
-				`Re-auth failed: ${packet.reasonCode}`,
-				packet.reasonCode,
-			)
-		}
+	public _finishReauth(err: Error | null, packet?: IAuthPacket) {
+		clearTimeout(this.reauthTimer)
+		this.reauthTimer = null
 
 		if (this._reauthCallback) {
 			const cb = this._reauthCallback
 			this._reauthCallback = null
 			cb(err, packet)
 		} else if (err) {
-			this.emit('error', err)
+			if (this.listenerCount('error') > 0) {
+				this.emit('error', err)
+			} else {
+				this.log(
+					'_finishReauth :: unexpected reauth error with no pending callback. Ignoring. Error: %s',
+					err.message,
+				)
+			}
 		}
 
 		if (!err && packet) {
@@ -1979,7 +2015,10 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		}
 
 		if (this._reauthCallback) {
-			this._handleReauth(new Error('client disconnected'))
+			const message = this.disconnecting
+				? 'reauthenticate: cancelled by client.end()'
+				: 'reauthenticate: client disconnected'
+			this._finishReauth(new Error(message))
 		}
 
 		if (!this.disconnecting && !this.reconnecting) {
@@ -2134,6 +2173,7 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			this.stream,
 			this.options,
 		)
+
 		this.log('_writePacket :: writeToStream result %s', result)
 		if (!result && cb && cb !== this.noop) {
 			this.log(
@@ -2544,5 +2584,17 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			this.messageIdProvider.deallocate(messageId)
 			this._invokeStoreProcessingQueue()
 		})
+	}
+
+	/**
+	 * _cleanupPendingOperations - clean up any pending operations on error
+	 * @param {Error} err - The error that triggered cleanup
+	 * @api private
+	 */
+	private _cleanupPendingOperations(err: Error) {
+		// Clean up reauth if pending
+		if (this._reauthCallback) {
+			this._finishReauth(err)
+		}
 	}
 }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -737,10 +737,6 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			this._setupReconnect()
 		})
 
-		this.on('error', (err) => {
-			this._cleanupPendingOperations(err)
-		})
-
 		if (!this.options.manualConnect) {
 			this.log('MqttClient :: setting up stream')
 			this.connect()
@@ -1762,23 +1758,24 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		}
 
 		if (!reauthOptions) return fail('reauthOptions is required')
-		else if (this.options.protocolVersion !== 5)
+		if (this.options.protocolVersion !== 5)
 			return fail('this feature works only with mqtt-v5')
-		else if (!this.connected) return fail('client is not connected')
-		else if (!reauthOptions.authenticationData)
+		if (
+			!this.connected ||
+			this.disconnecting ||
+			this.stream.destroyed ||
+			this.stream.writableEnded
+		)
+			return fail('client is not connected')
+		if (!reauthOptions.authenticationData)
 			return fail('authenticationData is required')
 
 		const method = this.options.properties?.authenticationMethod
 		if (!method)
 			return fail('authenticationMethod is required from initial CONNECT')
 
-		if (this._reauthCallback) {
-			this._finishReauth(
-				new Error(
-					'reauthenticate: interrupted by new reauthentication request',
-				),
-			)
-		}
+		if (this._reauthCallback || this.reauthTimer)
+			return fail('a re-authentication is already in progress')
 
 		const authPacket: IAuthPacket = {
 			cmd: 'auth',
@@ -1791,14 +1788,18 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 
 		this._reauthCallback = callback
 
-		if (this.options.reauthTimeout) {
+		if (this.options.reauthTimeout > 0) {
 			this.reauthTimer = setTimeout(() => {
 				this._finishReauth(new Error('reauthenticate: timed out'))
 			}, this.options.reauthTimeout)
 		}
 
+		// _sendPacket callback reports local write completion/failure only.
+		// The broker's AUTH reply is handled separately in handlers/auth.ts via _reauthCallback.
 		this._sendPacket(authPacket, (err) => {
-			if (err) this._finishReauth(err)
+			if (err) {
+				this._finishReauth(err)
+			}
 		})
 		return this
 	}
@@ -2019,7 +2020,7 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			})
 		}
 
-		if (this._reauthCallback) {
+		if (this._reauthCallback || this.reauthTimer) {
 			const message = this.disconnecting
 				? 'reauthenticate: cancelled by client.end()'
 				: 'reauthenticate: client disconnected'
@@ -2588,17 +2589,5 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			this.messageIdProvider.deallocate(messageId)
 			this._invokeStoreProcessingQueue()
 		})
-	}
-
-	/**
-	 * _cleanupPendingOperations - clean up any pending operations on error
-	 * @param {Error} err - The error that triggered cleanup
-	 * @api private
-	 */
-	private _cleanupPendingOperations(err: Error) {
-		// Clean up reauth if pending
-		if (this._reauthCallback) {
-			this._finishReauth(err)
-		}
 	}
 }

--- a/src/lib/handlers/auth.ts
+++ b/src/lib/handlers/auth.ts
@@ -19,8 +19,8 @@ const handleAuth: PacketHandler = (
 		return
 	}
 
-	if (rc === 0) {
-		client._handleReauthCompleted(null, packet)
+	if (client.connected) {
+		client['_handleReauth'](null, packet)
 		return
 	}
 
@@ -28,8 +28,7 @@ const handleAuth: PacketHandler = (
 		packet,
 		(err: ErrorWithReasonCode, packet2: IAuthPacket) => {
 			if (err) {
-				if (client.connected) client._handleReauthCompleted(err, packet)
-				else client.emit('error', err)
+				client.emit('error', err)
 				return
 			}
 
@@ -37,21 +36,13 @@ const handleAuth: PacketHandler = (
 				client.reconnecting = false
 				client['_sendPacket'](packet2)
 			} else {
-				console.log('### DEBUGGING rc: ', rc, ' ####')
 				const error = new ErrorWithReasonCode(
 					`Connection refused: ${ReasonCodes[rc]}`,
 					rc,
 				)
-				if (client.connected) {
-					client._handleReauthCompleted(error, packet)
-				} else {
-					client.emit('error', error)
-				}
+				client.emit('error', error)
 			}
 		},
-	)
-	console.log(
-		'DEBUG 3: Finished calling handleAuth (but did the callback run?)',
 	)
 }
 

--- a/src/lib/handlers/auth.ts
+++ b/src/lib/handlers/auth.ts
@@ -2,6 +2,9 @@ import { type IAuthPacket } from 'mqtt-packet'
 import { ErrorWithReasonCode, type PacketHandler } from '../shared'
 import { ReasonCodes } from './ack'
 
+const RC_SUCCESS = 0x00
+const RC_CONTINUE = 0x18
+
 const handleAuth: PacketHandler = (
 	client,
 	packet: IAuthPacket & { returnCode: number },
@@ -19,31 +22,60 @@ const handleAuth: PacketHandler = (
 		return
 	}
 
-	if (client.connected) {
-		client['_handleReauth'](null, packet)
-		return
-	}
-
-	client.handleAuth(
-		packet,
-		(err: ErrorWithReasonCode, packet2: IAuthPacket) => {
+	const continueAuth = () => {
+		client.handleAuth(packet, (err, nextPacket) => {
 			if (err) {
 				client.emit('error', err)
 				return
 			}
 
-			if (rc === 24) {
-				client.reconnecting = false
-				client['_sendPacket'](packet2)
-			} else {
-				const error = new ErrorWithReasonCode(
+			if (!nextPacket) {
+				client.emit(
+					'error',
+					new ErrorWithReasonCode(
+						'AUTH handler did not return a packet',
+						rc,
+					),
+				)
+				return
+			}
+
+			client['_sendPacket'](nextPacket)
+		})
+	}
+
+	if (!client.connected) {
+		if (rc !== RC_CONTINUE) {
+			client.emit(
+				'error',
+				new ErrorWithReasonCode(
 					`Connection refused: ${ReasonCodes[rc]}`,
 					rc,
-				)
-				client.emit('error', error)
-			}
-		},
-	)
+				),
+			)
+			return
+		}
+
+		continueAuth()
+		return
+	}
+
+	switch (rc) {
+		case RC_SUCCESS:
+			return client._finishReauth(null, packet)
+
+		case RC_CONTINUE:
+			return continueAuth()
+
+		default:
+			return client._finishReauth(
+				new ErrorWithReasonCode(
+					`Re-auth failed: ${ReasonCodes[rc]}`,
+					rc,
+				),
+				packet,
+			)
+	}
 }
 
 export default handleAuth

--- a/src/lib/handlers/auth.ts
+++ b/src/lib/handlers/auth.ts
@@ -33,7 +33,7 @@ const handleAuth: PacketHandler = (
 				client.emit(
 					'error',
 					new ErrorWithReasonCode(
-						'AUTH handler did not return a packet',
+						'Override client.handleAuth() to use MQTT 5 enhanced authentication.',
 						rc,
 					),
 				)

--- a/src/lib/handlers/auth.ts
+++ b/src/lib/handlers/auth.ts
@@ -30,6 +30,10 @@ const handleAuth: PacketHandler = (
 			if (rc === 24) {
 				client.reconnecting = false
 				client['_sendPacket'](packet2)
+			} else if (rc === 0) {
+				if (client.connected) {
+					client.emit('reauth', packet)
+				}
 			} else {
 				const error = new ErrorWithReasonCode(
 					`Connection refused: ${ReasonCodes[rc]}`,

--- a/src/lib/handlers/auth.ts
+++ b/src/lib/handlers/auth.ts
@@ -56,6 +56,7 @@ const handleAuth: PacketHandler = (
 			return
 		}
 
+		client.reconnecting = false
 		continueAuth()
 		return
 	}

--- a/src/lib/handlers/auth.ts
+++ b/src/lib/handlers/auth.ts
@@ -19,29 +19,39 @@ const handleAuth: PacketHandler = (
 		return
 	}
 
+	if (rc === 0) {
+		client._handleReauthCompleted(null, packet)
+		return
+	}
+
 	client.handleAuth(
 		packet,
 		(err: ErrorWithReasonCode, packet2: IAuthPacket) => {
 			if (err) {
-				client.emit('error', err)
+				if (client.connected) client._handleReauthCompleted(err, packet)
+				else client.emit('error', err)
 				return
 			}
 
 			if (rc === 24) {
 				client.reconnecting = false
 				client['_sendPacket'](packet2)
-			} else if (rc === 0) {
-				if (client.connected) {
-					client.emit('reauth', packet)
-				}
 			} else {
+				console.log('### DEBUGGING rc: ', rc, ' ####')
 				const error = new ErrorWithReasonCode(
 					`Connection refused: ${ReasonCodes[rc]}`,
 					rc,
 				)
-				client.emit('error', error)
+				if (client.connected) {
+					client._handleReauthCompleted(error, packet)
+				} else {
+					client.emit('error', error)
+				}
 			}
 		},
+	)
+	console.log(
+		'DEBUG 3: Finished calling handleAuth (but did the callback run?)',
 	)
 }
 

--- a/test/node/client_mqtt5.ts
+++ b/test/node/client_mqtt5.ts
@@ -1636,7 +1636,7 @@ describe('MQTT 5.0', () => {
 			function (t, done) {
 				const port = ports.PORTAND327 + 25
 
-				const FAILING_RC = 0x87
+				const FAILING_RC = 0x19
 				const testServer = serverBuilder('mqtt', (serverClient) => {
 					serverClient.on('connect', () => {
 						serverClient.connack({ reasonCode: 0 })
@@ -1664,7 +1664,7 @@ describe('MQTT 5.0', () => {
 						{ authenticationData: Buffer.from('test') },
 						(err, packet: IAuthPacket) => {
 							assert.ok(err)
-							assert.ok(!packet)
+							assert.strictEqual(packet.reasonCode, FAILING_RC)
 							client.end(true, () => testServer.close(done))
 						},
 					)
@@ -1842,6 +1842,7 @@ describe('MQTT 5.0', () => {
 				})
 			},
 		)
+
 		it(
 			'should error if reauthenticate times out',
 			{ timeout: 5000 },
@@ -1905,6 +1906,96 @@ describe('MQTT 5.0', () => {
 						client.end(true, () => testServer.close(done))
 					})
 				})
+			},
+		)
+
+		it(
+			'reauthenticateAsync resolves with the broker AUTH packet on success',
+			{ timeout: 15000 },
+			async function _test(t) {
+				const port = ports.PORTAND327 + 31
+				const newToken = Buffer.from('async-new-token')
+
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () => {
+						serverClient.connack({ reasonCode: 0 })
+					})
+
+					serverClient.on('auth', (packet) => {
+						assert.strictEqual(packet.reasonCode, 0x19)
+						assert.ok(
+							packet.properties.authenticationData.equals(
+								newToken,
+							),
+						)
+						serverClient.auth({ reasonCode: 0 })
+					})
+				}).listen(port)
+
+				const client = mqtt.connect({
+					port,
+					protocolVersion: 5,
+					properties: { authenticationMethod: 'test' },
+				})
+
+				await new Promise<void>((resolve) =>
+					client.once('connect', () => resolve()),
+				)
+
+				const packet = await client.reauthenticateAsync({
+					authenticationData: newToken,
+				})
+
+				assert.strictEqual(packet.reasonCode, 0)
+
+				await new Promise<void>((resolve) =>
+					client.end(true, () => testServer.close(() => resolve())),
+				)
+			},
+		)
+
+		it(
+			'reauthenticateAsync rejects when broker returns a non-zero reason code',
+			{ timeout: 15000 },
+			async function _test(t) {
+				const port = ports.PORTAND327 + 32
+				const FAILING_RC = 0x19
+
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () => {
+						serverClient.connack({ reasonCode: 0 })
+					})
+
+					serverClient.on('auth', () => {
+						serverClient.auth({ reasonCode: FAILING_RC })
+					})
+				}).listen(port)
+
+				const client = mqtt.connect({
+					port,
+					protocolVersion: 5,
+					properties: { authenticationMethod: 'test' },
+				})
+
+				await new Promise<void>((resolve) =>
+					client.once('connect', () => resolve()),
+				)
+
+				let error = false
+				try {
+					await client.reauthenticateAsync({
+						authenticationData: Buffer.from('test'),
+					})
+				} catch (err) {
+					error = true
+					assert.isTrue(err.message.includes('Re-auth failed'))
+				}
+
+				assert.isTrue(error)
+
+				await new Promise<void>((resolve) =>
+					client.end(true, () => testServer.close(() => resolve())),
+				)
 			},
 		)
 	})

--- a/test/node/client_mqtt5.ts
+++ b/test/node/client_mqtt5.ts
@@ -1391,6 +1391,117 @@ describe('MQTT 5.0', () => {
 	)
 
 	it(
+		'should successfully reauthenticate with the broker',
+		{
+			timeout: 15000,
+		},
+		function (t, done) {
+			const port = ports.PORTAND103 + 92
+			const authMethod = 'GS-AUTH'
+
+			const testServer = serverBuilder('mqtt', (serverClient) => {
+				serverClient.on('connect', () => {
+					serverClient.connack({ reasonCode: 0 })
+				})
+
+				serverClient.on('auth', (packet) => {
+					if (packet.properties.authenticationMethod === authMethod) {
+						serverClient.auth({ reasonCode: 0 })
+					}
+				})
+			}).listen(port)
+
+			const client = mqtt.connect({
+				port: port,
+				protocolVersion: 5,
+				properties: {
+					authenticationMethod: authMethod,
+				},
+			})
+
+			client.on('connect', () => {
+				client.reauthenticate({
+					authenticationData: Buffer.from('initial-token'),
+				})
+			})
+
+			client.on('reauth', (packet: any) => {
+				assert.strictEqual(packet.reasonCode, 0)
+				client.end(true, () => testServer.close(done))
+			})
+		},
+	)
+
+	it(
+		'should emit an error if reauthenticate is called on a non-v5 connection',
+		{
+			timeout: 15000,
+		},
+		function (t, done) {
+			const port = ports.PORTAND103 + 90
+			const testServer = serverBuilder('mqtt', (serverClient) => {
+				serverClient.on('connect', () =>
+					serverClient.connack({ returnCode: 0 }),
+				)
+			}).listen(port)
+
+			const client = mqtt.connect({
+				port: port,
+				protocolVersion: 4,
+			})
+
+			client.on('error', (err) => {
+				try {
+					assert.ok(err.message.includes('works only with mqtt-v5'))
+					client.end(true, () => testServer.close(done))
+				} catch (assertErr) {
+					done(assertErr)
+				}
+			})
+
+			client.on('connect', () => {
+				client.reauthenticate({
+					authenticationData: Buffer.from('test'),
+				})
+			})
+		},
+	)
+
+	it(
+		'should emit an error if reauthenticate is called without an initial authenticationMethod',
+		{
+			timeout: 15000,
+		},
+		function (t, done) {
+			const port = ports.PORTAND103 + 91
+			const testServer = serverBuilder('mqtt', (serverClient) => {
+				serverClient.on('connect', () =>
+					serverClient.connack({ reasonCode: 0 }),
+				)
+			}).listen(port)
+
+			const client = mqtt.connect({
+				port: port,
+				protocolVersion: 5,
+				// Missing authenticationMethod
+			})
+
+			client.on('error', (err) => {
+				assert.ok(
+					err.message.includes('authenticationMethod is required'),
+				)
+				client.end(true, () => testServer.close(done))
+			})
+
+			client.on('connect', () => {
+				client.reauthenticate({
+					authenticationData: Buffer.from('test'),
+				})
+			})
+		},
+	)
+
+	it(
 		'pubrec handling custom invalid reason code',
 		{
 			timeout: 15000,

--- a/test/node/client_mqtt5.ts
+++ b/test/node/client_mqtt5.ts
@@ -1486,7 +1486,10 @@ describe('MQTT 5.0', () => {
 						(err, packet: IAuthPacket) => {
 							assert.ifError(err)
 							assert.strictEqual(packet.reasonCode, 0)
-							client.end(true, () => testServer.close(done))
+							client.once('reauth', (packet) => {
+								assert.strictEqual(packet.reasonCode, 0)
+								client.end(true, () => testServer.close(done))
+							})
 						},
 					)
 				})
@@ -1672,23 +1675,30 @@ describe('MQTT 5.0', () => {
 			},
 		)
 
-		it('should interrupt a pending reauthentication with a new request', function (t, done) {
+		it('should reject a second reauthentication while the first is in progress', function (t, done) {
 			const port = ports.PORTAND327 + 26
 			let authPacketCount = 0
-			let lastAuthData = null
-			let firstCallbackErr = null
+			let firstCallbackErr: Error | null = null
+			let secondCallbackErr: Error | null = null
+			let firstCallbackPacket: IAuthPacket | null = null
 
 			const testServer = serverBuilder('mqtt', (serverClient) => {
 				serverClient.on('connect', () =>
 					serverClient.connack({ reasonCode: 0 }),
 				)
+
 				serverClient.on('auth', (packet) => {
 					authPacketCount++
-					lastAuthData =
-						packet.properties?.authenticationData?.toString()
-					if (lastAuthData === 'second') {
+
+					assert.strictEqual(
+						packet.properties?.authenticationData?.toString(),
+						'first',
+					)
+
+					// Delay response so first reauth stays in progress
+					setTimeout(() => {
 						serverClient.auth({ reasonCode: 0x00 })
-					}
+					}, 50)
 				})
 			}).listen(port)
 
@@ -1701,39 +1711,34 @@ describe('MQTT 5.0', () => {
 			client.on('connect', () => {
 				client.reauthenticate(
 					{ authenticationData: Buffer.from('first') },
-					(err) => {
+					(err, packet) => {
 						firstCallbackErr = err
+						firstCallbackPacket = packet
 					},
 				)
 
 				client.reauthenticate(
 					{ authenticationData: Buffer.from('second') },
-					(err, packet) => {
-						assert.ok(
-							firstCallbackErr,
-							'first callback should have errored',
-						)
+					(err) => {
+						secondCallbackErr = err
+
+						assert.ok(secondCallbackErr)
 						assert.strictEqual(
-							firstCallbackErr.message,
-							'reauthenticate: interrupted by new reauthentication request',
+							secondCallbackErr.message,
+							'reauthenticate: a re-authentication is already in progress',
 						)
 
-						assert.ifError(err)
-						assert.strictEqual(packet.reasonCode, 0x00)
-
-						assert.strictEqual(
-							authPacketCount,
-							2,
-							'broker should have received both AUTH packets',
-						)
-
-						assert.strictEqual(
-							lastAuthData,
-							'second',
-							'server should receive second AUTH with authenticationData=second',
-						)
-
-						client.end(true, () => testServer.close(done))
+						// Wait long enough for first reauth callback to complete
+						setTimeout(() => {
+							assert.ifError(firstCallbackErr)
+							assert.ok(firstCallbackPacket)
+							assert.strictEqual(
+								firstCallbackPacket.reasonCode,
+								0x00,
+							)
+							assert.strictEqual(authPacketCount, 1)
+							client.end(true, () => testServer.close(done))
+						}, 100)
 					},
 				)
 			})
@@ -1829,8 +1834,54 @@ describe('MQTT 5.0', () => {
 					},
 				})
 
+				client.once('connect', () => {
+					const originalWritePacket = (client as any)._writePacket
+
+					;(client as any)._writePacket = function (_packet, cb) {
+						cb?.(new Error('simulated _writePacket failure'))
+					}
+
+					client.reauthenticate(
+						{ authenticationData: Buffer.from('test') },
+						(err) => {
+							;(client as any)._writePacket = originalWritePacket
+
+							assert.ok(err)
+							assert.strictEqual(
+								err.message,
+								'simulated _writePacket failure',
+							)
+
+							client.end(true, () => testServer.close(done))
+						},
+					)
+				})
+			},
+		)
+
+		it(
+			'should error if reauthenticate is called after client.end()',
+			{ timeout: 15000 },
+			function (t, done) {
+				const port = ports.PORTAND327 + 29
+
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () => {
+						serverClient.connack({ reasonCode: 0 })
+					})
+				}).listen(port)
+
+				const client = mqtt.connect({
+					port,
+					protocolVersion: 5,
+					reconnectPeriod: 0,
+					properties: {
+						authenticationMethod: 'test',
+					},
+				})
+
 				client.on('connect', () => {
-					client.stream.end()
+					client.end()
 
 					client.reauthenticate(
 						{ authenticationData: Buffer.from('test') },
@@ -1847,7 +1898,7 @@ describe('MQTT 5.0', () => {
 			'should error if reauthenticate times out',
 			{ timeout: 5000 },
 			function (t, done) {
-				const port = ports.PORTAND327 + 29
+				const port = ports.PORTAND327 + 30
 
 				const testServer = serverBuilder('mqtt', (serverClient) => {
 					serverClient.on('connect', () => {
@@ -1882,7 +1933,7 @@ describe('MQTT 5.0', () => {
 			'should error if reauthenticate is called with null options',
 			{ timeout: 5000 },
 			function (t, done) {
-				const port = ports.PORTAND327 + 30
+				const port = ports.PORTAND327 + 31
 
 				const testServer = serverBuilder('mqtt', (serverClient) => {
 					serverClient.on('connect', () =>
@@ -1913,7 +1964,7 @@ describe('MQTT 5.0', () => {
 			'reauthenticateAsync resolves with the broker AUTH packet on success',
 			{ timeout: 15000 },
 			async function _test(t) {
-				const port = ports.PORTAND327 + 31
+				const port = ports.PORTAND327 + 32
 				const newToken = Buffer.from('async-new-token')
 
 				const testServer = serverBuilder('mqtt', (serverClient) => {
@@ -1958,7 +2009,7 @@ describe('MQTT 5.0', () => {
 			'reauthenticateAsync rejects when broker returns a non-zero reason code',
 			{ timeout: 15000 },
 			async function _test(t) {
-				const port = ports.PORTAND327 + 32
+				const port = ports.PORTAND327 + 33
 				const FAILING_RC = 0x19
 
 				const testServer = serverBuilder('mqtt', (serverClient) => {

--- a/test/node/client_mqtt5.ts
+++ b/test/node/client_mqtt5.ts
@@ -5,6 +5,7 @@ import { MqttServer } from './server'
 import serverBuilder from './server_helpers_for_client_tests'
 import getPorts from './helpers/port_list'
 import mqtt, { type ErrorWithReasonCode } from '../../src'
+import { type IAuthPacket } from 'mqtt-packet'
 
 const ports = getPorts(1)
 
@@ -1391,117 +1392,6 @@ describe('MQTT 5.0', () => {
 	)
 
 	it(
-		'should successfully reauthenticate with the broker',
-		{
-			timeout: 15000,
-		},
-		function (t, done) {
-			const port = ports.PORTAND103 + 92
-			const authMethod = 'GS-AUTH'
-
-			const testServer = serverBuilder('mqtt', (serverClient) => {
-				serverClient.on('connect', () => {
-					serverClient.connack({ reasonCode: 0 })
-				})
-
-				serverClient.on('auth', (packet) => {
-					if (packet.properties.authenticationMethod === authMethod) {
-						serverClient.auth({ reasonCode: 0 })
-					}
-				})
-			}).listen(port)
-
-			const client = mqtt.connect({
-				port: port,
-				protocolVersion: 5,
-				properties: {
-					authenticationMethod: authMethod,
-				},
-			})
-
-			client.on('connect', () => {
-				client.reauthenticate({
-					authenticationData: Buffer.from('initial-token'),
-				})
-			})
-
-			client.on('reauth', (packet: any) => {
-				assert.strictEqual(packet.reasonCode, 0)
-				client.end(true, () => testServer.close(done))
-			})
-		},
-	)
-
-	it(
-		'should emit an error if reauthenticate is called on a non-v5 connection',
-		{
-			timeout: 15000,
-		},
-		function (t, done) {
-			const port = ports.PORTAND103 + 90
-			const testServer = serverBuilder('mqtt', (serverClient) => {
-				serverClient.on('connect', () =>
-					serverClient.connack({ returnCode: 0 }),
-				)
-			}).listen(port)
-
-			const client = mqtt.connect({
-				port: port,
-				protocolVersion: 4,
-			})
-
-			client.on('error', (err) => {
-				try {
-					assert.ok(err.message.includes('works only with mqtt-v5'))
-					client.end(true, () => testServer.close(done))
-				} catch (assertErr) {
-					done(assertErr)
-				}
-			})
-
-			client.on('connect', () => {
-				client.reauthenticate({
-					authenticationData: Buffer.from('test'),
-				})
-			})
-		},
-	)
-
-	it(
-		'should emit an error if reauthenticate is called without an initial authenticationMethod',
-		{
-			timeout: 15000,
-		},
-		function (t, done) {
-			const port = ports.PORTAND103 + 91
-			const testServer = serverBuilder('mqtt', (serverClient) => {
-				serverClient.on('connect', () =>
-					serverClient.connack({ reasonCode: 0 }),
-				)
-			}).listen(port)
-
-			const client = mqtt.connect({
-				port: port,
-				protocolVersion: 5,
-				// Missing authenticationMethod
-			})
-
-			client.on('error', (err) => {
-				assert.ok(
-					err.message.includes('authenticationMethod is required'),
-				)
-				client.end(true, () => testServer.close(done))
-			})
-
-			client.on('connect', () => {
-				client.reauthenticate({
-					authenticationData: Buffer.from('test'),
-				})
-			})
-		},
-	)
-
-	it(
 		'pubrec handling custom invalid reason code',
 		{
 			timeout: 15000,
@@ -1549,4 +1439,189 @@ describe('MQTT 5.0', () => {
 			})
 		},
 	)
+
+	describe('reauthenticate', () => {
+		it(
+			'should successfully reauthenticate with a new token',
+			{ timeout: 15000 },
+			function (t, done) {
+				const port = ports.PORTAND327 + 20
+				const authMethod = 'GS-AUTH'
+				const initialToken = Buffer.from('initial-token')
+				const newToken = Buffer.from('new-refreshed-token')
+
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', (packet) => {
+						assert.ok(
+							packet.properties.authenticationData.equals(
+								initialToken,
+							),
+						)
+						serverClient.connack({ reasonCode: 0 })
+					})
+
+					serverClient.on('auth', (packet) => {
+						assert.strictEqual(packet.reasonCode, 0x19)
+						assert.ok(
+							packet.properties.authenticationData.equals(
+								newToken,
+							),
+						)
+						serverClient.auth({ reasonCode: 0 })
+					})
+				}).listen(port)
+
+				const client = mqtt.connect({
+					port,
+					protocolVersion: 5,
+					properties: {
+						authenticationMethod: authMethod,
+						authenticationData: initialToken,
+					},
+				})
+
+				client.on('connect', () => {
+					client.reauthenticate(
+						{ authenticationData: newToken },
+						(err, packet: IAuthPacket) => {
+							assert.ifError(err)
+							assert.strictEqual(packet.reasonCode, 0)
+							client.end(true, () => testServer.close(done))
+						},
+					)
+				})
+			},
+		)
+
+		it(
+			'should error if reauthenticate is called while disconnected',
+			{ timeout: 15000 },
+			function (t, done) {
+				const port = ports.PORTAND327 + 21
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () =>
+						serverClient.connack({ reasonCode: 0 }),
+					)
+				}).listen(port)
+
+				const client = mqtt.connect({ port, protocolVersion: 5 })
+
+				client.reauthenticate(
+					{ authenticationData: Buffer.from('test') },
+					(err) => {
+						assert.ok(err)
+						assert.strictEqual(
+							err.message,
+							'reauthenticate: client is not connected',
+						)
+						client.end(true, () => testServer.close(done))
+					},
+				)
+			},
+		)
+
+		it(
+			'should return an error if reauthenticate is called on a non-v5 connection',
+			{ timeout: 15000 },
+			function (t, done) {
+				const port = ports.PORTAND327 + 22
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () =>
+						serverClient.connack({ returnCode: 0 }),
+					)
+				}).listen(port)
+
+				const client = mqtt.connect({ port, protocolVersion: 4 })
+
+				client.on('connect', () => {
+					client.reauthenticate(
+						{ authenticationData: Buffer.from('test') },
+						(err) => {
+							assert.ok(err)
+							assert.ok(
+								err.message.includes('works only with mqtt-v5'),
+							)
+							client.end(true, () => testServer.close(done))
+						},
+					)
+				})
+			},
+		)
+
+		it('should not crash if reauthenticate is called without a callback', function (t, done) {
+			const port = ports.PORTAND327 + 23
+			const testServer = serverBuilder('mqtt', (serverClient) => {
+				serverClient.on('connect', () =>
+					serverClient.connack({ reasonCode: 0 }),
+				)
+				serverClient.on('auth', () => {
+					serverClient.auth({ reasonCode: 0 })
+					client.end(true, () => testServer.close(done))
+				})
+			}).listen(port)
+
+			const client = mqtt.connect({
+				port,
+				protocolVersion: 5,
+				properties: { authenticationMethod: 'test' },
+			})
+
+			client.on('connect', () => {
+				client.reauthenticate({
+					authenticationData: Buffer.from('test'),
+				})
+			})
+		})
+
+		it(
+			'should error if reauthenticate is called without an initial authenticationMethod',
+			{ timeout: 15000 },
+			function (t, done) {
+				const port = ports.PORTAND327 + 24
+
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () =>
+						serverClient.connack({ reasonCode: 0 }),
+					)
+				}).listen(port, () => {
+					const client = mqtt.connect({
+						port,
+						protocolVersion: 5,
+					})
+
+					client.on('connect', () => {
+						client.reauthenticate(
+							{ authenticationData: Buffer.from('test') },
+							(err) => {
+								assert.ok(err)
+								assert.strictEqual(
+									err.message,
+									'reauthenticate: authenticationMethod is required from initial CONNECT',
+								)
+
+								client.end(true, () => {
+									client.stream?.destroy?.()
+
+									testServer.close(() => {
+										done()
+									})
+								})
+							},
+						)
+					})
+
+					client.on('error', (err) => {
+						client.removeAllListeners()
+
+						try {
+							client.end(true)
+							client.stream?.destroy?.()
+						} catch {}
+
+						testServer.close(() => done(err))
+					})
+				})
+			},
+		)
+	})
 })

--- a/test/node/client_mqtt5.ts
+++ b/test/node/client_mqtt5.ts
@@ -1504,19 +1504,27 @@ describe('MQTT 5.0', () => {
 					)
 				}).listen(port)
 
-				const client = mqtt.connect({ port, protocolVersion: 5 })
+				const client = mqtt.connect({
+					port,
+					protocolVersion: 5,
+					properties: { authenticationMethod: 'test' },
+				})
 
-				client.reauthenticate(
-					{ authenticationData: Buffer.from('test') },
-					(err) => {
-						assert.ok(err)
-						assert.strictEqual(
-							err.message,
-							'reauthenticate: client is not connected',
+				client.once('connect', () => {
+					client.end(true, () => {
+						client.reauthenticate(
+							{ authenticationData: Buffer.from('test') },
+							(err) => {
+								assert.ok(err)
+								assert.strictEqual(
+									err.message,
+									'reauthenticate: client is not connected',
+								)
+								testServer.close(done)
+							},
 						)
-						client.end(true, () => testServer.close(done))
-					},
-				)
+					})
+				})
 			},
 		)
 
@@ -1538,8 +1546,9 @@ describe('MQTT 5.0', () => {
 						{ authenticationData: Buffer.from('test') },
 						(err) => {
 							assert.ok(err)
-							assert.ok(
-								err.message.includes('works only with mqtt-v5'),
+							assert.strictEqual(
+								err.message,
+								'reauthenticate: this feature works only with mqtt-v5',
 							)
 							client.end(true, () => testServer.close(done))
 						},
@@ -1613,27 +1622,9 @@ describe('MQTT 5.0', () => {
 									err.message,
 									'reauthenticate: authenticationMethod is required from initial CONNECT',
 								)
-
-								client.end(true, () => {
-									client.stream?.destroy?.()
-
-									testServer.close(() => {
-										done()
-									})
-								})
+								client.end(true, () => testServer.close(done))
 							},
 						)
-					})
-
-					client.on('error', (err) => {
-						client.removeAllListeners()
-
-						try {
-							client.end(true)
-							client.stream?.destroy?.()
-						} catch {}
-
-						testServer.close(() => done(err))
 					})
 				})
 			},
@@ -1643,8 +1634,9 @@ describe('MQTT 5.0', () => {
 			'should error if broker returns a non-zero reason code',
 			{ timeout: 15000 },
 			function (t, done) {
-				const port = ports.PORTAND327 + 82
+				const port = ports.PORTAND327 + 25
 
+				const FAILING_RC = 0x87
 				const testServer = serverBuilder('mqtt', (serverClient) => {
 					serverClient.on('connect', () => {
 						serverClient.connack({ reasonCode: 0 })
@@ -1657,19 +1649,13 @@ describe('MQTT 5.0', () => {
 								Buffer.from('test'),
 							),
 						)
-
-						setImmediate(() => {
-							if (serverClient.writable) {
-								serverClient.auth({ reasonCode: 0x18 })
-							}
-						})
+						serverClient.auth({ reasonCode: FAILING_RC })
 					})
 				}).listen(port)
 
 				const client = mqtt.connect({
 					port,
 					protocolVersion: 5,
-					keepalive: 0,
 					properties: { authenticationMethod: 'test' },
 				})
 
@@ -1678,17 +1664,7 @@ describe('MQTT 5.0', () => {
 						{ authenticationData: Buffer.from('test') },
 						(err, packet: IAuthPacket) => {
 							assert.ok(err)
-							assert.ok(packet)
-							assert.strictEqual(packet.reasonCode, 0x18)
-							assert.ok(
-								String(err.message)
-									.toLowerCase()
-									.includes('re-auth failed') ||
-									String(err.message)
-										.toLowerCase()
-										.includes('24'),
-							)
-
+							assert.ok(!packet)
 							client.end(true, () => testServer.close(done))
 						},
 					)
@@ -1698,10 +1674,22 @@ describe('MQTT 5.0', () => {
 
 		it('should interrupt a pending reauthentication with a new request', function (t, done) {
 			const port = ports.PORTAND327 + 26
+			let authPacketCount = 0
+			let lastAuthData = null
+			let firstCallbackErr = null
+
 			const testServer = serverBuilder('mqtt', (serverClient) => {
 				serverClient.on('connect', () =>
 					serverClient.connack({ reasonCode: 0 }),
 				)
+				serverClient.on('auth', (packet) => {
+					authPacketCount++
+					lastAuthData =
+						packet.properties?.authenticationData?.toString()
+					if (lastAuthData === 'second') {
+						serverClient.auth({ reasonCode: 0x00 })
+					}
+				})
 			}).listen(port)
 
 			const client = mqtt.connect({
@@ -1714,18 +1702,210 @@ describe('MQTT 5.0', () => {
 				client.reauthenticate(
 					{ authenticationData: Buffer.from('first') },
 					(err) => {
-						assert.ok(err)
+						firstCallbackErr = err
+					},
+				)
+
+				client.reauthenticate(
+					{ authenticationData: Buffer.from('second') },
+					(err, packet) => {
+						assert.ok(
+							firstCallbackErr,
+							'first callback should have errored',
+						)
 						assert.strictEqual(
-							err.message,
+							firstCallbackErr.message,
 							'reauthenticate: interrupted by new reauthentication request',
 						)
+
+						assert.ifError(err)
+						assert.strictEqual(packet.reasonCode, 0x00)
+
+						assert.strictEqual(
+							authPacketCount,
+							2,
+							'broker should have received both AUTH packets',
+						)
+
+						assert.strictEqual(
+							lastAuthData,
+							'second',
+							'server should receive second AUTH with authenticationData=second',
+						)
+
 						client.end(true, () => testServer.close(done))
 					},
 				)
-				client.reauthenticate({
-					authenticationData: Buffer.from('second'),
-				})
 			})
 		})
+
+		it(
+			'should handle multi-step re-authentication (0x18 Continue)',
+			{ timeout: 15000 },
+			function (t, done) {
+				const port = ports.PORTAND327 + 27
+				const authMethod = 'SCRAM-AUTH'
+				const initialToken = Buffer.from('initial-token')
+				const clientCredentials = Buffer.from('client-credentials')
+				const serverChallenge = Buffer.from('server-challenge')
+				const challengeResponse = Buffer.from('challenge-response')
+
+				let authStep = 0
+
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () => {
+						serverClient.connack({ reasonCode: 0 })
+					})
+
+					serverClient.on('auth', (packet) => {
+						authStep++
+
+						if (authStep === 1) {
+							serverClient.auth({
+								reasonCode: 0x18,
+								properties: {
+									authenticationMethod: authMethod,
+									authenticationData: serverChallenge,
+								},
+							})
+						} else if (authStep === 2) {
+							serverClient.auth({ reasonCode: 0x00 })
+						}
+					})
+				}).listen(port)
+
+				const client = mqtt.connect({
+					port,
+					protocolVersion: 5,
+					properties: {
+						authenticationMethod: authMethod,
+						authenticationData: initialToken,
+					},
+				})
+
+				client.handleAuth = (packet: IAuthPacket, callback) => {
+					callback(null, {
+						cmd: 'auth',
+						reasonCode: 0x18,
+						properties: {
+							authenticationMethod: authMethod,
+							authenticationData: challengeResponse,
+						},
+					})
+				}
+
+				client.on('connect', () => {
+					client.reauthenticate(
+						{ authenticationData: clientCredentials },
+						(err, packet: IAuthPacket) => {
+							assert.ifError(err)
+							assert.strictEqual(packet.reasonCode, 0x00)
+							assert.strictEqual(authStep, 2)
+							client.end(true, () => testServer.close(done))
+						},
+					)
+				})
+			},
+		)
+
+		it(
+			'should error if _sendPacket fails during reauthenticate',
+			{ timeout: 15000 },
+			function (t, done) {
+				const port = ports.PORTAND327 + 28
+
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () => {
+						serverClient.connack({ reasonCode: 0 })
+					})
+				}).listen(port)
+
+				const client = mqtt.connect({
+					port,
+					protocolVersion: 5,
+					reconnectPeriod: 0,
+					properties: {
+						authenticationMethod: 'test',
+					},
+				})
+
+				client.on('connect', () => {
+					client.stream.end()
+
+					client.reauthenticate(
+						{ authenticationData: Buffer.from('test') },
+						(err) => {
+							assert.ok(err)
+							client.end(true, () => testServer.close(done))
+						},
+					)
+				})
+			},
+		)
+		it(
+			'should error if reauthenticate times out',
+			{ timeout: 5000 },
+			function (t, done) {
+				const port = ports.PORTAND327 + 29
+
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () => {
+						serverClient.connack({ reasonCode: 0 })
+					})
+				}).listen(port)
+
+				const client = mqtt.connect({
+					port,
+					protocolVersion: 5,
+					reauthTimeout: 200,
+					properties: { authenticationMethod: 'test' },
+				})
+
+				client.on('connect', () => {
+					client.reauthenticate(
+						{ authenticationData: Buffer.from('test') },
+						(err) => {
+							assert.ok(err)
+							assert.strictEqual(
+								err.message,
+								'reauthenticate: timed out',
+							)
+							client.end(true, () => testServer.close(done))
+						},
+					)
+				})
+			},
+		)
+
+		it(
+			'should error if reauthenticate is called with null options',
+			{ timeout: 5000 },
+			function (t, done) {
+				const port = ports.PORTAND327 + 30
+
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () =>
+						serverClient.connack({ reasonCode: 0 }),
+					)
+				}).listen(port)
+
+				const client = mqtt.connect({
+					port,
+					protocolVersion: 5,
+					properties: { authenticationMethod: 'test' },
+				})
+
+				client.on('connect', () => {
+					client.reauthenticate(null, (err) => {
+						assert.ok(err)
+						assert.strictEqual(
+							err.message,
+							'reauthenticate: reauthOptions is required',
+						)
+						client.end(true, () => testServer.close(done))
+					})
+				})
+			},
+		)
 	})
 })

--- a/test/node/client_mqtt5.ts
+++ b/test/node/client_mqtt5.ts
@@ -1548,30 +1548,45 @@ describe('MQTT 5.0', () => {
 			},
 		)
 
-		it('should not crash if reauthenticate is called without a callback', function (t, done) {
-			const port = ports.PORTAND327 + 23
-			const testServer = serverBuilder('mqtt', (serverClient) => {
-				serverClient.on('connect', () =>
-					serverClient.connack({ reasonCode: 0 }),
-				)
-				serverClient.on('auth', () => {
-					serverClient.auth({ reasonCode: 0 })
+		it(
+			'should not crash if reauthenticate is called without a callback',
+			{ timeout: 15000 },
+			function (t, done) {
+				const port = ports.PORTAND327 + 23
+
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () =>
+						serverClient.connack({ reasonCode: 0 }),
+					)
+
+					serverClient.on('auth', (packet) => {
+						assert.strictEqual(packet.reasonCode, 0x19)
+						assert.ok(
+							packet.properties.authenticationData.equals(
+								Buffer.from('test'),
+							),
+						)
+						serverClient.auth({ reasonCode: 0 })
+					})
+				}).listen(port)
+
+				const client = mqtt.connect({
+					port,
+					protocolVersion: 5,
+					properties: { authenticationMethod: 'test' },
+				})
+
+				client.once('reauth', () => {
 					client.end(true, () => testServer.close(done))
 				})
-			}).listen(port)
 
-			const client = mqtt.connect({
-				port,
-				protocolVersion: 5,
-				properties: { authenticationMethod: 'test' },
-			})
-
-			client.on('connect', () => {
-				client.reauthenticate({
-					authenticationData: Buffer.from('test'),
+				client.once('connect', () => {
+					client.reauthenticate({
+						authenticationData: Buffer.from('test'),
+					})
 				})
-			})
-		})
+			},
+		)
 
 		it(
 			'should error if reauthenticate is called without an initial authenticationMethod',
@@ -1623,5 +1638,94 @@ describe('MQTT 5.0', () => {
 				})
 			},
 		)
+
+		it(
+			'should error if broker returns a non-zero reason code',
+			{ timeout: 15000 },
+			function (t, done) {
+				const port = ports.PORTAND327 + 82
+
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () => {
+						serverClient.connack({ reasonCode: 0 })
+					})
+
+					serverClient.on('auth', (packet) => {
+						assert.strictEqual(packet.reasonCode, 0x19)
+						assert.ok(
+							packet.properties.authenticationData.equals(
+								Buffer.from('test'),
+							),
+						)
+
+						setImmediate(() => {
+							if (serverClient.writable) {
+								serverClient.auth({ reasonCode: 0x18 })
+							}
+						})
+					})
+				}).listen(port)
+
+				const client = mqtt.connect({
+					port,
+					protocolVersion: 5,
+					keepalive: 0,
+					properties: { authenticationMethod: 'test' },
+				})
+
+				client.once('connect', () => {
+					client.reauthenticate(
+						{ authenticationData: Buffer.from('test') },
+						(err, packet: IAuthPacket) => {
+							assert.ok(err)
+							assert.ok(packet)
+							assert.strictEqual(packet.reasonCode, 0x18)
+							assert.ok(
+								String(err.message)
+									.toLowerCase()
+									.includes('re-auth failed') ||
+									String(err.message)
+										.toLowerCase()
+										.includes('24'),
+							)
+
+							client.end(true, () => testServer.close(done))
+						},
+					)
+				})
+			},
+		)
+
+		it('should interrupt a pending reauthentication with a new request', function (t, done) {
+			const port = ports.PORTAND327 + 26
+			const testServer = serverBuilder('mqtt', (serverClient) => {
+				serverClient.on('connect', () =>
+					serverClient.connack({ reasonCode: 0 }),
+				)
+			}).listen(port)
+
+			const client = mqtt.connect({
+				port,
+				protocolVersion: 5,
+				properties: { authenticationMethod: 'test' },
+			})
+
+			client.on('connect', () => {
+				client.reauthenticate(
+					{ authenticationData: Buffer.from('first') },
+					(err) => {
+						assert.ok(err)
+						assert.strictEqual(
+							err.message,
+							'reauthenticate: interrupted by new reauthentication request',
+						)
+						client.end(true, () => testServer.close(done))
+					},
+				)
+				client.reauthenticate({
+					authenticationData: Buffer.from('second'),
+				})
+			})
+		})
 	})
 })

--- a/test/node/client_mqtt5.ts
+++ b/test/node/client_mqtt5.ts
@@ -1560,11 +1560,96 @@ describe('MQTT 5.0', () => {
 			},
 		)
 
+		it('should emit error if handleAuth returns an error during 0x18 continue', function (t, done) {
+			const port = ports.PORTAND327 + 23
+			const testServer = serverBuilder('mqtt', (serverClient) => {
+				serverClient.on('connect', () => {
+					serverClient.connack({ reasonCode: 0 })
+				})
+				serverClient.on('auth', () => {
+					serverClient.auth({
+						reasonCode: 0x18,
+						properties: {
+							authenticationMethod: 'test',
+							authenticationData: Buffer.from('challenge'),
+						},
+					})
+				})
+			}).listen(port)
+
+			const client = mqtt.connect({
+				port,
+				protocolVersion: 5,
+				properties: { authenticationMethod: 'test' },
+			})
+
+			client.handleAuth = (_packet, callback) => {
+				callback(new Error('user-auth-failure'))
+			}
+
+			client.once('error', (err) => {
+				assert.strictEqual(err.message, 'user-auth-failure')
+				client.end(true, () => testServer.close(done))
+			})
+
+			client.on('connect', () => {
+				client.reauthenticate({
+					authenticationData: Buffer.from('test'),
+				})
+			})
+		})
+
+		it('should handle pre-connack 0x18 enhanced authentication', function (t, done) {
+			const port = ports.PORTAND327 + 24
+			let step = 0
+			const testServer = serverBuilder('mqtt', (serverClient) => {
+				serverClient.on('connect', () => {
+					serverClient.auth({
+						reasonCode: 0x18,
+						properties: {
+							authenticationMethod: 'test',
+							authenticationData: Buffer.from('challenge'),
+						},
+					})
+				})
+				serverClient.on('auth', () => {
+					step++
+					if (step === 1) {
+						serverClient.connack({ reasonCode: 0 })
+					}
+				})
+			}).listen(port)
+
+			const client = mqtt.connect({
+				port,
+				protocolVersion: 5,
+				properties: {
+					authenticationMethod: 'test',
+					authenticationData: Buffer.from('init'),
+				},
+			})
+
+			client.handleAuth = (_packet, callback) => {
+				callback(null, {
+					cmd: 'auth',
+					reasonCode: 0x18,
+					properties: {
+						authenticationMethod: 'test',
+						authenticationData: Buffer.from('response'),
+					},
+				})
+			}
+
+			client.once('connect', () => {
+				client.end(true, () => testServer.close(done))
+			})
+		})
+
 		it(
 			'should not crash if reauthenticate is called without a callback',
 			{ timeout: 15000 },
 			function (t, done) {
-				const port = ports.PORTAND327 + 23
+				const port = ports.PORTAND327 + 25
 
 				const testServer = serverBuilder('mqtt', (serverClient) => {
 					serverClient.on('connect', () =>
@@ -1604,7 +1689,7 @@ describe('MQTT 5.0', () => {
 			'should error if reauthenticate is called without an initial authenticationMethod',
 			{ timeout: 15000 },
 			function (t, done) {
-				const port = ports.PORTAND327 + 24
+				const port = ports.PORTAND327 + 26
 
 				const testServer = serverBuilder('mqtt', (serverClient) => {
 					serverClient.on('connect', () =>
@@ -1637,7 +1722,7 @@ describe('MQTT 5.0', () => {
 			'should error if broker returns a non-zero reason code',
 			{ timeout: 15000 },
 			function (t, done) {
-				const port = ports.PORTAND327 + 25
+				const port = ports.PORTAND327 + 27
 
 				const FAILING_RC = 0x19
 				const testServer = serverBuilder('mqtt', (serverClient) => {
@@ -1676,7 +1761,7 @@ describe('MQTT 5.0', () => {
 		)
 
 		it('should reject a second reauthentication while the first is in progress', function (t, done) {
-			const port = ports.PORTAND327 + 26
+			const port = ports.PORTAND327 + 28
 			let authPacketCount = 0
 			let firstCallbackErr: Error | null = null
 			let secondCallbackErr: Error | null = null
@@ -1748,7 +1833,7 @@ describe('MQTT 5.0', () => {
 			'should handle multi-step re-authentication (0x18 Continue)',
 			{ timeout: 15000 },
 			function (t, done) {
-				const port = ports.PORTAND327 + 27
+				const port = ports.PORTAND327 + 29
 				const authMethod = 'SCRAM-AUTH'
 				const initialToken = Buffer.from('initial-token')
 				const clientCredentials = Buffer.from('client-credentials')
@@ -1817,7 +1902,7 @@ describe('MQTT 5.0', () => {
 			'should error if _sendPacket fails during reauthenticate',
 			{ timeout: 15000 },
 			function (t, done) {
-				const port = ports.PORTAND327 + 28
+				const port = ports.PORTAND327 + 30
 
 				const testServer = serverBuilder('mqtt', (serverClient) => {
 					serverClient.on('connect', () => {
@@ -1863,7 +1948,7 @@ describe('MQTT 5.0', () => {
 			'should error if reauthenticate is called after client.end()',
 			{ timeout: 15000 },
 			function (t, done) {
-				const port = ports.PORTAND327 + 29
+				const port = ports.PORTAND327 + 31
 
 				const testServer = serverBuilder('mqtt', (serverClient) => {
 					serverClient.on('connect', () => {
@@ -1898,7 +1983,7 @@ describe('MQTT 5.0', () => {
 			'should error if reauthenticate times out',
 			{ timeout: 5000 },
 			function (t, done) {
-				const port = ports.PORTAND327 + 30
+				const port = ports.PORTAND327 + 32
 
 				const testServer = serverBuilder('mqtt', (serverClient) => {
 					serverClient.on('connect', () => {
@@ -1933,7 +2018,7 @@ describe('MQTT 5.0', () => {
 			'should error if reauthenticate is called with null options',
 			{ timeout: 5000 },
 			function (t, done) {
-				const port = ports.PORTAND327 + 31
+				const port = ports.PORTAND327 + 33
 
 				const testServer = serverBuilder('mqtt', (serverClient) => {
 					serverClient.on('connect', () =>
@@ -1964,7 +2049,7 @@ describe('MQTT 5.0', () => {
 			'reauthenticateAsync resolves with the broker AUTH packet on success',
 			{ timeout: 15000 },
 			async function _test(t) {
-				const port = ports.PORTAND327 + 32
+				const port = ports.PORTAND327 + 34
 				const newToken = Buffer.from('async-new-token')
 
 				const testServer = serverBuilder('mqtt', (serverClient) => {
@@ -2009,7 +2094,7 @@ describe('MQTT 5.0', () => {
 			'reauthenticateAsync rejects when broker returns a non-zero reason code',
 			{ timeout: 15000 },
 			async function _test(t) {
-				const port = ports.PORTAND327 + 33
+				const port = ports.PORTAND327 + 35
 				const FAILING_RC = 0x19
 
 				const testServer = serverBuilder('mqtt', (serverClient) => {
@@ -2049,5 +2134,123 @@ describe('MQTT 5.0', () => {
 				)
 			},
 		)
+
+		it('should emit error when validation fails without callback', function (t, done) {
+			const port = ports.PORTAND327 + 36
+			const testServer = serverBuilder('mqtt', (serverClient) => {
+				serverClient.on('connect', () =>
+					serverClient.connack({ reasonCode: 0 }),
+				)
+			}).listen(port)
+
+			const client = mqtt.connect({
+				port,
+				protocolVersion: 5,
+				properties: { authenticationMethod: 'test' },
+			})
+
+			client.once('error', (err) => {
+				assert.ok(err.message.includes('client is not connected'))
+				testServer.close(done)
+			})
+
+			client.once('connect', () => {
+				client.end(true, () => {
+					client.reauthenticate({
+						authenticationData: Buffer.from('test'),
+					})
+				})
+			})
+		})
+
+		it('should error if reauthenticate is called without authenticationData', function (t, done) {
+			const port = ports.PORTAND327 + 37
+			const testServer = serverBuilder('mqtt', (serverClient) => {
+				serverClient.on('connect', () =>
+					serverClient.connack({ reasonCode: 0 }),
+				)
+			}).listen(port)
+
+			const client = mqtt.connect({
+				port,
+				protocolVersion: 5,
+				properties: { authenticationMethod: 'test' },
+			})
+
+			client.on('connect', () => {
+				client.reauthenticate(
+					{}, // Empty object — missing authenticationData
+					(err) => {
+						assert.ok(err)
+						assert.strictEqual(
+							err.message,
+							'reauthenticate: authenticationData is required',
+						)
+						client.end(true, () => testServer.close(done))
+					},
+				)
+			})
+		})
+
+		it('should log error on timeout when no callback provided', function (t, done) {
+			const port = ports.PORTAND327 + 38
+			const testServer = serverBuilder('mqtt', (serverClient) => {
+				serverClient.on('connect', () =>
+					serverClient.connack({ reasonCode: 0 }),
+				)
+				// Broker never responds to AUTH — forces timeout
+			}).listen(port)
+
+			const client = mqtt.connect({
+				port,
+				protocolVersion: 5,
+				reauthTimeout: 200,
+				properties: { authenticationMethod: 'test' },
+			})
+
+			client.on('connect', () => {
+				// No callback — _reauthCallback is undefined
+				client.reauthenticate({
+					authenticationData: Buffer.from('test'),
+				})
+			})
+
+			// Wait for timeout to fire, then verify no crash
+			setTimeout(() => {
+				client.end(true, () => testServer.close(done))
+			}, 400)
+		})
+
+		it('should cancel in-flight reauth when client.end() is called', function (t, done) {
+			const port = ports.PORTAND327 + 39
+			const testServer = serverBuilder('mqtt', (serverClient) => {
+				serverClient.on('connect', () =>
+					serverClient.connack({ reasonCode: 0 }),
+				)
+				serverClient.on('auth', () => {})
+			}).listen(port)
+
+			const client = mqtt.connect({
+				port,
+				protocolVersion: 5,
+				reauthTimeout: 0,
+				properties: { authenticationMethod: 'test' },
+			})
+
+			client.on('connect', () => {
+				client.reauthenticate(
+					{ authenticationData: Buffer.from('test') },
+					(err) => {
+						assert.ok(err)
+						assert.ok(
+							err.message.includes('cancelled by client.end()'),
+						)
+						client.end(true, () => testServer.close(done))
+					},
+				)
+
+				setTimeout(() => client.end(), 50)
+			})
+		})
 	})
 })


### PR DESCRIPTION
## Description
* This feature was requested at issue #1795 
* This PR implements the **MQTT 5.0 Re-authentication** flow and enhances the handling of `AUTH` packets within the client. This allows for dynamic credential updates or extended authentication exchanges without disconnecting the session.

### Key Changes:
* **MqttClient API:** Added a public `.reauthenticate(options)` method to trigger the re-auth flow.
* **Packet Handling:** Updated `src/lib/handlers/auth.ts` to correctly process **Reason Code 0x00 (Success)** for both initial handshakes and mid-session re-authentication.
* **Event System:** Introduced a new `'reauth'` event that emits upon a successful authentication exchange, providing the server's response packet to the user.
* **Validation:** Added guards to ensure re-authentication is only attempted on MQTT 5.0 connections with a pre-established `authenticationMethod`.

---

## Test Plan
I have added a new suite of tests in `test/client_mqtt5.ts` to ensure stability:
* **[Success Path]**: Verified end-to-end `AUTH` exchange using a mock broker, ensuring the `'reauth'` event triggers correctly.
* **[Protocol Guard]**: Verified the client throws an error when attempting re-authentication on non-v5 (e.g., v3.1.1 or v4) connections.
* **[Constraint Check]**: Confirmed validation logic prevents calls if no `authenticationMethod` was defined during the initial connection.

**Local Results:**
* `npm test`: Passes (verified specifically for MQTT 5.0 client tests).
