### PR TITLE
feat(mqtt5): add client-initiated re-authentication (reauthenticate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,9 @@ Also user can manually register topic-alias pair using PUBLISH topic:'some', ta:
 - [`mqtt.Client#removeOutgoingMessage()`](#removeOutgoingMessage)
 - [`mqtt.Client#reconnect()`](#reconnect)
 - [`mqtt.Client#handleMessage()`](#handleMessage)
+- [`mqtt.Client#handleAuth()`](#handleAuth)
+- [`mqtt.Client#reauthenticate()`](#reauthenticate)
+- [`mqtt.Client#reauthenticateAsync()`](#reauthenticate-async)
 - [`mqtt.Client#connected`](#connected)
 - [`mqtt.Client#reconnecting`](#reconnecting)
 - [`mqtt.Client#getLastMessageId()`](#getLastMessageId)
@@ -427,6 +430,9 @@ The arguments are:
     is received with an error.
   - `connectTimeout`: `30 * 1000` milliseconds, time to wait before a
     CONNACK is received
+  - `reauthTimeout`: `30 * 1000` milliseconds, time to wait for the broker to
+    complete a re-authentication started with `reauthenticate()` (MQTT 5.0
+    only). Set to `0` to disable the timeout.
   - `username`: the username required by your broker, if any
   - `password`: the password required by your broker, if any
   - `socksProxy`: establish TCP and TLS connections via a socks proxy (URL, supported protocols are `socks5://`, `socks5h://`, `socks4://`, `socks4a://`)
@@ -599,6 +605,16 @@ and connections
 - `packet` received packet, as defined in
   [mqtt-packet](https://github.com/mcollina/mqtt-packet)
 
+#### Event `'reauth'`
+
+`function (packet) {}`
+
+Emitted when a re-authentication started with
+[`reauthenticate()`](#reauthenticate) completes successfully (MQTT 5.0 only).
+
+- `packet` the final `AUTH` packet received from the broker, as defined in
+  [mqtt-packet](https://github.com/mcollina/mqtt-packet)
+
 ---
 
 <a name="client-connect"></a>
@@ -749,6 +765,83 @@ Connect again using the same options as connect()
 Handle messages with backpressure support, one at a time.
 Override at will, but **always call `callback`**, or the client
 will hang.
+
+---
+
+<a name="handleAuth"></a>
+
+### mqtt.Client#handleAuth(packet, callback)
+
+Handle `AUTH` packets of an MQTT 5.0 enhanced authentication exchange
+(reason code `0x18` Continue authentication), both during the connection and
+during a [re-authentication](#reauthenticate). Override at will and
+**always call `callback(err, authPacket)`** with the next `AUTH` packet to send
+to the broker, otherwise the exchange will hang:
+
+```js
+client.handleAuth = (packet, callback) => {
+  // compute the answer to packet.properties.authenticationData
+  callback(null, {
+    cmd: 'auth',
+    reasonCode: 0x18,
+    properties: {
+      authenticationMethod: 'SCRAM-SHA-256',
+      authenticationData: Buffer.from('...'),
+    },
+  })
+}
+```
+
+---
+
+<a name="reauthenticate"></a>
+
+### mqtt.Client#reauthenticate([options], [callback])
+
+Start an MQTT 5.0 re-authentication exchange (section 4.12.1 of the spec),
+for example to provide a refreshed token to the broker without
+disconnecting. Only available with `protocolVersion: 5` and when an
+`authenticationMethod` was set in the CONNECT `properties`.
+
+The client sends an `AUTH` packet with reason code `0x19` (Re-authenticate).
+The broker can answer with `AUTH` `0x18` (Continue authentication), which is
+forwarded to [`handleAuth()`](#handleAuth), or `AUTH` `0x00` (Success),
+which completes the exchange and emits the [`'reauth'`](#events) event.
+
+- `options` is the optional object of properties of the `AUTH` packet:
+  - `authenticationData`: Binary Data containing authentication data `binary`,
+  - `reasonString`: representing the reason associated with this re-authentication `string`,
+  - `userProperties`: The User Property is allowed to appear multiple times to represent multiple name, value pairs `object`
+- `callback` - `function (err, packet)`, fired when the exchange completes.
+  `packet` is the final `AUTH` packet received from the broker. When no
+  callback is given, failures are emitted as `'error'` events.
+
+The exchange fails with an error when the broker does not answer within
+`reauthTimeout` milliseconds, when the connection is closed in the meantime,
+or when `handleAuth()` reports an error.
+
+```js
+client.reauthenticate(
+  { authenticationData: Buffer.from(refreshedToken) },
+  (err, packet) => {
+    if (err) {
+      console.error('re-authentication failed', err)
+    } else {
+      console.log('re-authenticated', packet.reasonCode)
+    }
+  },
+)
+```
+
+---
+
+<a name="reauthenticate-async"></a>
+
+### mqtt.Client#reauthenticateAsync([options])
+
+Async [`reauthenticate()`](#reauthenticate). Returns a `Promise` that
+resolves with the final `AUTH` packet received from the broker, or rejects
+with the error.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -431,8 +431,9 @@ The arguments are:
   - `connectTimeout`: `30 * 1000` milliseconds, time to wait before a
     CONNACK is received
   - `reauthTimeout`: `30 * 1000` milliseconds, time to wait for the broker to
-    complete a re-authentication started with `reauthenticate()` (MQTT 5.0
-    only). Set to `0` to disable the timeout.
+    answer each step of a re-authentication started with `reauthenticate()`
+    (MQTT 5.0 only). Set to `0` to disable the timeout; any other non-positive
+    or non-finite value falls back to the default.
   - `username`: the username required by your broker, if any
   - `password`: the password required by your broker, if any
   - `socksProxy`: establish TCP and TLS connections via a socks proxy (URL, supported protocols are `socks5://`, `socks5h://`, `socks4://`, `socks4a://`)
@@ -611,6 +612,9 @@ and connections
 
 Emitted when a re-authentication started with
 [`reauthenticate()`](#reauthenticate) completes successfully (MQTT 5.0 only).
+Success here is the broker's assertion: `handleAuth()` only runs for `0x18`
+challenges, so a mutual-authentication method cannot verify the final `0x00`
+through this event.
 
 - `packet` the final `AUTH` packet received from the broker, as defined in
   [mqtt-packet](https://github.com/mcollina/mqtt-packet)
@@ -801,25 +805,50 @@ client.handleAuth = (packet, callback) => {
 Start an MQTT 5.0 re-authentication exchange (section 4.12.1 of the spec),
 for example to provide a refreshed token to the broker without
 disconnecting. Only available with `protocolVersion: 5` and when an
-`authenticationMethod` was set in the CONNECT `properties`.
+`authenticationMethod` was set in the CONNECT `properties`. Returns the
+client, so calls can be chained.
 
 The client sends an `AUTH` packet with reason code `0x19` (Re-authenticate).
 The broker can answer with `AUTH` `0x18` (Continue authentication), which is
 forwarded to [`handleAuth()`](#handleAuth), or `AUTH` `0x00` (Success),
 which completes the exchange and emits the [`'reauth'`](#events) event.
+Only one exchange may be in flight at a time.
 
-- `options` is the optional object of properties of the `AUTH` packet:
-  - `authenticationData`: Binary Data containing authentication data `binary`,
+- `options` is the optional object of properties of the `AUTH` packet. All
+  three are optional, and no other property is sent:
+  - `authenticationData`: Binary Data containing authentication data, a
+    `Buffer` or a `string`,
   - `reasonString`: representing the reason associated with this re-authentication `string`,
   - `userProperties`: The User Property is allowed to appear multiple times to represent multiple name, value pairs `object`
-- `callback` - `function (err, packet)`, fired when the exchange completes.
-  `packet` is the final `AUTH` packet received from the broker, and is only
-  passed on success. When no callback is given, failures are emitted as
-  `'error'` events.
 
-The exchange fails with an error when the broker does not answer within
+  `authenticationMethod` is always the one used in the CONNECT packet and
+  cannot be overridden here: an `AUTH` packet naming a different method is
+  rejected, in either direction.
+- `callback` - `function (err, packet)`, fired when the exchange completes.
+  `packet` is the final `AUTH` packet received from the broker, or the one
+  that carried a broker side failure - its `reasonString` and `userProperties`
+  say why the broker refused. When no callback is given, failures are emitted
+  as `'error'` events. Errors that carry a reason code are
+  `ErrorWithReasonCode`, with the code in `err.code`.
+
+The exchange fails with an error when the broker does not answer a step within
 `reauthTimeout` milliseconds, when the connection is closed in the meantime,
-or when `handleAuth()` reports an error.
+when the broker answers with an unexpected reason code or authentication
+method, when it drives more than 10 `0x18` rounds, or when `handleAuth()`
+reports an error.
+
+A failed re-authentication does **not** close the connection: the client keeps
+running on the credentials the broker already accepted, and it is the
+application's job to decide whether to retry or call `end()`. `client.lastReauthError`
+holds the reason the last re-authentication failed, or `null`, so a client
+running on refused credentials can be told from a healthy one.
+
+**Breaking change:** an `AUTH` packet received after CONNACK while no
+re-authentication is in progress used to be forwarded to `handleAuth()`. Only
+the client may start a re-authentication ([MQTT-4.12.0-1]), so this is now
+treated as a protocol error: the connection is closed and an `'error'` with
+reason code `0x82` is emitted. Applications that relied on broker-initiated
+mid-session enhanced authentication are affected.
 
 ```js
 client.reauthenticate(

--- a/README.md
+++ b/README.md
@@ -813,8 +813,9 @@ which completes the exchange and emits the [`'reauth'`](#events) event.
   - `reasonString`: representing the reason associated with this re-authentication `string`,
   - `userProperties`: The User Property is allowed to appear multiple times to represent multiple name, value pairs `object`
 - `callback` - `function (err, packet)`, fired when the exchange completes.
-  `packet` is the final `AUTH` packet received from the broker. When no
-  callback is given, failures are emitted as `'error'` events.
+  `packet` is the final `AUTH` packet received from the broker, and is only
+  passed on success. When no callback is given, failures are emitted as
+  `'error'` events.
 
 The exchange fails with an error when the broker does not answer within
 `reauthTimeout` milliseconds, when the connection is closed in the meantime,

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -22,6 +22,7 @@ import { type ClientRequestArgs } from 'http'
 import * as validations from './validations'
 import Store, { type IStore } from './store'
 import handlePacket from './handlers'
+import { RC_REAUTHENTICATE } from './handlers/auth'
 import DefaultMessageIdProvider, {
 	type IMessageIdProvider,
 } from './default-message-id-provider'
@@ -52,6 +53,13 @@ const setImmediate =
 			callback(...args)
 		})
 	}) as typeof globalThis.setImmediate)
+
+/**
+ * Upper bound on the AUTH 0x18 challenges a broker may drive in one
+ * re-authentication exchange. Each one runs application `handleAuth()` work
+ * (typically a KDF), so an unbounded exchange is work the broker can force.
+ */
+const MAX_REAUTH_ROUNDS = 10
 
 const defaultConnectOptions: IClientOptions = {
 	keepalive: 60,
@@ -431,7 +439,7 @@ export type PacketCallback = (
 	packet?: Packet,
 ) => any
 export type CloseCallback = (error?: Error) => void
-export type AuthCallback = (err?: Error | null, packet?: IAuthPacket) => void
+export type AuthCallback = GenericCallback<IAuthPacket>
 /**
  * Properties of the AUTH packet sent by `reauthenticate()`. The
  * `authenticationMethod` is always the one used in the CONNECT packet.
@@ -530,6 +538,20 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	/** Callback of the pending re-authentication, if any */
 	private _reauthCallback: AuthCallback | null
 
+	/**
+	 * Why the last re-authentication failed, or null when the last one
+	 * succeeded or none has run. A failed re-authentication does not close the
+	 * connection, so this is what tells a healthy client from one still running
+	 * on credentials the broker has refused.
+	 */
+	public lastReauthError: Error | null
+
+	/** number of AUTH 0x18 rounds the broker has driven in the current exchange */
+	private _reauthRounds: number
+
+	/** the `_sendPacket` callback of the current exchange, parked on `drain` when the stream is backed up */
+	private _reauthSendCb: DoneCallback | null
+
 	private _storeProcessing: boolean
 
 	/** keep a reference of packets that have been successfully processed from outgoing store  */
@@ -567,6 +589,19 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			} else {
 				this.options[k] = options[k]
 			}
+		}
+
+		// A non-finite or negative timeout would silently disable the abort
+		// timer, turning every failed re-authentication into a permanent hang.
+		// Only an explicit 0 disables it.
+		const { reauthTimeout } = this.options
+		if (
+			reauthTimeout !== 0 &&
+			(typeof reauthTimeout !== 'number' ||
+				!Number.isFinite(reauthTimeout) ||
+				reauthTimeout < 0)
+		) {
+			this.options.reauthTimeout = defaultConnectOptions.reauthTimeout
 		}
 
 		this.log = this.options.log || _debug('mqttjs:client')
@@ -663,6 +698,9 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		this.reauthTimer = null
 		this._reauthPending = false
 		this._reauthCallback = null
+		this._reauthRounds = 0
+		this._reauthSendCb = null
+		this.lastReauthError = null
 		// Is processing store?
 		this._storeProcessing = false
 		// Packet Ids are put into the store during store processing
@@ -737,14 +775,9 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			this.log('close :: clearing connackTimer')
 			clearTimeout(this.connackTimer)
 
-			if (this._reauthPending) {
-				this.log('close :: aborting pending re-authentication')
-				this._finishReauth(
-					new Error(
-						'reauthenticate: connection closed before the broker answered',
-					),
-				)
-			}
+			// Backstop only: `_cleanUp` already aborts on the teardown paths
+			// the client controls. This catches a close driven by the peer.
+			this._abortReauth('connection closed before the broker answered')
 
 			this._destroyKeepaliveManager()
 
@@ -1740,6 +1773,13 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	 * @api public
 	 * @example client.reauthenticate({ authenticationData: Buffer.from(newToken) }, (err) => {})
 	 */
+	public reauthenticate(callback?: AuthCallback): MqttClient
+
+	public reauthenticate(
+		options: ReauthenticateOptions,
+		callback?: AuthCallback,
+	): MqttClient
+
 	public reauthenticate(
 		options?: ReauthenticateOptions | AuthCallback,
 		callback?: AuthCallback,
@@ -1753,12 +1793,10 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 
 		const fail = (message: string) => {
 			this.log('reauthenticate :: %s', message)
-			const err = new Error(`reauthenticate: ${message}`)
-			if (callback) {
-				callback(err)
-			} else {
-				this.emit('error', err)
-			}
+			this._dispatchError(
+				new Error(`reauthenticate: ${message}`),
+				callback,
+			)
 			return this
 		}
 
@@ -1766,7 +1804,17 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			return fail('re-authentication is only supported in MQTT 5.0')
 		}
 
-		if (!this.connected || this.disconnecting) {
+		if (this._checkDisconnecting(callback)) {
+			return this
+		}
+
+		// `connected` is not enough: a graceful `end()` half-closes the socket,
+		// so a write here would never be answered.
+		if (
+			!this.connected ||
+			this.stream?.destroyed ||
+			(this.stream as any)?.writableEnded
+		) {
 			return fail('client is not connected')
 		}
 
@@ -1783,38 +1831,98 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 			return fail('a re-authentication is already in progress')
 		}
 
+		let properties: IAuthPacket['properties']
+		try {
+			properties = this._buildReauthProperties(
+				options as ReauthenticateOptions,
+				authenticationMethod,
+			)
+		} catch (err) {
+			return fail(err.message)
+		}
+
 		const authPacket: IAuthPacket = {
 			cmd: 'auth',
-			reasonCode: 0x19, // Re-authenticate
-			properties: {
-				...(options as ReauthenticateOptions),
-				authenticationMethod,
-			},
+			reasonCode: RC_REAUTHENTICATE,
+			properties,
 		}
 
 		this._reauthPending = true
 		this._reauthCallback = callback || null
-
-		if (this.options.reauthTimeout > 0) {
-			this.reauthTimer = setTimeout(() => {
-				this.log('reauthenticate :: timeout hit, aborting')
-				this._finishReauth(
-					new Error(
-						'reauthenticate: timed out waiting for the broker AUTH response',
-					),
-				)
-			}, this.options.reauthTimeout)
-		}
+		this._reauthRounds = 0
+		this._armReauthTimer()
 
 		this.log('reauthenticate :: sending AUTH packet (reason code 0x19)')
-		this._sendPacket(authPacket, (err) => {
+		const sendCb: DoneCallback = (err) => {
 			if (err) {
 				this.log('reauthenticate :: failed to send AUTH packet')
 				this._finishReauth(err)
 			}
-		})
+		}
+		this._reauthSendCb = sendCb
+
+		try {
+			this._sendPacket(authPacket, sendCb)
+		} catch (err) {
+			// `_writePacket` serializes inline, so a malformed packet throws
+			// straight back at us. Without this the pending state would stay
+			// set for the life of the connection.
+			this.log('reauthenticate :: sending the AUTH packet threw')
+			this._finishReauth(err)
+		}
 
 		return this
+	}
+
+	/**
+	 * Build the AUTH properties for `reauthenticate()`. Only the three
+	 * documented properties are copied - an unknown or malformed one would make
+	 * mqtt-packet destroy the connection, with the raw token in the error
+	 * message - and `authenticationMethod` is always the negotiated one.
+	 */
+	private _buildReauthProperties(
+		options: ReauthenticateOptions | undefined,
+		authenticationMethod: string,
+	): IAuthPacket['properties'] {
+		const properties: IAuthPacket['properties'] = { authenticationMethod }
+
+		if (!options) {
+			return properties
+		}
+
+		const { authenticationData, reasonString, userProperties } = options
+
+		if (typeof authenticationData !== 'undefined') {
+			if (
+				!Buffer.isBuffer(authenticationData) &&
+				typeof authenticationData !== 'string'
+			) {
+				throw new Error(
+					'authenticationData must be a Buffer or a string',
+				)
+			}
+			properties.authenticationData = authenticationData as Buffer
+		}
+
+		if (typeof reasonString !== 'undefined') {
+			if (typeof reasonString !== 'string') {
+				throw new Error('reasonString must be a string')
+			}
+			properties.reasonString = reasonString
+		}
+
+		if (typeof userProperties !== 'undefined') {
+			if (
+				typeof userProperties !== 'object' ||
+				userProperties === null ||
+				Array.isArray(userProperties)
+			) {
+				throw new Error('userProperties must be an object')
+			}
+			properties.userProperties = userProperties
+		}
+
+		return properties
 	}
 
 	/**
@@ -1912,15 +2020,89 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		}
 	}
 
+	/**
+	 * Report an error to a caller supplied callback, or as an `'error'` event
+	 * when there is none. This is the error contract of `publish`, `subscribe`,
+	 * `unsubscribe` and `reauthenticate`.
+	 */
+	private _dispatchError(err: Error, callback?: GenericCallback<any>) {
+		if (callback && callback !== this.noop) {
+			callback(err)
+		} else {
+			this.emit('error', err)
+		}
+	}
+
 	private _checkDisconnecting(callback?: GenericCallback<any>) {
 		if (this.disconnecting) {
-			if (callback && callback !== this.noop) {
-				callback(new Error('client disconnecting'))
-			} else {
-				this.emit('error', new Error('client disconnecting'))
-			}
+			this._dispatchError(new Error('client disconnecting'), callback)
 		}
 		return this.disconnecting
+	}
+
+	/**
+	 * A protocol violation by the broker is fatal to the connection.
+	 *
+	 * This runs on the packet parsing path, where an `'error'` event with no
+	 * listener - or a listener that throws - would skip the parser's `done()`
+	 * and wedge it while `connected` stays true, so the event is deferred and
+	 * the teardown does not depend on the application having a listener.
+	 */
+	private _onProtocolError(err: ErrorWithReasonCode) {
+		this.log('_onProtocolError :: %s', err.message)
+		setImmediate(() => {
+			if (this.listenerCount('error') > 0) {
+				this.emit('error', err)
+			}
+		})
+		this._cleanUp(true)
+	}
+
+	/** (Re)arm the abort timer of the current re-authentication exchange. */
+	private _armReauthTimer() {
+		clearTimeout(this.reauthTimer)
+		this.reauthTimer = null
+
+		if (this.options.reauthTimeout > 0) {
+			this.reauthTimer = setTimeout(() => {
+				this.log('reauthenticate :: timeout hit, aborting')
+				this._finishReauth(
+					new Error(
+						'reauthenticate: timed out waiting for the broker AUTH response',
+					),
+				)
+			}, this.options.reauthTimeout)
+		}
+	}
+
+	/**
+	 * Account for one broker challenge (AUTH 0x18) of the current exchange.
+	 * Returns false when the exchange has been aborted for exceeding
+	 * `MAX_REAUTH_ROUNDS`; a legitimate round refreshes the deadline.
+	 */
+	private _startReauthRound(): boolean {
+		this._reauthRounds += 1
+
+		if (this._reauthRounds > MAX_REAUTH_ROUNDS) {
+			this.log('reauthenticate :: too many challenges, aborting')
+			this._finishReauth(
+				new Error(
+					`reauthenticate: the broker sent more than ${MAX_REAUTH_ROUNDS} authentication challenges`,
+				),
+			)
+			return false
+		}
+
+		this._armReauthTimer()
+		return true
+	}
+
+	/** Abort a re-authentication that can no longer complete. No-op when none is pending. */
+	private _abortReauth(reason: string) {
+		if (this._reauthPending) {
+			this.log('_abortReauth :: %s', reason)
+			this._finishReauth(new Error(`reauthenticate: ${reason}`))
+		}
 	}
 
 	/**
@@ -1981,10 +2163,6 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	}
 
 	/**
-	 * _cleanUp - clean up on connection end
-	 * @api private
-	 */
-	/**
 	 * _finishReauth - complete the pending re-authentication exchange
 	 *
 	 * Clears the timer and the pending state, then reports the outcome to the
@@ -1992,8 +2170,9 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	 * given). On success the `'reauth'` event is emitted.
 	 *
 	 * @param {Error | null} err - failure reason, or null on success
-	 * @param {IAuthPacket} [packet] - the final AUTH packet received, only
-	 * reported to the callback on success
+	 * @param {IAuthPacket} [packet] - the last AUTH packet received, reported to
+	 * the callback on success and on a broker side failure: its `reasonString`
+	 * and `userProperties` are the only record of why the broker refused
 	 */
 	private _finishReauth(err: Error | null, packet?: IAuthPacket) {
 		if (!this._reauthPending) {
@@ -2011,26 +2190,40 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		clearTimeout(this.reauthTimer)
 		this.reauthTimer = null
 
+		// The send callback is parked on 'drain' while the stream is backed up;
+		// leaving it there leaks one listener per aborted exchange.
+		if (this._reauthSendCb) {
+			this.stream?.removeListener('drain', this._reauthSendCb)
+			this._reauthSendCb = null
+		}
+
 		const callback = this._reauthCallback
 		this._reauthPending = false
 		this._reauthCallback = null
+		this._reauthRounds = 0
 
 		if (err) {
-			if (callback) {
-				callback(err)
-			} else {
-				this.emit('error', err)
-			}
+			this.lastReauthError = err
+			this._dispatchError(err, callback)
 			return
 		}
 
+		this.lastReauthError = null
 		if (callback) {
 			callback(null, packet)
 		}
 		this.emit('reauth', packet)
 	}
 
+	/**
+	 * _cleanUp - clean up on connection end
+	 * @api private
+	 */
 	private _cleanUp(forced: boolean, done?: DoneCallback, opts = {}) {
+		// Synchronous teardown entry point: a graceful end() only half-closes
+		// the socket, so waiting for 'close' can strand the exchange forever.
+		this._abortReauth('connection closed before the broker answered')
+
 		if (done) {
 			this.log('_cleanUp :: done callback provided for on stream close')
 			this.stream.on('close', done)

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -65,6 +65,7 @@ const defaultConnectOptions: IClientOptions = {
 	subscribeBatchSize: null,
 	writeCache: true,
 	timerVariant: 'auto',
+	reauthTimeout: 30 * 1000,
 }
 
 export type BaseMqttProtocol =
@@ -182,6 +183,12 @@ export interface IClientOptions extends ISecureClientOptions {
 	 * 30 * 1000 milliseconds, time to wait before a CONNACK is received
 	 */
 	connectTimeout?: number
+	/**
+	 * 30 * 1000 milliseconds, time to wait for the broker to complete a
+	 * re-authentication exchange started with `reauthenticate()`
+	 * (MQTT 5.0 only). Set to 0 to disable the timeout.
+	 */
+	reauthTimeout?: number
 
 	/**
 	 * a Store for the incoming packets
@@ -424,6 +431,15 @@ export type PacketCallback = (
 	packet?: Packet,
 ) => any
 export type CloseCallback = (error?: Error) => void
+export type AuthCallback = (err?: Error | null, packet?: IAuthPacket) => void
+/**
+ * Properties of the AUTH packet sent by `reauthenticate()`. The
+ * `authenticationMethod` is always the one used in the CONNECT packet.
+ */
+export type ReauthenticateOptions = Pick<
+	NonNullable<IAuthPacket['properties']>,
+	'authenticationData' | 'reasonString' | 'userProperties'
+>
 
 export interface MqttClientEventCallbacks {
 	connect: OnConnectCallback
@@ -437,6 +453,7 @@ export interface MqttClientEventCallbacks {
 	reconnect: VoidCallback
 	offline: VoidCallback
 	outgoingEmpty: VoidCallback
+	reauth: (packet: IAuthPacket) => void
 }
 
 /**
@@ -503,6 +520,15 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	private connackTimer: NodeJS.Timeout
 
 	private reconnectTimer: NodeJS.Timeout
+
+	/** Timer used to abort a re-authentication that receives no answer */
+	private reauthTimer: NodeJS.Timeout
+
+	/** True while a re-authentication exchange is in progress */
+	private _reauthPending: boolean
+
+	/** Callback of the pending re-authentication, if any */
+	private _reauthCallback: AuthCallback | null
 
 	private _storeProcessing: boolean
 
@@ -633,6 +659,10 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 		this.connackTimer = null
 		// Reconnect timer
 		this.reconnectTimer = null
+		// Re-authentication state
+		this.reauthTimer = null
+		this._reauthPending = false
+		this._reauthCallback = null
 		// Is processing store?
 		this._storeProcessing = false
 		// Packet Ids are put into the store during store processing
@@ -706,6 +736,15 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 
 			this.log('close :: clearing connackTimer')
 			clearTimeout(this.connackTimer)
+
+			if (this._reauthPending) {
+				this.log('close :: aborting pending re-authentication')
+				this._finishReauth(
+					new Error(
+						'reauthenticate: connection closed before the broker answered',
+					),
+				)
+			}
 
 			this._destroyKeepaliveManager()
 
@@ -1683,6 +1722,123 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	}
 
 	/**
+	 * reauthenticate - start an MQTT 5.0 re-authentication exchange
+	 * (MQTT 5.0 spec, section 4.12.1).
+	 *
+	 * Sends an AUTH packet with reason code 0x19 (Re-authenticate) using the
+	 * `authenticationMethod` of the CONNECT packet. The broker answers with
+	 * AUTH 0x18 (Continue authentication, forwarded to `handleAuth()`) or
+	 * AUTH 0x00 (Success), after which the `'reauth'` event is emitted.
+	 *
+	 * @param {Object} [options] - AUTH packet properties
+	 * @param {Buffer} [options.authenticationData] - Binary Data for the authentication method
+	 * @param {String} [options.reasonString] - Reason String
+	 * @param {Object} [options.userProperties] - User Properties
+	 * @param {Function} [callback] - fired when the exchange completes: `(err, packet)`.
+	 *   When omitted, failures are emitted as `'error'` events.
+	 * @returns {MqttClient} this - for chaining
+	 * @api public
+	 * @example client.reauthenticate({ authenticationData: Buffer.from(newToken) }, (err) => {})
+	 */
+	public reauthenticate(
+		options?: ReauthenticateOptions | AuthCallback,
+		callback?: AuthCallback,
+	): MqttClient {
+		this.log('reauthenticate :: (%s)', this.options.clientId)
+
+		if (typeof options === 'function') {
+			callback = options
+			options = undefined
+		}
+
+		const fail = (message: string) => {
+			this.log('reauthenticate :: %s', message)
+			const err = new Error(`reauthenticate: ${message}`)
+			if (callback) {
+				callback(err)
+			} else {
+				this.emit('error', err)
+			}
+			return this
+		}
+
+		if (this.options.protocolVersion !== 5) {
+			return fail('re-authentication is only supported in MQTT 5.0')
+		}
+
+		if (!this.connected || this.disconnecting) {
+			return fail('client is not connected')
+		}
+
+		const authenticationMethod =
+			this.options.properties?.authenticationMethod
+
+		if (!authenticationMethod) {
+			return fail(
+				'an authenticationMethod must be set in the CONNECT properties',
+			)
+		}
+
+		if (this._reauthPending) {
+			return fail('a re-authentication is already in progress')
+		}
+
+		const authPacket: IAuthPacket = {
+			cmd: 'auth',
+			reasonCode: 0x19, // Re-authenticate
+			properties: {
+				...(options as ReauthenticateOptions),
+				authenticationMethod,
+			},
+		}
+
+		this._reauthPending = true
+		this._reauthCallback = callback || null
+
+		if (this.options.reauthTimeout > 0) {
+			this.reauthTimer = setTimeout(() => {
+				this.log('reauthenticate :: timeout hit, aborting')
+				this._finishReauth(
+					new Error(
+						'reauthenticate: timed out waiting for the broker AUTH response',
+					),
+				)
+			}, this.options.reauthTimeout)
+		}
+
+		this.log('reauthenticate :: sending AUTH packet (reason code 0x19)')
+		this._sendPacket(authPacket, (err) => {
+			if (err) {
+				this.log('reauthenticate :: failed to send AUTH packet')
+				this._finishReauth(err)
+			}
+		})
+
+		return this
+	}
+
+	/**
+	 * reauthenticateAsync - promise wrapper around `reauthenticate()`
+	 *
+	 * @param {Object} [options] - see `reauthenticate()`
+	 * @returns {Promise<IAuthPacket>} resolves with the final AUTH packet of the broker
+	 * @api public
+	 */
+	public reauthenticateAsync(
+		options?: ReauthenticateOptions,
+	): Promise<IAuthPacket> {
+		return new Promise((resolve, reject) => {
+			this.reauthenticate(options, (err, packet) => {
+				if (err) {
+					reject(err)
+				} else {
+					resolve(packet)
+				}
+			})
+		})
+	}
+
+	/**
 	 * PRIVATE METHODS
 	 * =====================
 	 * */
@@ -1828,6 +1984,51 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	 * _cleanUp - clean up on connection end
 	 * @api private
 	 */
+	/**
+	 * _finishReauth - complete the pending re-authentication exchange
+	 *
+	 * Clears the timer and the pending state, then reports the outcome to the
+	 * `reauthenticate()` callback (or emits `'error'` when no callback was
+	 * given). On success the `'reauth'` event is emitted.
+	 *
+	 * @param {Error | null} err - failure reason, or null on success
+	 * @param {IAuthPacket} [packet] - the final AUTH packet received
+	 */
+	private _finishReauth(err: Error | null, packet?: IAuthPacket) {
+		if (!this._reauthPending) {
+			this.log(
+				'_finishReauth :: no re-authentication in progress, ignoring',
+			)
+			return
+		}
+
+		this.log(
+			'_finishReauth :: %s',
+			err ? `failed: ${err.message}` : 'success',
+		)
+
+		clearTimeout(this.reauthTimer)
+		this.reauthTimer = null
+
+		const callback = this._reauthCallback
+		this._reauthPending = false
+		this._reauthCallback = null
+
+		if (err) {
+			if (callback) {
+				callback(err)
+			} else {
+				this.emit('error', err)
+			}
+			return
+		}
+
+		if (callback) {
+			callback(null, packet)
+		}
+		this.emit('reauth', packet)
+	}
+
 	private _cleanUp(forced: boolean, done?: DoneCallback, opts = {}) {
 		if (done) {
 			this.log('_cleanUp :: done callback provided for on stream close')

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1992,7 +1992,8 @@ export default class MqttClient extends TypedEventEmitter<MqttClientEventCallbac
 	 * given). On success the `'reauth'` event is emitted.
 	 *
 	 * @param {Error | null} err - failure reason, or null on success
-	 * @param {IAuthPacket} [packet] - the final AUTH packet received
+	 * @param {IAuthPacket} [packet] - the final AUTH packet received, only
+	 * reported to the callback on success
 	 */
 	private _finishReauth(err: Error | null, packet?: IAuthPacket) {
 		if (!this._reauthPending) {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -446,8 +446,14 @@ export type AuthCallback = GenericCallback<IAuthPacket>
  */
 export type ReauthenticateOptions = Pick<
 	NonNullable<IAuthPacket['properties']>,
-	'authenticationData' | 'reasonString' | 'userProperties'
->
+	'reasonString' | 'userProperties'
+> & {
+	/**
+	 * The new credential. `mqtt-packet` types this as a Buffer, but a string is
+	 * accepted too and is written as UTF-8.
+	 */
+	authenticationData?: Buffer | string
+}
 
 export interface MqttClientEventCallbacks {
 	connect: OnConnectCallback

--- a/src/lib/handlers/ack.ts
+++ b/src/lib/handlers/ack.ts
@@ -3,7 +3,7 @@
 import { type PacketHandler, ErrorWithReasonCode } from '../shared'
 
 export const ReasonCodes = {
-	0: '',
+	0: 'Success',
 	1: 'Unacceptable protocol version',
 	2: 'Identifier rejected',
 	3: 'Server unavailable',
@@ -11,6 +11,8 @@ export const ReasonCodes = {
 	5: 'Not authorized',
 	16: 'No matching subscribers',
 	17: 'No subscription existed',
+	24: 'Continue authentication',
+	25: 'Re-authenticate',
 	128: 'Unspecified error',
 	129: 'Malformed Packet',
 	130: 'Protocol Error',
@@ -47,6 +49,13 @@ export const ReasonCodes = {
 	161: 'Subscription Identifiers not supported',
 	162: 'Wildcard Subscriptions not supported',
 }
+
+/**
+ * Human readable text for a reason code, falling back to the numeric value so
+ * an unlisted code still names itself in the error message.
+ */
+export const reasonCodeText = (code: number): string =>
+	ReasonCodes[code] || `Unknown reason code 0x${Number(code).toString(16)}`
 
 const handleAck: PacketHandler = (client, packet) => {
 	/* eslint no-fallthrough: "off" */

--- a/src/lib/handlers/auth.ts
+++ b/src/lib/handlers/auth.ts
@@ -2,6 +2,10 @@ import { type IAuthPacket } from 'mqtt-packet'
 import { ErrorWithReasonCode, type PacketHandler } from '../shared'
 import { ReasonCodes } from './ack'
 
+const RC_SUCCESS = 0x00
+const RC_CONTINUE_AUTHENTICATION = 0x18
+const RC_PROTOCOL_ERROR = 0x82
+
 const handleAuth: PacketHandler = (
 	client,
 	packet: IAuthPacket & { returnCode: number },
@@ -9,6 +13,8 @@ const handleAuth: PacketHandler = (
 	const { options } = client
 	const version = options.protocolVersion
 	const rc = version === 5 ? packet.reasonCode : packet.returnCode
+
+	client.log('handleAuth :: received AUTH packet, reason code %d', rc)
 
 	if (version !== 5) {
 		const err = new ErrorWithReasonCode(
@@ -19,26 +25,102 @@ const handleAuth: PacketHandler = (
 		return
 	}
 
-	client.handleAuth(
-		packet,
-		(err: ErrorWithReasonCode, packet2: IAuthPacket) => {
-			if (err) {
-				client.emit('error', err)
-				return
-			}
+	if (!client.connected) {
+		// Enhanced authentication exchange during connection (before CONNACK)
+		client.log('handleAuth :: enhanced authentication during connect')
+		client.handleAuth(
+			packet,
+			(err: ErrorWithReasonCode, packet2: IAuthPacket) => {
+				if (err) {
+					client.emit('error', err)
+					return
+				}
 
-			if (rc === 24) {
-				client.reconnecting = false
-				client['_sendPacket'](packet2)
-			} else {
-				const error = new ErrorWithReasonCode(
-					`Connection refused: ${ReasonCodes[rc]}`,
+				if (rc === RC_CONTINUE_AUTHENTICATION) {
+					client.reconnecting = false
+					client['_sendPacket'](packet2)
+				} else {
+					const error = new ErrorWithReasonCode(
+						`Connection refused: ${ReasonCodes[rc]}`,
+						rc,
+					)
+					client.emit('error', error)
+				}
+			},
+		)
+		return
+	}
+
+	// Re-authentication (MQTT 5.0 spec, section 4.12.1): the exchange can only
+	// be started by the client, so an AUTH packet received while no
+	// re-authentication is in progress is a protocol error.
+	if (!client['_reauthPending']) {
+		client.log(
+			'handleAuth :: unexpected AUTH packet while no re-authentication is in progress',
+		)
+		client.emit(
+			'error',
+			new ErrorWithReasonCode(
+				'Protocol error: received AUTH packet while no re-authentication is in progress',
+				RC_PROTOCOL_ERROR,
+			),
+		)
+		return
+	}
+
+	switch (rc) {
+		case RC_SUCCESS:
+			client.log('handleAuth :: re-authentication succeeded')
+			client['_finishReauth'](null, packet)
+			break
+
+		case RC_CONTINUE_AUTHENTICATION:
+			client.log(
+				'handleAuth :: re-authentication continues, calling client.handleAuth()',
+			)
+			client.handleAuth(
+				packet,
+				(err: ErrorWithReasonCode, packet2: IAuthPacket) => {
+					if (err) {
+						client.log('handleAuth :: client.handleAuth() failed')
+						client['_finishReauth'](err)
+						return
+					}
+
+					if (!packet2) {
+						client['_finishReauth'](
+							new ErrorWithReasonCode(
+								'Re-authentication failed: client.handleAuth() did not provide an AUTH packet to continue the exchange',
+								rc,
+							),
+						)
+						return
+					}
+
+					client.log('handleAuth :: sending next AUTH packet')
+					client['_sendPacket'](packet2, (sendErr) => {
+						if (sendErr) {
+							client.log(
+								'handleAuth :: failed to send next AUTH packet',
+							)
+							client['_finishReauth'](sendErr)
+						}
+					})
+				},
+			)
+			break
+
+		default:
+			client.log('handleAuth :: re-authentication refused by broker')
+			client['_finishReauth'](
+				new ErrorWithReasonCode(
+					`Re-authentication failed: ${ReasonCodes[rc]}`,
 					rc,
-				)
-				client.emit('error', error)
-			}
-		},
-	)
+				),
+				packet,
+			)
+			break
+	}
 }
 
 export default handleAuth

--- a/src/lib/handlers/auth.ts
+++ b/src/lib/handlers/auth.ts
@@ -1,10 +1,53 @@
 import { type IAuthPacket } from 'mqtt-packet'
 import { ErrorWithReasonCode, type PacketHandler } from '../shared'
-import { ReasonCodes } from './ack'
+import { reasonCodeText } from './ack'
 
-const RC_SUCCESS = 0x00
-const RC_CONTINUE_AUTHENTICATION = 0x18
-const RC_PROTOCOL_ERROR = 0x82
+export const RC_SUCCESS = 0x00
+export const RC_CONTINUE_AUTHENTICATION = 0x18
+export const RC_REAUTHENTICATE = 0x19
+export const RC_PROTOCOL_ERROR = 0x82
+export const RC_BAD_AUTHENTICATION_METHOD = 0x8c
+
+/**
+ * Hand an AUTH packet to `client.handleAuth()` and send the packet it provides.
+ * Shared by the pre-CONNACK exchange and the re-authentication exchange, which
+ * differ only in where a failure is reported: that is `onError`.
+ */
+const continueAuth = (
+	client: Parameters<PacketHandler>[0],
+	packet: IAuthPacket,
+	rc: number,
+	onError: (err: Error) => void,
+) => {
+	client.handleAuth(
+		packet,
+		(err: ErrorWithReasonCode, packet2: IAuthPacket) => {
+			if (err) {
+				client.log('handleAuth :: client.handleAuth() failed')
+				onError(err)
+				return
+			}
+
+			if (!packet2) {
+				onError(
+					new ErrorWithReasonCode(
+						'Authentication failed: client.handleAuth() did not provide an AUTH packet to continue the exchange',
+						rc,
+					),
+				)
+				return
+			}
+
+			client.log('handleAuth :: sending next AUTH packet')
+			client['_sendPacket'](packet2, (sendErr) => {
+				if (sendErr) {
+					client.log('handleAuth :: failed to send next AUTH packet')
+					onError(sendErr)
+				}
+			})
+		},
+	)
+}
 
 const handleAuth: PacketHandler = (
 	client,
@@ -14,7 +57,10 @@ const handleAuth: PacketHandler = (
 	const version = options.protocolVersion
 	const rc = version === 5 ? packet.reasonCode : packet.returnCode
 
-	client.log('handleAuth :: received AUTH packet, reason code %d', rc)
+	client.log(
+		'handleAuth :: received AUTH packet, reason code 0x%s',
+		Number(rc).toString(16),
+	)
 
 	if (version !== 5) {
 		const err = new ErrorWithReasonCode(
@@ -28,26 +74,22 @@ const handleAuth: PacketHandler = (
 	if (!client.connected) {
 		// Enhanced authentication exchange during connection (before CONNACK)
 		client.log('handleAuth :: enhanced authentication during connect')
-		client.handleAuth(
-			packet,
-			(err: ErrorWithReasonCode, packet2: IAuthPacket) => {
-				if (err) {
-					client.emit('error', err)
-					return
-				}
 
-				if (rc === RC_CONTINUE_AUTHENTICATION) {
-					client.reconnecting = false
-					client['_sendPacket'](packet2)
-				} else {
-					const error = new ErrorWithReasonCode(
-						`Connection refused: ${ReasonCodes[rc]}`,
-						rc,
-					)
-					client.emit('error', error)
-				}
-			},
-		)
+		if (rc !== RC_CONTINUE_AUTHENTICATION) {
+			client.emit(
+				'error',
+				new ErrorWithReasonCode(
+					`Connection refused: ${reasonCodeText(rc)}`,
+					rc,
+				),
+			)
+			return
+		}
+
+		client.reconnecting = false
+		continueAuth(client, packet, rc, (err) => {
+			client.emit('error', err)
+		})
 		return
 	}
 
@@ -58,12 +100,32 @@ const handleAuth: PacketHandler = (
 		client.log(
 			'handleAuth :: unexpected AUTH packet while no re-authentication is in progress',
 		)
-		client.emit(
-			'error',
+		client['_onProtocolError'](
 			new ErrorWithReasonCode(
 				'Protocol error: received AUTH packet while no re-authentication is in progress',
 				RC_PROTOCOL_ERROR,
 			),
+		)
+		return
+	}
+
+	// [MQTT-4.12.0-5]: every AUTH packet of an exchange carries the
+	// authentication method of the CONNECT packet. Enforce it here so a broker
+	// cannot steer client.handleAuth() onto a method the client never agreed to.
+	const negotiated = options.properties?.authenticationMethod
+	const received = packet.properties?.authenticationMethod
+	if (received !== negotiated) {
+		client.log(
+			'handleAuth :: authentication method mismatch, expected %s got %o',
+			negotiated,
+			received,
+		)
+		client['_finishReauth'](
+			new ErrorWithReasonCode(
+				`Bad authentication method: the broker answered with '${received}' instead of the negotiated '${negotiated}'`,
+				RC_BAD_AUTHENTICATION_METHOD,
+			),
+			packet,
 		)
 		return
 	}
@@ -78,50 +140,30 @@ const handleAuth: PacketHandler = (
 			client.log(
 				'handleAuth :: re-authentication continues, calling client.handleAuth()',
 			)
-			client.handleAuth(
-				packet,
-				(err: ErrorWithReasonCode, packet2: IAuthPacket) => {
-					if (err) {
-						client.log('handleAuth :: client.handleAuth() failed')
-						client['_finishReauth'](err)
-						return
-					}
-
-					if (!packet2) {
-						client['_finishReauth'](
-							new ErrorWithReasonCode(
-								'Re-authentication failed: client.handleAuth() did not provide an AUTH packet to continue the exchange',
-								rc,
-							),
-						)
-						return
-					}
-
-					client.log('handleAuth :: sending next AUTH packet')
-					client['_sendPacket'](packet2, (sendErr) => {
-						if (sendErr) {
-							client.log(
-								'handleAuth :: failed to send next AUTH packet',
-							)
-							client['_finishReauth'](sendErr)
-						}
-					})
-				},
-			)
+			// A multi-round exchange must not run past its deadline just
+			// because it started in time, and an unbounded number of rounds is
+			// work the broker can force on the client.
+			if (!client['_startReauthRound']()) {
+				break
+			}
+			continueAuth(client, packet, rc, (err) => {
+				client['_finishReauth'](err, packet)
+			})
 			break
 
 		default:
 			// An AUTH packet can only carry 0x00, 0x18 or 0x19, so this is
 			// always 0x19: a broker must never ask a client to re-authenticate.
 			client.log(
-				'handleAuth :: unexpected AUTH reason code %d from broker',
-				rc,
+				'handleAuth :: unexpected AUTH reason code 0x%s from broker',
+				Number(rc).toString(16),
 			)
 			client['_finishReauth'](
 				new ErrorWithReasonCode(
 					`Protocol error: unexpected AUTH reason code ${rc} received from the broker`,
 					rc,
 				),
+				packet,
 			)
 			break
 	}

--- a/src/lib/handlers/auth.ts
+++ b/src/lib/handlers/auth.ts
@@ -111,13 +111,17 @@ const handleAuth: PacketHandler = (
 			break
 
 		default:
-			client.log('handleAuth :: re-authentication refused by broker')
+			// An AUTH packet can only carry 0x00, 0x18 or 0x19, so this is
+			// always 0x19: a broker must never ask a client to re-authenticate.
+			client.log(
+				'handleAuth :: unexpected AUTH reason code %d from broker',
+				rc,
+			)
 			client['_finishReauth'](
 				new ErrorWithReasonCode(
-					`Re-authentication failed: ${ReasonCodes[rc]}`,
+					`Protocol error: unexpected AUTH reason code ${rc} received from the broker`,
 					rc,
 				),
-				packet,
 			)
 			break
 	}

--- a/test/node/client_mqtt5.ts
+++ b/test/node/client_mqtt5.ts
@@ -2320,5 +2320,157 @@ describe('MQTT 5.0', () => {
 				})
 			},
 		)
+
+		it(
+			'should reject a reasonString that is not a string',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 26
+				let authPackets = 0
+				const testServer = buildReauthServer(port, (serverClient) => {
+					authPackets++
+					serverClient.auth({
+						reasonCode: 0,
+						properties: { authenticationMethod: authMethod },
+					})
+				})
+				const client = connectV5(port)
+				client.on('error', done)
+
+				client.once('connect', () => {
+					client.reauthenticate(
+						{ reasonString: 42 } as any,
+						(err) => {
+							assert.strictEqual(
+								err.message,
+								'reauthenticate: reasonString must be a string',
+							)
+							assert.strictEqual(authPackets, 0)
+							client.end(true, () => testServer.close(done))
+						},
+					)
+				})
+			},
+		)
+
+		it(
+			'should reject userProperties that are not a plain object',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 27
+				let received: any = null
+				const testServer = buildReauthServer(
+					port,
+					(serverClient, packet) => {
+						received = packet.properties.userProperties
+						serverClient.auth({
+							reasonCode: 0,
+							properties: { authenticationMethod: authMethod },
+						})
+					},
+				)
+				const client = connectV5(port)
+				client.on('error', done)
+
+				client.once('connect', () => {
+					client.reauthenticate(
+						{ userProperties: ['session'] } as any,
+						(err) => {
+							assert.strictEqual(
+								err.message,
+								'reauthenticate: userProperties must be an object',
+							)
+							assert.isNull(received)
+							// a valid object is forwarded to the broker
+							client.reauthenticate(
+								{ userProperties: { session: 'abc' } },
+								(err2) => {
+									assert.ifError(err2)
+									assert.deepStrictEqual(received, {
+										session: 'abc',
+									})
+									client.end(true, () =>
+										testServer.close(done),
+									)
+								},
+							)
+						},
+					)
+				})
+			},
+		)
+
+		it(
+			'should not strand the exchange when the AUTH packet cannot be serialized',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 28
+				let authPackets = 0
+				const testServer = buildReauthServer(port, (serverClient) => {
+					authPackets++
+					serverClient.auth({
+						reasonCode: 0,
+						properties: { authenticationMethod: authMethod },
+					})
+				})
+				const client = connectV5(port)
+				client.on('error', done)
+
+				client.once('connect', () => {
+					// mqtt-packet reads every user property value while it
+					// measures the packet, so a null one throws out of
+					// _writePacket before a byte reaches the stream
+					client.reauthenticate(
+						{ userProperties: { session: null } } as any,
+						(err) => {
+							assert.instanceOf(err, TypeError)
+							assert.strictEqual(authPackets, 0)
+							assert.isFalse(client['_reauthPending'])
+							// the pending state was released, so the next
+							// exchange still runs
+							client.reauthenticate((err2) => {
+								assert.ifError(err2)
+								assert.strictEqual(authPackets, 1)
+								client.end(true, () => testServer.close(done))
+							})
+						},
+					)
+				})
+			},
+		)
+
+		it(
+			'should emit an error when handleAuth fails before CONNACK',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 29
+				let authPackets = 0
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () =>
+						serverClient.auth({
+							reasonCode: 0x18,
+							properties: {
+								authenticationMethod: authMethod,
+							},
+						}),
+					)
+					serverClient.on('auth', () => {
+						authPackets++
+					})
+				}).listen(port)
+
+				const client = connectV5(port)
+				client.handleAuth = (packet, callback) => {
+					callback(new Error('token expired') as ErrorWithReasonCode)
+				}
+
+				client.once('error', (err) => {
+					assert.strictEqual(err.message, 'token expired')
+					assert.strictEqual(authPackets, 0)
+					assert.isFalse(client.connected)
+					client.end(true, () => testServer.close(done))
+				})
+			},
+		)
 	})
 })

--- a/test/node/client_mqtt5.ts
+++ b/test/node/client_mqtt5.ts
@@ -1863,5 +1863,53 @@ describe('MQTT 5.0', () => {
 				})
 			},
 		)
+		it(
+			'reauthenticateAsync should reject when the exchange fails',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 13
+				const testServer = buildReauthServer(port, (serverClient) => {
+					serverClient.auth({ reasonCode: 0x19 })
+				})
+
+				const client = connectV5(port)
+				client.on('error', done)
+
+				client.once('connect', async () => {
+					try {
+						await client.reauthenticateAsync()
+						done(new Error('should have rejected'))
+					} catch (err) {
+						assert.match(err.message, /Protocol error/)
+						client.end(true, () => testServer.close(done))
+					}
+				})
+			},
+		)
+
+		it(
+			'should emit an error when the exchange fails and no callback is given',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 14
+				const testServer = buildReauthServer(port, (serverClient) => {
+					serverClient.auth({ reasonCode: 0x19 })
+				})
+
+				const client = connectV5(port)
+
+				client.once('connect', () => {
+					client.once('error', (err) => {
+						assert.match(err.message, /Protocol error/)
+						assert.strictEqual(
+							(err as ErrorWithReasonCode).code,
+							0x19,
+						)
+						client.end(true, () => testServer.close(done))
+					})
+					client.reauthenticate()
+				})
+			},
+		)
 	})
 })

--- a/test/node/client_mqtt5.ts
+++ b/test/node/client_mqtt5.ts
@@ -1494,7 +1494,12 @@ describe('MQTT 5.0', () => {
 							packet.properties.reasonString,
 							'token refresh',
 						)
-						serverClient.auth({ reasonCode: 0 })
+						serverClient.auth({
+							reasonCode: 0,
+							properties: {
+								authenticationMethod: authMethod,
+							},
+						})
 					},
 				)
 
@@ -1534,7 +1539,12 @@ describe('MQTT 5.0', () => {
 			function _test(t, done) {
 				const port = basePort + 1
 				const testServer = buildReauthServer(port, (serverClient) => {
-					serverClient.auth({ reasonCode: 0 })
+					serverClient.auth({
+						reasonCode: 0,
+						properties: {
+							authenticationMethod: authMethod,
+						},
+					})
 				})
 
 				const client = connectV5(port)
@@ -1579,7 +1589,12 @@ describe('MQTT 5.0', () => {
 									response,
 								),
 							)
-							serverClient.auth({ reasonCode: 0 })
+							serverClient.auth({
+								reasonCode: 0,
+								properties: {
+									authenticationMethod: authMethod,
+								},
+							})
 						}
 					},
 				)
@@ -1679,12 +1694,31 @@ describe('MQTT 5.0', () => {
 				const client = connectV5(port)
 				client.on('error', done)
 
+				client.reauthenticate((err) => {
+					assert.strictEqual(
+						err.message,
+						'reauthenticate: client is not connected',
+					)
+					client.end(true, () => testServer.close(done))
+				})
+			},
+		)
+
+		it(
+			'should fail when the client is disconnecting',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 4
+				const testServer = buildReauthServer(port, () => {})
+				const client = connectV5(port)
+				client.on('error', done)
+
 				client.once('connect', () => {
 					client.end(true, () => {
 						client.reauthenticate((err) => {
 							assert.strictEqual(
 								err.message,
-								'reauthenticate: client is not connected',
+								'client disconnecting',
 							)
 							testServer.close(done)
 						})
@@ -1805,7 +1839,10 @@ describe('MQTT 5.0', () => {
 				const port = basePort + 11
 				const testServer = buildReauthServer(port, (serverClient) => {
 					// 0x19 (Re-authenticate) may only travel client to broker
-					serverClient.auth({ reasonCode: 0x19 })
+					serverClient.auth({
+						reasonCode: 0x19,
+						properties: { authenticationMethod: authMethod },
+					})
 				})
 
 				const client = connectV5(port)
@@ -1869,7 +1906,10 @@ describe('MQTT 5.0', () => {
 			function _test(t, done) {
 				const port = basePort + 13
 				const testServer = buildReauthServer(port, (serverClient) => {
-					serverClient.auth({ reasonCode: 0x19 })
+					serverClient.auth({
+						reasonCode: 0x19,
+						properties: { authenticationMethod: authMethod },
+					})
 				})
 
 				const client = connectV5(port)
@@ -1893,7 +1933,10 @@ describe('MQTT 5.0', () => {
 			function _test(t, done) {
 				const port = basePort + 14
 				const testServer = buildReauthServer(port, (serverClient) => {
-					serverClient.auth({ reasonCode: 0x19 })
+					serverClient.auth({
+						reasonCode: 0x19,
+						properties: { authenticationMethod: authMethod },
+					})
 				})
 
 				const client = connectV5(port)
@@ -1908,6 +1951,372 @@ describe('MQTT 5.0', () => {
 						client.end(true, () => testServer.close(done))
 					})
 					client.reauthenticate()
+				})
+			},
+		)
+
+		it(
+			'should run the enhanced authentication exchange before CONNACK',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 24
+				const challenge = Buffer.from('challenge')
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () =>
+						serverClient.auth({
+							reasonCode: 0x18,
+							properties: {
+								authenticationMethod: authMethod,
+								authenticationData: challenge,
+							},
+						}),
+					)
+					serverClient.on('auth', (packet) => {
+						assert.strictEqual(packet.reasonCode, 0x18)
+						assert.ok(
+							packet.properties.authenticationData.equals(
+								Buffer.from('response'),
+							),
+						)
+						serverClient.connack({ reasonCode: 0 })
+					})
+				}).listen(port)
+
+				const client = connectV5(port)
+				client.on('error', done)
+
+				client.handleAuth = (packet, callback) => {
+					assert.ok(
+						packet.properties.authenticationData.equals(challenge),
+					)
+					callback(null, {
+						cmd: 'auth',
+						reasonCode: 0x18,
+						properties: {
+							authenticationMethod: authMethod,
+							authenticationData: Buffer.from('response'),
+						},
+					})
+				}
+
+				client.once('connect', () => {
+					client.end(true, () => testServer.close(done))
+				})
+			},
+		)
+
+		it(
+			'should refuse the connection when a pre-CONNACK AUTH is not a challenge',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 25
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () =>
+						serverClient.auth({
+							reasonCode: 0x19,
+							properties: {
+								authenticationMethod: authMethod,
+							},
+						}),
+					)
+				}).listen(port)
+
+				const client = connectV5(port)
+				client.once('error', (err) => {
+					assert.strictEqual(
+						err.message,
+						'Connection refused: Re-authenticate',
+					)
+					client.end(true, () => testServer.close(done))
+				})
+			},
+		)
+
+		it(
+			'should reject an AUTH packet carrying a different authentication method',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 15
+				const testServer = buildReauthServer(port, (serverClient) => {
+					serverClient.auth({
+						reasonCode: 0x18,
+						properties: { authenticationMethod: 'WEAKER-AUTH' },
+					})
+				})
+
+				const client = connectV5(port)
+				client.on('error', done)
+
+				let handleAuthCalls = 0
+				client.handleAuth = (packet, callback) => {
+					handleAuthCalls++
+					callback(null, packet)
+				}
+
+				client.once('connect', () => {
+					client.reauthenticate((err) => {
+						assert.match(err.message, /Bad authentication method/)
+						assert.strictEqual(
+							(err as ErrorWithReasonCode).code,
+							0x8c,
+						)
+						// the hook must not run under the broker's method
+						assert.strictEqual(handleAuthCalls, 0)
+						client.end(true, () => testServer.close(done))
+					})
+				})
+			},
+		)
+
+		it(
+			'should not let options override the negotiated authenticationMethod',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 16
+				const testServer = buildReauthServer(
+					port,
+					(serverClient, packet) => {
+						assert.strictEqual(
+							packet.properties.authenticationMethod,
+							authMethod,
+						)
+						serverClient.auth({
+							reasonCode: 0,
+							properties: {
+								authenticationMethod: authMethod,
+							},
+						})
+					},
+				)
+
+				const client = connectV5(port)
+				client.on('error', done)
+
+				client.once('connect', () => {
+					client.reauthenticate(
+						{ authenticationMethod: 'other' } as any,
+						(err) => {
+							assert.ifError(err)
+							client.end(true, () => testServer.close(done))
+						},
+					)
+				})
+			},
+		)
+
+		it(
+			'should reject an authenticationData that is neither Buffer nor string',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 17
+				let authPackets = 0
+				const testServer = buildReauthServer(port, (serverClient) => {
+					authPackets++
+					serverClient.auth({
+						reasonCode: 0,
+						properties: { authenticationMethod: authMethod },
+					})
+				})
+				const client = connectV5(port)
+				client.on('error', done)
+
+				client.once('connect', () => {
+					client.reauthenticate(
+						{ authenticationData: { token: 1 } } as any,
+						(err) => {
+							assert.strictEqual(
+								err.message,
+								'reauthenticate: authenticationData must be a Buffer or a string',
+							)
+							assert.strictEqual(authPackets, 0)
+							// nothing was sent, so the pending state must not be
+							// stuck: a valid exchange still works
+							client.reauthenticate(
+								{ authenticationData: 'refreshed' },
+								(err2) => {
+									assert.ifError(err2)
+									assert.strictEqual(authPackets, 1)
+									client.end(true, () =>
+										testServer.close(done),
+									)
+								},
+							)
+						},
+					)
+				})
+			},
+		)
+
+		it(
+			'should fail when the default handleAuth answers a 0x18 challenge',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 18
+				const testServer = buildReauthServer(port, (serverClient) => {
+					serverClient.auth({
+						reasonCode: 0x18,
+						properties: { authenticationMethod: authMethod },
+					})
+				})
+
+				// client.handleAuth is left at its default, which calls back
+				// with no packet
+				const client = connectV5(port)
+				client.on('error', done)
+
+				client.once('connect', () => {
+					client.reauthenticate((err) => {
+						assert.match(
+							err.message,
+							/did not provide an AUTH packet/,
+						)
+						client.end(true, () => testServer.close(done))
+					})
+				})
+			},
+		)
+
+		it(
+			'should stop an exchange the broker will not end',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 19
+				const testServer = buildReauthServer(port, (serverClient) => {
+					serverClient.auth({
+						reasonCode: 0x18,
+						properties: { authenticationMethod: authMethod },
+					})
+				})
+
+				const client = connectV5(port, { reauthTimeout: 0 })
+				client.on('error', done)
+
+				client.handleAuth = (packet, callback) => {
+					callback(null, {
+						cmd: 'auth',
+						reasonCode: 0x18,
+						properties: { authenticationMethod: authMethod },
+					})
+				}
+
+				client.once('connect', () => {
+					client.reauthenticate((err) => {
+						// reauthTimeout is disabled, so only the round cap can
+						// break this loop
+						assert.match(err.message, /authentication challenges/)
+						client.end(true, () => testServer.close(done))
+					})
+				})
+			},
+		)
+
+		it(
+			'should abort a pending re-authentication on a graceful end()',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 20
+				// the broker never answers and never closes the socket
+				const testServer = buildReauthServer(port, () => {})
+				const client = connectV5(port, { reauthTimeout: 0 })
+				client.on('error', done)
+
+				client.once('connect', () => {
+					client.reauthenticate((err) => {
+						assert.match(err.message, /connection closed/)
+						assert.ok(client.lastReauthError)
+						testServer.close(done)
+					})
+					client.end()
+				})
+			},
+		)
+
+		it(
+			'should clear the pending state across a reconnect',
+			{ timeout: 10000 },
+			function _test(t, done) {
+				const port = basePort + 21
+				let connections = 0
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					connections++
+					const first = connections === 1
+					serverClient.on('connect', () =>
+						serverClient.connack({ reasonCode: 0 }),
+					)
+					serverClient.on('auth', () => {
+						if (first) {
+							// drop the connection mid-exchange
+							serverClient.destroy()
+						} else {
+							serverClient.auth({
+								reasonCode: 0,
+								properties: {
+									authenticationMethod: authMethod,
+								},
+							})
+						}
+					})
+					serverClient.on('pingreq', () => serverClient.pingresp())
+				}).listen(port)
+
+				const client = connectV5(port, { reconnectPeriod: 100 })
+				client.on('error', () => {})
+
+				client.once('connect', () => {
+					client.reauthenticate((err) => {
+						assert.ok(err)
+						client.once('connect', () => {
+							client.reauthenticate((err2) => {
+								assert.ifError(err2)
+								client.end(true, () => testServer.close(done))
+							})
+						})
+					})
+				})
+			},
+		)
+
+		it(
+			'should fall back to the default reauthTimeout for a non-finite one',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 22
+				const testServer = buildReauthServer(port, () => {})
+				const client = connectV5(port, {
+					reauthTimeout: Number.NaN,
+				})
+				assert.strictEqual(client.options.reauthTimeout, 30 * 1000)
+				client.on('error', done)
+				client.once('connect', () =>
+					client.end(true, () => testServer.close(done)),
+				)
+			},
+		)
+
+		it(
+			'should tear the connection down on an unsolicited AUTH packet',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 23
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () => {
+						serverClient.connack({ reasonCode: 0 })
+						serverClient.auth({
+							reasonCode: 0,
+							properties: {
+								authenticationMethod: authMethod,
+							},
+						})
+					})
+				}).listen(port)
+
+				// no 'error' listener: a protocol violation must not depend on
+				// the application having one
+				const client = connectV5(port)
+
+				client.once('close', () => {
+					assert.strictEqual(client.connected, false)
+					client.end(true, () => testServer.close(done))
 				})
 			},
 		)

--- a/test/node/client_mqtt5.ts
+++ b/test/node/client_mqtt5.ts
@@ -1438,4 +1438,364 @@ describe('MQTT 5.0', () => {
 			})
 		},
 	)
+	describe('re-authentication', () => {
+		const authMethod = 'TEST-AUTH'
+		const basePort = ports.PORTAND327 + 30
+
+		function buildReauthServer(
+			port: number,
+			onAuth: (serverClient: any, packet: any) => void,
+		) {
+			return serverBuilder('mqtt', (serverClient) => {
+				serverClient.on('connect', () =>
+					serverClient.connack({ reasonCode: 0 }),
+				)
+				serverClient.on('auth', (packet) =>
+					onAuth(serverClient, packet),
+				)
+				serverClient.on('pingreq', () => serverClient.pingresp())
+			}).listen(port)
+		}
+
+		function connectV5(port: number, extra: mqtt.IClientOptions = {}) {
+			return mqtt.connect({
+				host: 'localhost',
+				port,
+				protocolVersion: 5,
+				reconnectPeriod: 0,
+				properties: {
+					authenticationMethod: authMethod,
+					authenticationData: Buffer.from('initial'),
+				},
+				...extra,
+			})
+		}
+
+		it(
+			'should send AUTH 0x19 and complete when the broker answers with success',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort
+				const newToken = Buffer.from('refreshed-token')
+				const testServer = buildReauthServer(
+					port,
+					(serverClient, packet) => {
+						assert.strictEqual(packet.reasonCode, 0x19)
+						assert.strictEqual(
+							packet.properties.authenticationMethod,
+							authMethod,
+						)
+						assert.ok(
+							packet.properties.authenticationData.equals(
+								newToken,
+							),
+						)
+						assert.strictEqual(
+							packet.properties.reasonString,
+							'token refresh',
+						)
+						serverClient.auth({ reasonCode: 0 })
+					},
+				)
+
+				const client = connectV5(port)
+				let eventPacket: any = null
+
+				client.on('error', done)
+				client.once('reauth', (packet) => {
+					eventPacket = packet
+				})
+
+				client.once('connect', () => {
+					client.reauthenticate(
+						{
+							authenticationData: newToken,
+							reasonString: 'token refresh',
+						},
+						(err, packet) => {
+							assert.ifError(err)
+							assert.strictEqual(packet.cmd, 'auth')
+							assert.strictEqual(packet.reasonCode, 0)
+							// the callback fires before the event
+							assert.isNull(eventPacket)
+							process.nextTick(() => {
+								assert.strictEqual(eventPacket, packet)
+								client.end(true, () => testServer.close(done))
+							})
+						},
+					)
+				})
+			},
+		)
+
+		it(
+			'reauthenticateAsync should resolve with the broker AUTH packet',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 1
+				const testServer = buildReauthServer(port, (serverClient) => {
+					serverClient.auth({ reasonCode: 0 })
+				})
+
+				const client = connectV5(port)
+				client.on('error', done)
+
+				client.once('connect', async () => {
+					try {
+						const packet = await client.reauthenticateAsync({
+							authenticationData: Buffer.from('refreshed'),
+						})
+						assert.strictEqual(packet.reasonCode, 0)
+						client.end(true, () => testServer.close(done))
+					} catch (err) {
+						done(err)
+					}
+				})
+			},
+		)
+
+		it(
+			'should forward AUTH 0x18 to handleAuth and send the next AUTH packet',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 2
+				const challenge = Buffer.from('challenge')
+				const response = Buffer.from('response')
+				const testServer = buildReauthServer(
+					port,
+					(serverClient, packet) => {
+						if (packet.reasonCode === 0x19) {
+							serverClient.auth({
+								reasonCode: 0x18,
+								properties: {
+									authenticationMethod: authMethod,
+									authenticationData: challenge,
+								},
+							})
+						} else {
+							assert.strictEqual(packet.reasonCode, 0x18)
+							assert.ok(
+								packet.properties.authenticationData.equals(
+									response,
+								),
+							)
+							serverClient.auth({ reasonCode: 0 })
+						}
+					},
+				)
+
+				const client = connectV5(port)
+				client.on('error', done)
+
+				let handleAuthCalls = 0
+				client.handleAuth = (packet, callback) => {
+					handleAuthCalls++
+					assert.strictEqual(packet.reasonCode, 0x18)
+					assert.ok(
+						packet.properties.authenticationData.equals(challenge),
+					)
+					callback(null, {
+						cmd: 'auth',
+						reasonCode: 0x18,
+						properties: {
+							authenticationMethod: authMethod,
+							authenticationData: response,
+						},
+					})
+				}
+
+				client.once('connect', () => {
+					client.reauthenticate(
+						{ authenticationData: Buffer.from('refreshed') },
+						(err, packet) => {
+							assert.ifError(err)
+							assert.strictEqual(handleAuthCalls, 1)
+							assert.strictEqual(packet.reasonCode, 0)
+							client.end(true, () => testServer.close(done))
+						},
+					)
+				})
+			},
+		)
+
+		it(
+			'should report handleAuth errors to the reauthenticate callback only',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 3
+				const testServer = buildReauthServer(port, (serverClient) => {
+					serverClient.auth({
+						reasonCode: 0x18,
+						properties: { authenticationMethod: authMethod },
+					})
+				})
+
+				const client = connectV5(port)
+				client.on('error', done)
+
+				client.handleAuth = (packet, callback) => {
+					callback(new Error('user-auth-failure'))
+				}
+
+				client.once('connect', () => {
+					client.reauthenticate((err) => {
+						assert.strictEqual(err.message, 'user-auth-failure')
+						client.end(true, () => testServer.close(done))
+					})
+				})
+			},
+		)
+
+		it(
+			'should emit an error on an AUTH packet received while no re-authentication is in progress',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 5
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () => {
+						serverClient.connack({ reasonCode: 0 })
+						setTimeout(
+							() => serverClient.auth({ reasonCode: 0 }),
+							50,
+						)
+					})
+				}).listen(port)
+
+				const client = connectV5(port)
+				client.once('error', (err) => {
+					assert.match(err.message, /Protocol error/)
+					assert.strictEqual((err as ErrorWithReasonCode).code, 0x82)
+					client.end(true, () => testServer.close(done))
+				})
+			},
+		)
+
+		it(
+			'should fail when the client is not connected',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 6
+				const testServer = buildReauthServer(port, () => {})
+				const client = connectV5(port)
+				client.on('error', done)
+
+				client.once('connect', () => {
+					client.end(true, () => {
+						client.reauthenticate((err) => {
+							assert.strictEqual(
+								err.message,
+								'reauthenticate: client is not connected',
+							)
+							testServer.close(done)
+						})
+					})
+				})
+			},
+		)
+
+		it(
+			'should fail when the protocol version is not 5',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 7
+				const testServer = serverBuilder('mqtt', (serverClient) => {
+					serverClient.on('connect', () =>
+						serverClient.connack({ returnCode: 0 }),
+					)
+				}).listen(port)
+
+				const client = mqtt.connect({
+					host: 'localhost',
+					port,
+					protocolVersion: 4,
+					reconnectPeriod: 0,
+				})
+				client.on('error', done)
+
+				client.once('connect', () => {
+					client.reauthenticate((err) => {
+						assert.strictEqual(
+							err.message,
+							'reauthenticate: re-authentication is only supported in MQTT 5.0',
+						)
+						client.end(true, () => testServer.close(done))
+					})
+				})
+			},
+		)
+
+		it(
+			'should emit an error when no authenticationMethod was set and no callback is given',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 8
+				const testServer = buildReauthServer(port, () => {})
+				const client = connectV5(port, { properties: {} })
+
+				client.once('error', (err) => {
+					assert.strictEqual(
+						err.message,
+						'reauthenticate: an authenticationMethod must be set in the CONNECT properties',
+					)
+					client.end(true, () => testServer.close(done))
+				})
+
+				client.once('connect', () => {
+					client.reauthenticate({
+						authenticationData: Buffer.from('refreshed'),
+					})
+				})
+			},
+		)
+
+		it(
+			'should reject a second re-authentication while one is in progress and time out',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 9
+				// the broker never answers
+				const testServer = buildReauthServer(port, () => {})
+				const client = connectV5(port, { reauthTimeout: 200 })
+				client.on('error', done)
+
+				client.once('connect', () => {
+					let secondFailed = false
+					client.reauthenticate((err) => {
+						assert.ok(err)
+						assert.match(err.message, /timed out/)
+						assert.isTrue(secondFailed)
+						client.end(true, () => testServer.close(done))
+					})
+					client.reauthenticate((err) => {
+						assert.strictEqual(
+							err.message,
+							'reauthenticate: a re-authentication is already in progress',
+						)
+						secondFailed = true
+					})
+				})
+			},
+		)
+
+		it(
+			'should abort a pending re-authentication when the connection closes',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 10
+				const testServer = buildReauthServer(port, (serverClient) => {
+					serverClient.destroy()
+				})
+				const client = connectV5(port)
+				client.on('error', done)
+
+				client.once('connect', () => {
+					client.reauthenticate((err) => {
+						assert.ok(err)
+						assert.match(err.message, /connection closed/)
+						client.end(true, () => testServer.close(done))
+					})
+				})
+			},
+		)
+	})
 })

--- a/test/node/client_mqtt5.ts
+++ b/test/node/client_mqtt5.ts
@@ -1797,5 +1797,71 @@ describe('MQTT 5.0', () => {
 				})
 			},
 		)
+
+		it(
+			'should fail the re-authentication on an unexpected AUTH reason code',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 11
+				const testServer = buildReauthServer(port, (serverClient) => {
+					// 0x19 (Re-authenticate) may only travel client to broker
+					serverClient.auth({ reasonCode: 0x19 })
+				})
+
+				const client = connectV5(port)
+				client.on('error', done)
+
+				client.once('connect', () => {
+					client.reauthenticate((err) => {
+						assert.ok(err)
+						assert.strictEqual(
+							err.message,
+							'Protocol error: unexpected AUTH reason code 25 received from the broker',
+						)
+						assert.strictEqual(
+							(err as ErrorWithReasonCode).code,
+							0x19,
+						)
+						client.end(true, () => testServer.close(done))
+					})
+				})
+			},
+		)
+
+		it(
+			'should fail when handleAuth continues the exchange without a packet',
+			{ timeout: 5000 },
+			function _test(t, done) {
+				const port = basePort + 12
+				const testServer = buildReauthServer(port, (serverClient) => {
+					serverClient.auth({
+						reasonCode: 0x18,
+						properties: { authenticationMethod: authMethod },
+					})
+				})
+
+				const client = connectV5(port)
+				client.on('error', done)
+
+				client.handleAuth = (packet, callback) => {
+					callback(null, undefined)
+				}
+
+				client.once('connect', () => {
+					client.reauthenticate((err) => {
+						assert.ok(err)
+						assert.match(
+							err.message,
+							/did not provide an AUTH packet/,
+						)
+						assert.strictEqual(
+							(err as ErrorWithReasonCode).code,
+							0x18,
+						)
+						client.end(true, () => testServer.close(done))
+					})
+				})
+			},
+		)
 	})
 })


### PR DESCRIPTION
Closes #1795

Adds `client.reauthenticate(options, callback)` and `client.reauthenticateAsync(options)`, implementing MQTT 5.0 re-authentication (spec section 4.12.1) on an established connection, e.g. to hand a refreshed token to the broker without reconnecting.

### Behaviour

- sends an `AUTH` packet with reason code `0x19` (Re-authenticate) using the `authenticationMethod` of the CONNECT packet
- `AUTH 0x18` (Continue authentication) is forwarded to `client.handleAuth()` and the packet it provides is sent; an error from `handleAuth()` is reported to the `reauthenticate()` callback, so the callback never hangs
- `AUTH 0x00` (Success) completes the exchange: the callback is called first, then the new `'reauth'` event is emitted
- an `AUTH` packet whose `authenticationMethod` is not the negotiated one is rejected before `handleAuth()` sees it ([MQTT-4.12.0-5], code `0x8C`)
- a pending exchange is aborted after `reauthTimeout` ms (new option, default 30 s, `0` disables; the deadline is refreshed on each accepted `0x18`) and on teardown; the exchange is also capped at 10 rounds
- a failed re-authentication leaves the connection up - that is the application's call - and is recorded in `client.lastReauthError`
- **breaking:** an `AUTH` packet received after CONNACK while no re-authentication is in progress used to be forwarded to `client.handleAuth()`. Only the client may start a re-authentication, so it is now a protocol error (code `0x82`) that closes the connection. Anyone relying on broker-initiated mid-session enhanced authentication is affected; documented in the README.
- the pre-CONNACK enhanced authentication flow is unchanged apart from sharing the `handleAuth()` continuation with the re-auth path, which gives it the missing "no packet provided" guard and makes it reject a non-`0x18` code before calling the hook instead of after
- `client.log()` calls on every path of `reauthenticate()` and `handlers/auth.ts`

### Notes

- This builds on the review feedback given on #2048 (unsolicited AUTH, hanging callback on `handleAuth` errors, missing logging, listener registered after the event). That PR has been inactive since May, so I am proposing a fresh implementation; happy to defer to it or to rebase if its author returns.
- `mqtt-packet` only parses `AUTH` reason codes `0x00`/`0x18`/`0x19`, so a "refused" `AUTH` cannot reach the handler. The only code that can reach the `default` branch is `0x19`, which a broker must never send to a client, so it is reported as a protocol error.

### Tests

- 26 new tests in `test/node/client_mqtt5.ts`, including the pre-CONNACK enhanced authentication exchange, which had no coverage anywhere before this PR
- `npm run test:node` on Node 22: 944 tests, 939 passed, 0 failed, 5 skipped; coverage gate green
- `tsc --noEmit`, `eslint`, `prettier --check`: clean

README documents the new methods, the `reauthTimeout` option and the `'reauth'` event.



