### PR TITLE
fix: support relative WebSocket URLs

### DIFF
--- a/src/lib/connect/index.ts
+++ b/src/lib/connect/index.ts
@@ -18,6 +18,18 @@ const debug = _debug('mqttjs')
 
 let protocols: Record<string, StreamBuilder> = null
 
+function getDefaultWebSocketProtocol(): MqttProtocol {
+	if (typeof location !== 'undefined') {
+		return location.protocol === 'https:' ? 'wss' : 'ws'
+	}
+
+	if (typeof document !== 'undefined') {
+		return new URL(document.URL).protocol === 'https:' ? 'wss' : 'ws'
+	}
+
+	return 'ws'
+}
+
 /**
  * Parse the auth attribute and merge username and password in the options object.
  *
@@ -59,6 +71,11 @@ function connect(
 	if (brokerUrl && typeof brokerUrl === 'string') {
 		const parsedUrl = url.parse(brokerUrl, true)
 		const parsedOptions: Partial<IClientOptions> = {}
+		const isRelativeWebSocketUrl =
+			!parsedUrl.protocol &&
+			!parsedUrl.hostname &&
+			parsedUrl.path?.startsWith('/') &&
+			(isBrowser || opts.forceNativeWebSocket)
 
 		if (parsedUrl.port != null) {
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -75,11 +92,13 @@ function connect(
 		opts = { ...parsedOptions, ...opts }
 
 		// when parsing an url expect the protocol to be set
-		if (!opts.protocol) {
+		if (!opts.protocol && !isRelativeWebSocketUrl) {
 			throw new Error('Missing protocol')
 		}
 
-		opts.protocol = opts.protocol.replace(/:$/, '') as MqttProtocol
+		opts.protocol = (
+			opts.protocol || getDefaultWebSocketProtocol()
+		).replace(/:$/, '') as MqttProtocol
 	}
 
 	opts.unixSocket = opts.unixSocket || opts.protocol?.includes('+unix')

--- a/test/node/mqtt.ts
+++ b/test/node/mqtt.ts
@@ -44,6 +44,19 @@ describe('mqtt', () => {
 			c.end((err) => done(err))
 		})
 
+		it('should support relative WebSocket URLs when using native WebSocket', function _test(t, done) {
+			const c = mqtt.connect('/mqtt', {
+				forceNativeWebSocket: true,
+				host: 'localhost',
+			})
+
+			c.should.be.instanceOf(mqtt.MqttClient)
+			c.options.should.have.property('protocol', 'ws')
+			c.options.should.have.property('path', '/mqtt')
+			c.on('error', () => {})
+			c.end((err) => done(err))
+		})
+
 		it('should work with unix sockets', function _test(t, done) {
 			const c = mqtt.connect('mqtt+unix:///tmp/mqtt.sock')
 


### PR DESCRIPTION
## Summary
- allow relative WebSocket URLs such as `/mqtt` for browser/native WebSocket connections
- choose `wss` by default when the current browser page is HTTPS, otherwise `ws`
- keep the existing `Missing protocol` behavior for non-WebSocket relative URLs
- add a regression test for relative WebSocket URL parsing

## Verification
- npm run lint
- npm run build
- npm run unit-test:node

Closes #2035