### PR TITLE
fix: schedule browser process.nextTick with queueMicrotask

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -18,6 +18,20 @@ const options = {
     globalName: 'mqtt',
     sourcemap: false, // this can be enabled while debugging, if we decide to keep this enabled we should also ship the `src` folder to npm
     plugins: [
+        {
+            name: 'browser-process',
+            setup(build) {
+                // mqtt-packet corks the stream and uncorks on process.nextTick.
+                // The default browser process shim drains that queue with
+                // setTimeout(0), which React Native throttles while
+                // backgrounded, so writes stall. Resolve process to a
+                // queueMicrotask-based shim instead (issue #2053).
+                const shim = require('path').resolve(__dirname, 'src/lib/browser-process.ts')
+                build.onResolve({ filter: /^(node:)?process$/ }, () => ({
+                    path: shim,
+                }))
+            }
+        },
         polyfillNode({
             polyfills: [
                 'readable-stream'

--- a/src/lib/browser-process.ts
+++ b/src/lib/browser-process.ts
@@ -1,0 +1,91 @@
+const pending: Array<{
+	fun: (...args: any[]) => void
+	args: any[]
+}> = []
+let draining = false
+
+function runNextTicks() {
+	draining = true
+	while (pending.length) {
+		const item = pending.shift()
+		item.fun(...item.args)
+	}
+	draining = false
+}
+
+function scheduleDrain() {
+	if (typeof queueMicrotask === 'function') {
+		queueMicrotask(runNextTicks)
+	} else {
+		setTimeout(runNextTicks, 0)
+	}
+}
+
+export function nextTick(fun: (...args: any[]) => void, ...args: any[]): void {
+	if (typeof fun !== 'function') {
+		throw new TypeError('"callback" argument must be a function')
+	}
+	pending.push({ fun, args })
+	if (pending.length === 1 && !draining) {
+		scheduleDrain()
+	}
+}
+
+function noop() {}
+
+export const title = 'browser'
+export const browser = true
+export const env: Record<string, string | undefined> = {}
+export const argv: string[] = []
+export const version = ''
+export const versions: Record<string, string | undefined> = {}
+export const on = noop
+export const addListener = noop
+export const once = noop
+export const off = noop
+export const removeListener = noop
+export const removeAllListeners = noop
+export const emit = noop
+export const prependListener = noop
+export const prependOnceListener = noop
+export function listeners() {
+	return []
+}
+export function binding() {
+	throw new Error('process.binding is not supported')
+}
+export function cwd() {
+	return '/'
+}
+export function chdir() {
+	throw new Error('process.chdir is not supported')
+}
+export function umask() {
+	return 0
+}
+
+const browserProcess = {
+	title,
+	browser,
+	env,
+	argv,
+	version,
+	versions,
+	nextTick,
+	on,
+	addListener,
+	once,
+	off,
+	removeListener,
+	removeAllListeners,
+	emit,
+	prependListener,
+	prependOnceListener,
+	listeners,
+	binding,
+	cwd,
+	chdir,
+	umask,
+}
+
+export default browserProcess

--- a/test/node/browser-process.ts
+++ b/test/node/browser-process.ts
@@ -1,0 +1,81 @@
+import { describe, it } from 'node:test'
+import { PassThrough } from 'node:stream'
+import { assert } from 'chai'
+import { nextTick } from '../../src/lib/browser-process'
+
+describe('browser process.nextTick', () => {
+	it('runs the callback as a microtask, not via setTimeout(0)', async () => {
+		const origSetTimeout = setTimeout
+		let timeoutUsed = false
+		global.setTimeout = ((...args: Parameters<typeof setTimeout>) => {
+			timeoutUsed = true
+			return origSetTimeout(...args)
+		}) as typeof setTimeout
+
+		try {
+			let ran = false
+			nextTick(() => {
+				ran = true
+			})
+			assert.equal(ran, false, 'must not run synchronously')
+			await Promise.resolve()
+			assert.equal(ran, true, 'must run after a microtask')
+			assert.equal(timeoutUsed, false, 'must not schedule setTimeout')
+		} finally {
+			global.setTimeout = origSetTimeout
+		}
+	})
+
+	it('forwards extra arguments', async () => {
+		let received: unknown[] = []
+		nextTick(
+			(a: number, b: string) => {
+				received = [a, b]
+			},
+			1,
+			'pong',
+		)
+		await Promise.resolve()
+		assert.deepEqual(received, [1, 'pong'])
+	})
+
+	it('throws when the callback is not a function', () => {
+		assert.throws(
+			() => {
+				nextTick(null as unknown as () => void)
+			},
+			TypeError,
+			'"callback" argument must be a function',
+		)
+	})
+
+	it('uncorks a stream without waiting for setTimeout', async () => {
+		const origSetTimeout = setTimeout
+		let timeoutUsed = false
+		global.setTimeout = ((...args: Parameters<typeof setTimeout>) => {
+			timeoutUsed = true
+			return origSetTimeout(...args)
+		}) as typeof setTimeout
+
+		try {
+			const stream = new PassThrough()
+			const chunks: Buffer[] = []
+			stream.on('data', (chunk) => {
+				chunks.push(chunk)
+			})
+			stream.cork()
+			stream.write('ping')
+			assert.equal(chunks.length, 0, 'corked writes stay buffered')
+
+			nextTick(() => {
+				stream.uncork()
+			})
+			await Promise.resolve()
+
+			assert.equal(Buffer.concat(chunks).toString(), 'ping')
+			assert.equal(timeoutUsed, false)
+		} finally {
+			global.setTimeout = origSetTimeout
+		}
+	})
+})


### PR DESCRIPTION
## Summary

The React Native and browser bundle polyfilled `process.nextTick` with `setTimeout(0)`. `mqtt-packet` corks the transport and uncorks on nextTick, so when React Native throttles timers in the background, `writeToStream()` returns normally while `_write()` never runs.

The browser build now resolves `process` to a small shim that drains via `queueMicrotask` (with a `setTimeout` fallback). Node keeps using the real `process.nextTick`.

Fixes #2053

## Test plan

- [x] `test/node/browser-process.ts`: nextTick is a microtask, forwards extra args, rejects a non-function, and uncorks a stream without `setTimeout`
- [x] `npm run lint`
- [x] `npm run unit-test:node` (698 pass, 0 fail)
- [ ] Maintainer: confirm a backgrounded RN client still sends pingreq while timers are throttled